### PR TITLE
Enable ability to handle samples with different WC lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Temporary and binary files
+*~
+*.py[cod]
+*.so
+*.cfg
+!.isort.cfg
+!setup.cfg
+*.orig
+*.log
+*.pot
+__pycache__/*
+.cache/*
+.*.swp
+*/.ipynb_checkpoints/*
+.DS_Store
+
+# Project files
+.ropeproject
+.project
+.pydevproject
+.settings
+.idea
+tags
+
+# Package files
+*.egg
+*.eggs/
+.installed.cfg
+*.egg-info
+
+# Unittest and coverage
+htmlcov/*
+.coverage
+.tox
+junit.xml
+coverage.xml
+.pytest_cache/
+
+# Build and docs folder/files
+build/*
+dist/*
+sdist/*
+docs/api/*
+docs/_rst/*
+docs/_build/*
+cover/*
+MANIFEST
+
+# Per-project virtualenvs
+.venv*/

--- a/analysis/topEFT/run.py
+++ b/analysis/topEFT/run.py
@@ -34,7 +34,8 @@ if __name__ == '__main__':
   parser.add_argument('--treename'   , default='Events', help = 'Name of the tree inside the files')
   parser.add_argument('--do-errors', action='store_true', help = 'Save the w**2 coefficients')
   parser.add_argument('--do-systs', action='store_true', help = 'Run over systematic samples (takes longer)')
-
+  parser.add_argument('--wc-list', action='extend', nargs='+', help = 'Specify a list of Wilson coefficients to use in filling histograms.')
+  
   args = parser.parse_args()
   jsonFiles  = args.jsonFiles
   prefix     = args.prefix
@@ -48,6 +49,7 @@ if __name__ == '__main__':
   treename   = args.treename
   do_errors = args.do_errors
   do_systs  = args.do_systs
+  wc_lst = args.wc_list if args.wc_list is not None else []
 
   if dotest:
     nchunks = 2
@@ -131,12 +133,24 @@ if __name__ == '__main__':
     print('pretending...')
     exit() 
 
-  # Check that all datasets have the same list of WCs
-  for i,k in enumerate(samplesdict.keys()):
-    if i == 0:
-      wc_lst = samplesdict[k]['WCnames']
-    if wc_lst != samplesdict[k]['WCnames']:
-      raise Exception("Not all of the datasets have the same list of WCs.")
+  # Extract the list of all WCs, as long as we haven't already specified one.
+  if len(wc_lst) == 0:
+    for k in samplesdict.keys():
+      for wc in samplesdict[k]['WCnames']:
+        if wc not in wc_lst:
+          wc_lst.append(wc)
+
+  if len(wc_lst) > 0:
+    # Yes, why not have the output be in correct English?
+    if len(wc_lst) == 1:
+      wc_print = wc_lst[0]
+    elif len(wc_lst) == 2:
+      wc_print = wc_lst[0] + ' and ' + wc_lst[1]
+    else:
+      wc_print = ', '.join(wc_lst[:-1]) + ', and ' + wc_lst[-1]
+    print('Wilson Coefficients: {}.'.format(wc_print))
+  else:
+    print('No Wilson coefficients specified')
  
   processor_instance = topeft.AnalysisProcessor(samplesdict,wc_lst,do_errors,do_systs)
 

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -21,9 +21,6 @@ import topcoffea.modules.eft_helper as efth
 
 #coffea.deprecations_as_errors = True
 
-# In the future these names will be read from the nanoAOD files
-#wc_names_lst= ['ctW', 'ctp', 'cpQM', 'ctli', 'cQei', 'ctZ', 'cQlMi', 'cQl3i', 'ctG', 'ctlTi', 'cbW', 'cpQ3', 'ctei', 'cpt', 'ctlSi', 'cptb']
-
 class AnalysisProcessor(processor.ProcessorABC):
     def __init__(self, samples, wc_names_lst=[], do_errors=False, do_systematics=False, dtype=np.float32):
         self._samples = samples
@@ -449,6 +446,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Extract the EFT quadratic coefficients and optionally use them to calculate the coefficients on the w**2 quartic function
         # eft_coeffs is never Jagged so convert immediately to numpy for ease of use.
         eft_coeffs = ak.to_numpy(events['EFTfitCoefficients']) if hasattr(events, "EFTfitCoefficients") else None
