### PR TITLE
Fix bug in HistEFT.add()

### DIFF
--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -155,7 +155,11 @@ class HistEFT(coffea.hist.Hist):
       for rkey in right.keys():
         lkey = tuple(self.axis(rax).index(rax[ridx]) for rax, ridx in zip(raxes, rkey))
         if lkey in left:
-          left[lkey] += right[rkey]
+          if isinstance(left[lkey],list):
+            for l,r in zip(left[lkey],right[rkey]):
+              l += r
+          else:
+            left[lkey] += right[rkey]
         else:
           left[lkey] = copy.deepcopy(right[rkey])
 


### PR DESCRIPTION
Because some of the objects stored in the sparse bin dicts are Python lists, the "+=" operator concatenates the lists instead of adding the lists elements as intended.  Hopefully this will fix #15.