### PR TITLE
Sync

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -69,6 +69,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         met = events.MET
         e   = events.Electron
         mu  = events.Muon
+        tau = events.Tau
         j   = events.Jet
  
         # Muon selection

--- a/topcoffea/modules/objects.py
+++ b/topcoffea/modules/objects.py
@@ -1,9 +1,7 @@
 '''
  objects.py
-
  This script contains several functions that implement the object selection according to different object definitions.
  The functions are called with (jagged)arrays as imputs and return a boolean mask.
-
 '''
 import numpy as np
 
@@ -18,27 +16,53 @@ def isTightElectronPOG(pt,eta,dxy,dz,tight_id,tightCharge,year):
     mask = ((pt>10)&(abs(eta)<2.5)&(tight_id==4)&(tightCharge)) # Trigger: HLT_Ele27_WPTight_Gsf_v
     return mask
 
-def isGoodJet(pt, eta, jet_id, jetPtCut=30):
-    mask = (pt>jetPtCut) & (abs(eta)<2.4) & ((jet_id&2)==2)
+#Return if obj_A is close to obj_B, obj can be lepton or jet.
+def isClean(obj_A, obj_B, drmin=0.4):
+   ABpairs = obj_A.cross(obj_B, nested=True)
+   ABgoodPairs = (ABpairs.i0.delta_r(ABpairs.i1) > drmin).all()
+   return ABgoodPairs
+   
+def isTightJet(pt, eta, jet_id, neHEF, neEmEF, chHEF, chEmEF, nConstituents, jetPtCut=30.0):
+    mask = (pt>jetPtCut) & (abs(eta)<2.4)# & ((jet_id&6)==6)
+    loose = (pt>0)#(neHEF<0.99)&(neEmEF<0.99)&(chEmEF<0.99)&(nConstituents>1)
+    tight = (neHEF<0.9)&(neEmEF<0.9)&(chHEF>0.0)
+    jetMETcorrection = (pt>0)#(neEmEF + chEmEF < 0.9)
+    mask = mask & loose & tight & jetMETcorrection
     return mask
 
-def isClean(jets, electrons, muons, drmin=0.4):
+def isCleanJet(jets, electrons, muons, taus, drmin=0.4):
   ''' Returns mask to select clean jets '''
   epairs = jets.cross(electrons, nested=True)
   mpairs = jets.cross(muons, nested=True)
+  tpairs = jets.cross(taus, nested=True)
   egoodPairs = (epairs.i0.delta_r(epairs.i1) > drmin).all()
   mgoodPairs = (mpairs.i0.delta_r(mpairs.i1) > drmin).all()
-  return (egoodPairs) & (mgoodPairs)
+  tgoodPairs = (tpairs.i0.delta_r(tpairs.i1) > drmin).all()
+  return (egoodPairs) & (mgoodPairs)# & (tgoodPairs)
 
-def isMuonMVA(pt, eta, dxy, dz, miniIso, sip3D, mvaTTH, mediumPrompt, tightCharge, jetDeepB=0, minpt=15):
-  mask = (pt>minpt)&(abs(eta)<2.4)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(miniIso<0.4)&(sip3D<5)&(mvaTTH>0.55)&(mediumPrompt)&(tightCharge==2)&(jetDeepB<0.1522)
+def isPresMuon(dxy, dz, sip3D, looseId):
+  mask = (abs(dxy)<0.05)&(abs(dz)<0.1)&(sip3D<8)&(looseId)
+  return mask
+  
+def isTightMuon(pt, eta, dxy, dz, miniIso, sip3D, mvaTTH, mediumPrompt, tightCharge, looseId, minpt=10.0):
+  mask = (pt>minpt)&(abs(eta)<2.5)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(sip3D<8)&(looseId)#&(miniIso<0.25)#&(mvaTTH>0.90)&(tightCharge==2)&(mediumPrompt)
   return mask
 