+        if eft_coeffs is not None:
+            # Check to see if the ordering of WCs for this sample matches what want
+            if self._samples[dataset]['WCnames'] != self._wc_names_lst:
+                eft_coeffs = efth.remap_coeffs(self._samples[dataset]['WCnames'], self._wc_names_lst, eft_coeffs)
         eft_w2_coeffs = efth.calc_w2_coeffs(eft_coeffs,self._dtype) if (self._do_errors and eft_coeffs is not None) else None
 
         # Selections and cuts

--- a/analysis/topEFT/work_queue_run.py
+++ b/analysis/topEFT/work_queue_run.py
@@ -130,16 +130,16 @@ if len(wc_lst) == 0:
     wc_lst.append(wc)
 
 if len(wc_lst) > 0:
-    # Yes, why not have the output be in correct English?
-    if len(wc_lst) == 1:
-      wc_print = wc_lst[0]
-    elif len(wc_lst) == 2:
-      wc_print = wc_lst[0] + ' and ' + wc_lst[1]
-    else:
-      wc_print = ', '.join(wc_lst[:-1]) + ', and ' + wc_lst[-1]
-    print('Wilson Coefficients: {}.'.format(wc_print))
-  else:
-    print('No Wilson coefficients specified')
+ # Yes, why not have the output be in correct English?
+ if len(wc_lst) == 1:
+  wc_print = wc_lst[0]
+ elif len(wc_lst) == 2:
+  wc_print = wc_lst[0] + ' and ' + wc_lst[1]
+ else:
+  wc_print = ', '.join(wc_lst[:-1]) + ', and ' + wc_lst[-1]
+  print('Wilson Coefficients: {}.'.format(wc_print))
+else:
+ print('No Wilson coefficients specified')
 
 processor_instance = topeft.AnalysisProcessor(samplesdict,wc_lst,do_errors,do_systs)
 

--- a/analysis/topEFT/work_queue_run.py
+++ b/analysis/topEFT/work_queue_run.py
@@ -94,12 +94,14 @@ for f in allInputFiles:
           else: LoadJsonToSampleName(l, prefix)
 
 flist = {};
+nevts_total = 0
 for sname in samplesdict.keys():
   redirector = samplesdict[sname]['redirector']
   flist[sname] = [(redirector+f) for f in samplesdict[sname]['files']]
   samplesdict[sname]['year'] = int(samplesdict[sname]['year'])
   samplesdict[sname]['xsec'] = float(samplesdict[sname]['xsec'])
   samplesdict[sname]['nEvents'] = int(samplesdict[sname]['nEvents'])
+  nevts_total += samplesdict[sname]['nEvents']
   samplesdict[sname]['nGenEvents'] = int(samplesdict[sname]['nGenEvents'])
   samplesdict[sname]['nSumOfWeights'] = float(samplesdict[sname]['nSumOfWeights'])
 
@@ -147,7 +149,7 @@ executor_args = {#'flatten': True, #used for all executors
                  'compression': 0, #used for all executors
                  'cores': 1,
                  'disk': 5000, #MB
-                 'memory': 10000, #MB
+                 'memory': 4000, #MB
                  'resource-monitor': True,
                  'debug-log': 'debug.log',
                  'transactions-log': 'tr.log',
@@ -166,6 +168,8 @@ executor_args = {#'flatten': True, #used for all executors
 tstart = time.time()
 output = processor.run_uproot_job(flist, treename=treename, processor_instance=processor_instance, executor=processor.work_queue_executor, executor_args=executor_args, chunksize=chunksize, maxchunks=nchunks)
 dt = time.time() - tstart
+
+print('Processed {} events in {} seconds ({:.2f} evts/sec).'.format(nevts_total,dt,nevts_total/dt))
 
 nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
 nfilled = sum(sum(np.sum(arr > 0) for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))


### PR DESCRIPTION
This commit provides the ability to fill different EFT samples in the same HistEFT even if the WC lists are different.  The topeft.py processor is provided with a list of the desired WCs in its constructor, and the HistEFTs are constructed according to that list.  During the run of the processor, the actual list of WCs for the sample being processed is compared to the desired list.  The EFT weight fit coefficients are reordered to match the desired list.  The fit coefficients for any WCs on the desired list that are not present for this sample are set to zero.  If there are any WCs in the current sample that are not in the list of desired coefficients, they are dropped.

By default, the run.py and work_queue_run.py scripts set the list of desired WCs in the processor to the union of all sets of WCs for the individual samples processed.  Optionally, you can override this list by specifying your own list with the `--wc-list` command line argument.

There are two small changes that are not directly related to managing WC lists included here just to have them somewhere:
* The `--do-systs` command line argument was propagated to work_queue_run.py
* An appropriate `.gitignore` files was added to the repository to declutter the `git status` output.