### PR TITLE
Add simple processor

### DIFF
--- a/analysis/topEFT/simple_processor.py
+++ b/analysis/topEFT/simple_processor.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+import lz4.frame as lz4f
+import cloudpickle
+import json
+import pprint
+import coffea
+import numpy as np
+import awkward as ak
+np.seterr(divide='ignore', invalid='ignore', over='ignore')
+from coffea import hist, processor
+from coffea.util import load, save
+from optparse import OptionParser
+from coffea.analysis_tools import PackedSelection
+
+from topcoffea.modules.objects import *
+from topcoffea.modules.corrections import SFevaluator, GetLeptonSF
+from topcoffea.modules.selection import *
+from topcoffea.modules.HistEFT import HistEFT, EFTHelper
+
+class AnalysisProcessor(processor.ProcessorABC):
+    def __init__(self, samples, wc_names_lst=[], do_errors=False):
+        self._samples = samples
+
+        # Create the histograms
+        # In general, histograms depend on 'sample', 'channel' (final state) and 'cut' (level of selection)
+        self._accumulator = processor.dict_accumulator({
+        'counts'  : hist.Hist("Events", hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("counts", "Counts", 1, 0, 2)),
+        'njets'   : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("njets",  "Jet multiplicity ", 12, 0, 12)),
+        'j0pt'    : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("j0pt",   "Leading jet  $p_{T}$ (GeV)", 10, 0, 600)),
+        'j0eta'   : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("j0eta",  "Leading jet  $\eta$", 10, -3.0, 3.0)),
+        'l0pt'    : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("l0pt",   "Leading lep $p_{T}$ (GeV)", 15, 0, 400)),
+        })
+
+        self._eft_helper = EFTHelper(wc_names_lst)
+        self._do_errors = do_errors # Whether to calculate and store the w**2 coefficients
+        
+    @property
+    def accumulator(self):
+        return self._accumulator
+
+    @property
+    def columns(self):
+        return self._columns
+
+    # Main function: run on a given dataset
+    def process(self, events):
+
+        print("\nHere in process!!!\n")
+
+        # Dataset parameters
+        dataset = events.metadata['dataset']
+        year   = self._samples[dataset]['year']
+        xsec   = self._samples[dataset]['xsec']
+        sow    = self._samples[dataset]['nSumOfWeights' ]
+        isData = self._samples[dataset]['isData']
+        datasets = ['SingleMuon', 'SingleElectron', 'EGamma', 'MuonEG', 'DoubleMuon', 'DoubleElectron']
+        for d in datasets: 
+          if d in dataset: dataset = dataset.split('_')[0] 
+
+        print("\nHere in process 2!!!\n")
+
+        # Initialize objects
+        e = events.GenPart[abs(events.GenPart.pdgId)==11]
+        m = events.GenPart[abs(events.GenPart.pdgId)==13]
+        tau = events.GenPart[abs(events.GenPart.pdgId)==15]
+        j = events.GenJet
+
+        run = events.run
+        luminosityBlock = events.luminosityBlock
+        event = events.event
+
+        print("run:",run)
+        print("luminosityBlock:",luminosityBlock)
+        print("event:",event)
+ 
+        print("\n\nleptons before selection:")
+        print("\te pt",e.pt)
+        print("\te eta",e.eta)
+        print("\tm pt",m.pt)
+        print("\tm eta",m.eta)
+
+        # Lepton selection
+        e_selec = ( (e.pt>15) & (abs(e.eta)<2.5) )
+        m_selec = ( (m.pt>15) & (abs(m.eta)<2.5) )
+        e = e[e_selec]
+        m = m[m_selec]
+
+        # Put the e and mu togheter
+        l = ak.concatenate([e,m],axis=1)
+
+        n_e = ak.num(e)
+        n_m = ak.num(m)
+        n_l = ak.num(l)
+
+        print("after selection:")
+        print("\te pt",e.pt)
+        print("\tm pt",m.pt)
+        print("\tl pt:",l.pt)
+        print("\tn e", n_e)
+        print("\tn m",n_m)
+        print("\tn l",n_l)
+
+        #at_least_two_leps = ((n_e + n_m) >= 2)
+        at_least_two_leps = (n_l >= 2)
+
+        #print("ne + nm:",n_e+n_m)
+        print("at least two lep:",at_least_two_leps)
+
+
+        e0 = e[ak.argmax(e.pt,axis=-1,keepdims=True)]
+        m0 = m[ak.argmax(m.pt,axis=-1,keepdims=True)]
+        l0 = l[ak.argmax(l.pt,axis=-1,keepdims=True)]
+
+        print("e0",e0.pt)
+        print("m0",m0.pt)
+        print("l0",l0.pt)
+
+        # Jet selection
+
+        print("\njets:")
+        print("jpt",j.pt)
+
+        j_selec = ( (j.pt>30) & (abs(j.eta)<2.5) )
+        print("jselect",j_selec)
+
+        j = j[j_selec]
+        print("jpt",j.pt)
+
+        j['isClean'] = isClean(j, e, drmin=0.4)& isClean(j, m, drmin=0.4)
+        #goodJets = j[(j.isClean)&(j.isGood)]
+        #print("j['isClean']",j['isClean'])
+        j_isclean = isClean(j, e, drmin=0.4) & isClean(j, m, drmin=0.4)
+        print("j is clean",j_isclean)
+
+        #goodJets = j[(j.isClean)]
+        j = j[j_isclean]
+        print("clean jets pt",j.pt)
+
+        n_j = ak.num(j)
+        print("n_j",n_j)
+        j0 = j[ak.argmax(j.pt,axis=-1,keepdims=True)]
+
+        print("j0pt",j0.pt)
+
+        at_least_two_jets = (n_j >= 2)
+        print("at_least_two_jets",at_least_two_jets)
+
+        event_selec = (at_least_two_leps & at_least_two_jets)
+        print("\nEvent selection:",event_selec,"\n")
+
+        # Extract the EFT quadratic coefficients and optionally use them to calculate the coefficients on the w**2 quartic function
+        eft_coeffs = ak.to_numpy(events['EFTfitCoefficients']) if hasattr(events, "EFTfitCoefficients") else None
+        eft_w2_coeffs = self._eft_helper.calc_w2_coeffs(eft_coeffs) if self._do_errors else None
+
+        # Selections and cuts
+
+        selections = PackedSelection()
+
+        selections.add('2l2j', event_selec)
+
+        #channels2l = ['2leps']
+        #levels = ['base','2jets', '3jets']
+        #selections.add('2leps', event_selec)
+        #selections.add('base', event_selec)
+        #selections.add('2jets',(n_j>=2))
+        #selections.add('3jets',(n_j>=3))
+
+        varnames = {}
+        varnames['counts'] = np.ones_like(events.MET.pt)
+        varnames['njets'] = n_j
+        varnames['j0pt' ] = j0.pt
+        varnames['j0eta'] = j0.eta
+        varnames['l0pt' ] = l0.pt
+
+        print("np.ones_like(events.MET.pt)",np.ones_like(events.MET.pt))
+
+        # fill Histos
+        hout = self.accumulator.identity()
+
+        #print("\nFIlling hists!!!\n")
+
+        for var, v in varnames.items():
+            cut = selections.all("2l2j")
+            values = v[cut]
+            eft_coeffs_cut = eft_coeffs[cut] if eft_coeffs is not None else None
+            eft_w2_coeffs_cut = eft_w2_coeffs[cut] if eft_w2_coeffs is not None else None
+            #print('var!!!',var)
+            if var == "counts":
+                #print(values)
+                hout[var].fill(counts=values, sample=dataset, channel="2l", cut="2l")
+            elif var == "njets":
+                #print(values)
+                hout[var].fill(njets=values, sample=dataset, channel="2l", cut="2l", eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+            elif var == "j0pt":
+                #print(values)
+                hout[var].fill(j0pt=values, sample=dataset, channel="2l", cut="2l", eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+            elif var == "j0eta":
+                #print(values)
+                hout[var].fill(j0eta=values, sample=dataset, channel="2l", cut="2l", eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+            elif var == "l0pt":
+                #print(values)
+                hout[var].fill(l0pt=values, sample=dataset, channel="2l", cut="2l", eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+
+        '''
+        for var, v in varnames.items():
+            print("\nVAR:",var)
+            print("\tv:",v)
+            #for ch in channels2LSS+channels3L:
+            for ch in channels2l:
+                #print("\n\tCHANNEL:",ch,"\n")
+                for lev in levels:
+                    #print("\n\t\tLEVEL:",lev,"\n")
+
+                    cuts = [ch] + [lev]
+                    print("\tcuts!!!",cuts)
+                    cut = selections.all(*cuts)
+                    eft_coeffs_cut = eft_coeffs[cut] if eft_coeffs is not None else None
+                    eft_w2_coeffs_cut = eft_w2_coeffs[cut] if eft_w2_coeffs is not None else None
+                    print("\tcut!!!",cut)
+                    values = v[cut] 
+                    print("\tvalues!!!",values)
+                    if var == 'counts':
+                        hout[var].fill(counts=values, sample=dataset, channel=ch, cut=lev)
+                    elif var == 'njets':
+                        hout[var].fill(njets=values, sample=dataset, channel=ch, cut=lev, eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+                    elif var == 'j0pt': 
+                        values = ak.flatten(values)
+                        hout[var].fill(j0pt=values, sample=dataset, channel=ch, cut=lev, eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+                    elif var == 'j0eta': 
+                        values = ak.flatten(values)
+                        hout[var].fill(j0eta=values, sample=dataset, channel=ch, cut=lev, eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+                    elif var == 'l0pt': 
+                        values = ak.flatten(values)
+                        hout[var].fill(l0pt=values, sample=dataset, channel=ch, cut=lev, eft_coeff=eft_coeffs_cut, eft_err_coeff=eft_w2_coeffs_cut)
+        '''
+
+        return hout
+
+    def postprocess(self, accumulator):
+        return accumulator
+
+if __name__ == '__main__':
+    # Load the .coffea files
+    outpath= './coffeaFiles/'
+    samples     = load(outpath+'samples.coffea')
+    topprocessor = AnalysisProcessor(samples)
+


### PR DESCRIPTION
This branch adds a single file: `analysis/topEFT/simple_processor.py`. This processor was written for the `HistEFT` vs `TH1EFT` validation that we performed in May 2021. The processor performs very minimal object and event selection, with the goal of matching the object/event selection in this [simple analyzer](https://github.com/TopEFT/EFTGenReader/blob/master/GenReader/plugins/EFTMaodHists.cc) that we also wrote for the comparison. The idea was to process a MAOD file with the analyzer, generate NAOD from the MAOD using the code outlined [here](https://github.com/TopEFT/mgprod), process the NAOD file with the coffea processor, and compare the resulting histograms.

We are no longer using this processor, but would like to commit it for documentation purposes. Merging this branch will have no impact on any of the other branches or PRs, since it does not modify any existing files (it just adds a single new file).