### PR TITLE
Some updates to the yields checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Compare yields
         run: |
           cd analysis/topEFT
-          python comp_yields.py test/UL17_private_ttH_for_CI_yields.json output_check_yields.json -t1 "Ref yields" -t2 "New yields"
+          python comp_yields.py output_check_yields.json test/UL17_private_ttH_for_CI_yields.json -t1 "New yields" -t2 "Ref yields"

--- a/analysis/topEFT/check_yields.sh
+++ b/analysis/topEFT/check_yields.sh
@@ -23,7 +23,7 @@ python get_yield_json.py -f histos/${OUT_FILE_NAME}.pkl.gz -n ${OUT_FILE_NAME} -
 
 # Compare the yields to the ref json
 printf "\nComparing yields agains reference...\n"
-python comp_yields.py ${REF_FILE_NAME} ${OUT_FILE_NAME}.json -t1 "Ref yields" -t2 "New yields" --quiet
+python comp_yields.py ${OUT_FILE_NAME}.json ${REF_FILE_NAME} -t1 "New yields" -t2 "Ref yields" --quiet
 
 # Do something with the exit code?
 echo $?

--- a/analysis/topEFT/comp_yields.py
+++ b/analysis/topEFT/comp_yields.py
@@ -58,7 +58,7 @@ def main():
         mlt.print_end()
 
     # Raise errors if yields are too different
-    yields_agree_bool = yt.print_yld_dicts(pdiff_dict,f"Percent diff between {args.tag1} and {args.tag2}",tolerance=1e-8)
+    yields_agree_bool = yt.print_yld_dicts(pdiff_dict,f"Percent diff between {args.tag1} and {args.tag2}",tolerance=1e-5)
     if not yields_agree_bool:
         sys.exit(1)
 


### PR DESCRIPTION
In this branch:
* The order we pass the new yields file and reference yield file to `comp_yields.py` has been swapped in both scripts we use for checking yields (i.e. in both [`check_yields.sh`](https://github.com/TopEFT/topcoffea/blob/update-check-yields/analysis/topEFT/check_yields.sh#L26) and the [CI yaml file](https://github.com/TopEFT/topcoffea/blob/update-check-yields/.github/workflows/main.yml#L48)) so that we're now checking `(new yield - ref yield)/(ref yield)` instead of `(ref yield - new yield)/(new yield)`.
* The tolerance for the comparison has been updated from 1e-8 to 1e-5, as suggested by @klannon.