### PR TITLE
Remove njet cut from lep selection

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -460,6 +460,10 @@ class AnalysisProcessor(processor.ProcessorABC):
                     if syst == "noweight": weight = np.ones(len(events)) # For data
                     else: weight = weights_object.weight(weight_fluct) # For MC
 
+                    # Get a mask for events that pass any of the njet requiremens in this nlep cat
+                    # Useful in cases like njets hist where we don't store njets in a sparse axis
+                    njets_any_mask = selections.any(*cat_dict[nlep_cat]["njets_lst"])
+
                     # Loop over the appropriate AR and SR for this channel
                     for appl in cat_dict[nlep_cat]["appl_lst"]:
 
@@ -472,7 +476,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                                 # Loop over the lep flavor list for each channel
                                 for lep_flav in cat_dict[nlep_cat]["lep_flav_lst"]:
 
-                                    # Construct the hist name and the cuts mask for all selections
+                                    # Construct the hist name
                                     flav_ch = None
                                     njet_ch = None
                                     cuts_lst = [appl,lep_chan]
@@ -483,7 +487,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                                         njet_ch = njet_val
                                         cuts_lst.append(njet_val)
                                     ch_name = construct_cat_name(lep_chan,njet_str=njet_ch,flav_str=flav_ch)
-                                    all_cuts_mask = selections.all(*cuts_lst)
+
+                                    # Get the cuts mask for all selections
+                                    if dense_axis_name == "njets":
+                                        all_cuts_mask = (selections.all(*cuts_lst) & njets_any_mask)
+                                    else:
+                                        all_cuts_mask = selections.all(*cuts_lst)
 
                                     # Weights and eft coeffs
                                     weights_flat = weight[all_cuts_mask]

--- a/topcoffea/modules/selection.py
+++ b/topcoffea/modules/selection.py
@@ -201,14 +201,11 @@ def add2lMaskAndSFs(events, year, isData):
     eleID1 = (abs(padded_FOs[:,0].pdgId)!=11) | ((padded_FOs[:,0].convVeto != 0) & (padded_FOs[:,0].lostHits==0) & (padded_FOs[:,0].tightCharge>=2))
     eleID2 = (abs(padded_FOs[:,1].pdgId)!=11) | ((padded_FOs[:,1].convVeto != 0) & (padded_FOs[:,1].lostHits==0) & (padded_FOs[:,1].tightCharge>=2))
 
-    # Jet requirements:
-    njet4 = (events.njets>3)
-
     # 2l requirements:
     exclusive = ak.num( FOs[FOs.isTightLep],axis=-1)<3
     dilep = (ak.num(FOs)) >= 2 
     pt2515 = (ak.any(FOs[:,0:1].conept > 25.0, axis=1) & ak.any(FOs[:,1:2].conept > 15.0, axis=1))
-    mask = (filters & cleanup & dilep & pt2515 & exclusive & Zee_veto & eleID1 & eleID2 & muTightCharge & njet4)
+    mask = (filters & cleanup & dilep & pt2515 & exclusive & Zee_veto & eleID1 & eleID2 & muTightCharge)
     events['is2l'] = ak.fill_none(mask,False)
 
     # SFs
@@ -241,9 +238,6 @@ def add3lMaskAndSFs(events, year, isData):
     eleID2=(abs(padded_FOs[:,1].pdgId)!=11) | ((padded_FOs[:,1].convVeto != 0) & (padded_FOs[:,1].lostHits==0))
     eleID3=(abs(padded_FOs[:,2].pdgId)!=11) | ((padded_FOs[:,2].convVeto != 0) & (padded_FOs[:,2].lostHits==0))
 
-    # Jet requirements:
-    njet2 = (events.njets>1)
-
     # Pt requirements for 3rd lepton (different for e and m)
     pt3lmask = ak.any(ak.where(abs(FOs[:,2:3].pdgId)==11,FOs[:,2:3].conept>15.0,FOs[:,2:3].conept>10.0),axis=1)
 
