### PR TITLE
Changes to make HistEFT a little more user friendly

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -42,7 +42,7 @@ class DatacardMaker():
         self.charge = list({k[3]:0 for k in self.hists['njets'].values().keys()})
         self.syst = list({k[4]:0 for k in self.hists['njets'].values().keys()})
         self.hsow = self.hists['SumOfEFTweights']
-        self.hsow.set_wilson_coefficients(np.zeros(self.hsow._nwc))
+        self.hsow.set_sm()
         self.smsow = {proc: self.hsow.integrate('sample', proc).values()[()][0] for proc in self.samples}
         with open(lumiJson) as jf:
             lumi = json.load(jf)
@@ -96,7 +96,7 @@ class DatacardMaker():
                 elif '4l' in channel: h_base = h_base.rebin('njets', hist.Bin("njets",  "Jet multiplicity ", [2,3,4]))
             #Save the SM plot
             h_sm = h_base#.copy()
-            h_sm.set_wilson_coefficients(np.zeros(h_base._nwc))
+            h_sm.set_sm()
             fout[pname+'sm'] = hist.export1d(h_sm)
             #Asimov data: data_obs = MC at SM (all WCs = 0)
             fout['data_obs'] = hist.export1d(h_sm)
@@ -108,7 +108,7 @@ class DatacardMaker():
                 #Handle linear and quadratic terms
                 if 'lin' in name:
                     h_lin = h_base#.copy()
-                    h_lin.set_wilson_coefficients(wcpt)
+                    h_lin.set_wilson_coeff_from_array(wcpt)
                     if np.sum(h_lin.values()[()]) > self.tolerance:
                         fout[pname+name] = hist.export1d(h_lin)
                         if variable == 'njets':
@@ -123,12 +123,12 @@ class DatacardMaker():
                                 '_'.join([channel, maxb, variable])
                 elif 'quad' in name and 'mix' not in name:
                     h_quad = h_base#.copy()
-                    h_quad.set_wilson_coefficients(wcpt)
+                    h_quad.set_wilson_coeff_from_array(wcpt)
                     if np.sum(h_quad.values()[()]) > self.tolerance:
                         fout[pname+name] = hist.export1d(h_quad)
                 else:
                     h_mix = h_base#.copy()
-                    h_mix.set_wilson_coefficients(wcpt)
+                    h_mix.set_wilson_coeff_from_array(wcpt)
                     if np.sum(h_mix.values()[()]) > self.tolerance:
                         fout[pname+name] = hist.export1d(h_mix)
         

--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -53,9 +53,34 @@ class HistEFT(coffea.hist.Hist):
       else:
         self._sumw2[key] = self._sumw[key].copy()
             
-  def set_wilson_coefficients(self,values):
-    """Set the WC values used to evaluate the bin contents of this histogram"""
+  def set_wilson_coeff_from_array(self, values):
+    """Set the WC values used to evaluate the bin contents of this histogram to the contents of 
+       an array where the elements are ordered according to the order defined by wcnames.
+    """
     self._wcs = np.asarray(values).copy()
+
+  def set_sm(self):
+    """Conveniece method to set the WC values to SM (all zero)"""
+    self._wcs = np.zeros(self._nwc)
+    
+  def set_wilson_coefficients(self, **values):
+    """Set the WC values used to evaluate the bin contents of this histogram
+       where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
+    """
+    self.set_sm()
+    for key in values:
+      try:
+        index = self._wcnames.index(key)
+        self._wcs[index] = values[key]
+      except ValueError:
+        msg = 'This HistEFT does not know about the "{}" Wilson coefficient.  '.format(key)
+        if self._nwc == 0:
+          msg += 'There are no Wilson coefficients defined for this HistEFT.'
+        else:
+          wc_string = ', '.join(self._wcnames)
+          part1, _, part2 = wc_string.rpartition(', ')
+          msg += ('Defined Wilson coefficients: '+part1 + ', and ' + part2+'.')
+        raise LookupError(msg)
 
   def copy(self, content=True):
     """ Copy """

--- a/topcoffea/plotter/plotter.py
+++ b/topcoffea/plotter/plotter.py
@@ -186,7 +186,7 @@ class plotter:
       sow = sow[process].sum("process")
     nwc = sow._nwc
     if nwc > 0:
-        sow.set_wilson_coefficients(np.zeros(nwc))
+        sow.set_sm()
         sow = sow.integrate("sample")
         sow = np.sum(sow.values()[()])
         h.scale(1. / sow) # Divie EFT samples by sum of weights at SM

--- a/unit.py
+++ b/unit.py
@@ -294,7 +294,7 @@ def test_histeft():
 
     chk_x = 1.5
     chk_y = s00*1.0 + s10*chk_x + s11*chk_x*chk_x
-    chk_arr = np.array([chk_x,0]) # CtG=chk_x, ctZ=0
+    chk_vals = {wc_name:chk_x, 'ctZ':0.0}
     chk_pt = WCPoint(f'EFTrwgt0_{wc_name}_{chk_x}',0.0)
 
     print('Running unit tests for HistEFT class')
