### PR TITLE
work_queue_factory instead of condor_submit_workers

### DIFF
--- a/README_WORKQUEUE.md
+++ b/README_WORKQUEUE.md
@@ -161,7 +161,7 @@ factory.json
 # Remember to replace USER in the manager-name of the configuration file with
 # your user id.
 conda activate topcoffea-env
-condor_submit_workers -Tcondor -Cfactory.json
+work_queue_factory -Tcondor -Cfactory.json
 ```
 
 The greatest advantage of using a configuration file for the factory is that


### PR DESCRIPTION
The command work_queue_factory is the proper command to set up workers using the Work Queue Factory. condor_submit_workers does not work with these arguments: -Tcondor -Cfactory.json