-def isElecMVA(pt, eta, dxy, dz, miniIso, sip3D, mvaTTH, elecMVA, lostHits, convVeto, tightCharge, jetDeepB=0, minpt=15):
-  miniIsoCut = 0.085 # Tight
-  mask = (pt>minpt)&(abs(eta)<2.4)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(miniIso<miniIsoCut)&(sip3D<8)&(mvaTTH>0.125)&(elecMVA>0.80)&(jetDeepB<0.1522)&(lostHits<1)&(convVeto)&(tightCharge==2)
-  return mask 
-
-
-   
-
+def isPresElec(pt, eta, dxy, dz, miniIso, sip3D, lostHits, minpt=15.0):
+  mask = (pt>minpt)&(abs(eta)<2.5)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(sip3D<8)&(lostHits<=1)#&(eInvMinusPInv>-0.04)&(maskhoe)&(miniIso<0.25)
+  return mask
+ 
+def isTightElec(pt, eta, dxy, dz, miniIso, sip3D, mvaTTH, elecMVA, lostHits, convVeto, tightCharge, sieie, hoe, eInvMinusPInv, minpt=15.0):
+  maskPOGMVA = ((pt<10)&(abs(eta)<0.8)&(elecMVA>-0.13))|((pt<10)&(abs(eta)>0.8)&(abs(eta)<1.44)&(elecMVA>-0.32))|((pt<10)&(abs(eta)>1.44)&(elecMVA>-0.08))|\
+               ((pt>10)&(abs(eta)<0.8)&(elecMVA>-0.86))|((pt>10)&(abs(eta)>0.8)&(abs(eta)<1.44)&(elecMVA>-0.81))|((pt>10)&(abs(eta)>1.44)&(elecMVA>-0.72))
+  maskSieie  = ((abs(eta)<1.479)&(sieie<0.011))|((abs(eta)>1.479)&(sieie<0.030))
+  maskhoe    = ((abs(eta)<1.479)&(hoe<0.10))|((abs(eta)>1.479)&(hoe<0.07))
+  mask = (pt>minpt)&(abs(eta)<2.5)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(sip3D<8)&(lostHits<=1)&\
+         (convVeto)&(maskSieie)#&(maskPOGMVA)&(eInvMinusPInv>-0.04)&(maskhoe)&(miniIso<0.25)#&(mvaTTH>0.90)&(tightCharge==2)
+  return mask
+ 
+def isPresTau(pt, eta, dxy, dz, leadTkPtOverTauPt, idAntiMu, idAntiEle, rawIso, idDecayModeNewDMs, minpt=20.0):
+  kinematics = (pt>minpt)&(abs(eta)<2.3)&(dxy<1000.)&(dz<0.2)#&(leadTkPtOverTauPt*pt>0.5)
+  medium = (idAntiMu>0.5)&(idAntiEle>0.5)&(rawIso>0.5)&(idDecayModeNewDMs)
+  return kinematics# & medium
+ 


### PR DESCRIPTION
Major changes in the object selection to make the framework in sync with the analysis.

Leptons:

Functions renamed: isElec(Muon)MVA -> isTightElec(Muon): it now marks the tight electrons (muons).
Functions added: isPresElec(Muon): it marks the preselected electrons (muons). Preselected electrons and muons are used to cleanse the taus. (No impact right now because tau cleaning is disabled)
Object added: Tau. Relevant functions: isPresTau

Different arguments for isTightElec(Muon): some of the cuts are disabled right now: lepMVA, RelIso, H/E (for the electrons).
minimun pT for electron changed: 10 -> 15


Jets:

Added the tau object as one of the arguments for isClean (currently disabled).
Function renamed: isGoodJet -> isTightJet
Added neutral/charged hardon/E&M energy fraction and number of constituents as arguments for isTightJet (the respective cuts are currently disabled). 

A different btag algorithm: btagDeepFlavB -> btagDeepB
Btag cut changed: btagDeepFlavB > 0.2770  ->  btagDeepB > 0.4941


Trival:

Function added: isClean(obj1, obj2, drmin=0.4). It checks if obj2 is in a cone centred at obj1 with a given radius. It is primarily used for cleaning purpose.

Central of Z mass: 91 -> 91.2
Radius of Z mass range: 15 -> 10