@@ -324,7 +324,7 @@ def test_histeft():
 
     ###########################
 
-    h_base.set_wilson_coefficients(chk_arr)
+    h_base.set_wilson_coefficients(**chk_vals)
 
     expected = fit_1.EvalPoint(chk_pt)
     result = list(h_base.values().values())[0][0]
@@ -345,9 +345,9 @@ def test_histeft():
 
     chk_x = 0.75
     chk_y = s00*1.0 + s10*chk_x + s11*chk_x*chk_x
-    chk_arr = np.array([chk_x,0]) # CtG=chk_x, ctZ=0
+    chk_vals = {wc_name:chk_x, 'ctZ':0.0}
     chk_pt.SetStrength(wc_name,chk_x)
-    h_base.set_wilson_coefficients(chk_arr)
+    h_base.set_wilson_coefficients(**chk_vals)
 
     expected = fit_1.EvalPoint(chk_pt)
     result = list(h_base.values().values())[0][0]
@@ -367,7 +367,7 @@ def test_histeft():
     ###########################
 
     h_base.fill(n=val, sample='test', weight=np.ones_like(val), eft_coeff=[ak.Array(sconst)*2])
-    h_base.set_wilson_coefficients(chk_arr)
+    h_base.set_wilson_coefficients(**chk_vals)
 
     # First make sure the original WCFits weren't messed with
     expected = chk_y + 2*chk_y
@@ -411,10 +411,10 @@ def test_histeft():
 
     chk_x = 0.975
     chk_y = s00*1.0 + s10*chk_x + s11*chk_x*chk_x
-    chk_arr = np.array([chk_x,0]) # CtG=chk_x, ctZ=0
+    chk_vals = {wc_name:chk_x, 'ctZ':0.0}
     chk_pt.SetStrength(wc_name,chk_x)
     
-    h_new.set_wilson_coefficients(chk_arr)
+    h_new.set_wilson_coefficients(**chk_vals)
 
     # First check that h_new has the right value
     expected = fit_1.EvalPoint(chk_pt) + fit_2.EvalPoint(chk_pt)
@@ -434,7 +434,7 @@ def test_histeft():
     
     chk_x = 0.75    # Needs to be w/e chk_x was before UNIT 6
     chk_y = s00*1.0 + s10*chk_x + s11*chk_x*chk_x
-    chk_arr = np.array([chk_x,0]) # CtG=chk_x, ctZ=0
+    chk_vals = {wc_name:chk_x, 'ctZ':0.0}
     chk_pt.SetStrength(wc_name,chk_x)
 
     # Next check that the h_base was unaffected when we scaled h_new
@@ -457,7 +457,7 @@ def test_histeft():
     expected = fit_1.EvalPoint(chk_pt) + fit_2.EvalPoint(chk_pt) #fits for h_base
     expected += fit_1.EvalPoint(chk_pt) + fit_2.EvalPoint(chk_pt) #fits for h_new
     h_base.add(h_new)
-    h_base.set_wilson_coefficients(chk_arr) #evaluate h_base at chk_pt
+    h_base.set_wilson_coefficients(**chk_vals) #evaluate h_base at chk_pt
     result = list(h_base.values().values())[0][0]
 
     unit_chk = abs(result - expected) < tolerance
@@ -475,11 +475,11 @@ def test_histeft():
     # Check HistEFT.add() reweight
     chk_x = 0.75    # Needs to be w/e chk_x was before UNIT 6
     chk_y = s00*1.0 + s10*chk_x + s11*chk_x*chk_x
-    chk_arr = np.array([chk_x,0]) # CtG=chk_x, ctZ=0
+    chk_vals = {wc_name:chk_x, 'ctZ':0.0}
     chk_pt.SetStrength(wc_name,chk_x)
     expected = fit_1.EvalPoint(chk_pt) + fit_2.EvalPoint(chk_pt)
     expected += fit_1.EvalPoint(chk_pt) + fit_2.EvalPoint(chk_pt)
-    h_base.set_wilson_coefficients(chk_arr)
+    h_base.set_wilson_coefficients(**chk_vals)
     result = list(h_base.values().values())[0][0]
 
     unit_chk = abs(result - expected) < tolerance


### PR DESCRIPTION
There are a couple of changes intended to make HistEFT a little more user friendly to work with:

1. Made the `set_wilson_coefficients()` function take the WC names as keyword arguments, so that it's easy to set values.  (No more having to figure out which index to set in a plain array.
2. Per Brian Winer's request, added a `set_sm()` function to easily set the WC values to all zero.

I kept the original setting of Wilson coefficients through a plain numpy array as `set_wilson_coeff_from_array().`

Examples using the new function:
```py
hist.set_wilson_coefficients(ctW = 2.0, ctZ = 1.0, ctG = -0.01)

wc_vals = {'cpt' : 0.89, 'ctp' : 0.98}
hist.set_wilson_coefficients(**wc_vals)
```

I've changed all the committed code in the repository to match this new interface, but if you have local code, you'll need to make changes to keep it from breaking.  (That will teach you not to commit your code!)