@@ -251,7 +245,7 @@ def add3lMaskAndSFs(events, year, isData):
     trilep = (ak.num(FOs)) >=3
     pt251510 = (ak.any(FOs[:,0:1].conept > 25.0, axis=1) & ak.any(FOs[:,1:2].conept > 15.0, axis=1) & pt3lmask)
     exclusive = ak.num( FOs[FOs.isTightLep],axis=-1)<4
-    mask = (filters & cleanup & trilep & pt251510 & exclusive & eleID1 & eleID2 & eleID3 & njet2) 
+    mask = (filters & cleanup & trilep & pt251510 & exclusive & eleID1 & eleID2 & eleID3)
     events['is3l'] = ak.fill_none(mask,False)
 
     # SFs
@@ -285,9 +279,6 @@ def add4lMaskAndSFs(events, year, isData):
     eleID3 = ((abs(padded_FOs[:,2].pdgId)!=11) | ((padded_FOs[:,2].convVeto != 0) & (padded_FOs[:,2].lostHits==0)))
     eleID4 = ((abs(padded_FOs[:,3].pdgId)!=11) | ((padded_FOs[:,3].convVeto != 0) & (padded_FOs[:,3].lostHits==0)))
 
-    # Jet requirements:
-    njet2 = (events.njets>=2)
-
     # Pt requirements for 3rd and 4th leptons (different for e and m)
     pt3lmask = ak.any(ak.where(abs(FOs[:,2:3].pdgId)==11,FOs[:,2:3].conept>15.0,FOs[:,2:3].conept>10.0),axis=1)
     pt4lmask = ak.any(ak.where(abs(FOs[:,3:4].pdgId)==11,FOs[:,3:4].conept>15.0,FOs[:,3:4].conept>10.0),axis=1)
@@ -296,7 +287,7 @@ def add4lMaskAndSFs(events, year, isData):
     fourlep  = (ak.num(FOs)) >= 4
     pt25151510 = (ak.any(FOs[:,0:1].conept > 25.0, axis=1) & ak.any(FOs[:,1:2].conept > 15.0, axis=1) & pt3lmask & pt4lmask)
     tightleps = ((padded_FOs[:,0].isTightLep) & (padded_FOs[:,1].isTightLep) & (padded_FOs[:,2].isTightLep) & (padded_FOs[:,3].isTightLep))
-    mask = (filters & cleanup & fourlep & pt25151510 & tightleps & eleID1 & eleID2 & eleID3 & eleID4 & njet2)
+    mask = (filters & cleanup & fourlep & pt25151510 & tightleps & eleID1 & eleID2 & eleID3 & eleID4)
     events['is4l'] = ak.fill_none(mask,False)
 
     # SFs:


### PR DESCRIPTION
In this branch, we've removed the njets cut from the lepton category selection functions in `selection.py`. After discussing with @yanfr0818 and @Andrew42, we think it makes more sense to keep the njets cuts separate for a few reasons:
* The naming of the lepton category selection functions do not make it obvious that an njets cut is applied as part of the selection, so it could lead to confusion.
* The njets selection is done in the processor, so it seems redundant to include it in both locations.
* For the implementation of the CRs, it is necessary to include njets categories that might be lower than the min njets category in the SR, so including the cut in the lepton category selection function does not make sense for this scenario. 

After removing the njets cut from the functions in `selection.py`, we also added an additional check in the histogram filling for loop [here](https://github.com/TopEFT/topcoffea/blob/rm-njet-cut-from-lep-sel/analysis/topEFT/topeft.py#L493) in the processor to make sure the njets histogram does not get filled with events that don't pass any of the njets requirements for the category.

As far as we are aware, removing this cut from `selection.py` should not change the output of the processor. However, since the reason why we originally included the njets cut in the lepton category selection functions was because that was how it was implemented in the ttH files we based these functions on, we wanted to check with @sscruz to make sure we're not missing something about why it might be important to include njets cuts in those functions.  