### PR TITLE
Split HistEFT sparse axis by EFT quadratic terms

### DIFF
--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -107,7 +107,7 @@ class HistEFT(coffea.hist.Hist):
     """
     if self.dense_dim() > 1:
       raise RuntimeError("Splitting by terms not implemented for histograms with more than 1 dense axis")
-    if not axis_name in self._axes
+    if not axis_name in self._axes:
       raise KeyError(f"No axis {axis_name} found in {self}")
     dense_ax = self.dense_axes()[0]
 

--- a/topcoffea/modules/utils.py
+++ b/topcoffea/modules/utils.py
@@ -1,0 +1,17 @@
+import re
+
+# Match strings using one or more regular expressions
+def regex_match(lst,regex_lst):
+    # NOTE: For the regex_lst patterns, we use the raw string to generate the regular expression.
+    #       This means that any regex special characters in the regex_lst should be properly
+    #       escaped prior to calling this function.
+    # NOTE: The input list is assumed to be a list of str objects and nothing else!
+    matches = []
+    if len(regex_lst) == 0: return lst[:]
+    for s in lst:
+        for pat in regex_lst:
+            m = re.search(r"{}".format(pat),s)
+            if m is not None:
+                matches.append(s)
+                break
+    return matches

--- a/topcoffea/modules/utils.py
+++ b/topcoffea/modules/utils.py
@@ -6,11 +6,12 @@ def regex_match(lst,regex_lst):
     #       This means that any regex special characters in the regex_lst should be properly
     #       escaped prior to calling this function.
     # NOTE: The input list is assumed to be a list of str objects and nothing else!
-    matches = []
     if len(regex_lst) == 0: return lst[:]
+    matches = []
+    to_match = [re.compile(r"{}".format(x)) for x in regex_lst]
     for s in lst:
-        for pat in regex_lst:
-            m = re.search(r"{}".format(pat),s)
+        for pat in to_match:
+            m = pat.search(s)
             if m is not None:
                 matches.append(s)
                 break


### PR DESCRIPTION
This PR introduces a new class method called `split_by_terms()` to `HistEFT` that allows us to transform a histogram with a sparse axis that is binned by sample names (ttH, ttlnu, ttll, etc.) to one that is binned by the quadratic terms of the EFT parameterization for those sample names.

The method takes as input one required argument that is a list of axis bins that should correspond to bins with an EFT paramterization and also one optional argument that specifies the name of the sparse axis to use. The axis name should almost always correspond to whichever sparse axis defines the different sample names of the histogram. In the case of `topEFT`, this axis name is called `sample`, which is what the default is set to.

The method creates a copy of the calling histogram and makes the following modifications:
* A subset of the sparse axis is combined together and given a temporary new name in the axis. This combines the EFT paramterizations from different samples into one bin without removing the sparse axis altogether. This is accomplished through the `group()` class method.
* The quadratic function of the newly combined bin is extracted and then split up term-by-term. Each term is "labeled" based on the pair of WCs it depends on, e.g. `ctG.ctZ`, `ctW.ctW`, `SM.ctp`, etc. (A `.` was used here instead of `*` b/c coffea histograms don't allow sparse bins to be named using an asterisk (`*`))
* A new bin category in the sparse axis is created and filled for each of these quadratic terms, with the category name corresponding to the term's "label" via the `fill()` method. The `fill()` method is called exactly once for each term of the quadratic function, with the event weight set based on whatever that term in the quadratic would evaluate to
* The temporary bin category that was created by grouping the subset of bins from the sparse axis is then removed

An important thing to note is that the calling histogram should be reweighted to whatever WC phase space point that you care about _before_ calling the `split_by_terms()` method. This is b/c the generated histogram currently does not preserve any of the quadratic parameterization info from the original histogram, so it can't be reweighted once generated.

The PR also adds a new module called `utils.py` where we can include various useful functions that are not associated with any particular module. Currently, I've only added one function called `regex_match()`, which filters a list of strings passed to it based on a list of regular expressions that are also passed to it. This function is not strictly necessary, but is nice to have for convenience.

Below is a MWE showing how to use this method with a histogram loaded from a `.pkl` file produced by our `topeft.py` processor:
```python
import pickle
import gzip

from coffea.processor.accumulator import dict_accumulator
from topcoffea.modules.HistEFT import HistEFT

# Should make sure these have already been properly normalized
mc_sgnl_hists = pickle.load(gzip.open("histos/some_sgnl_mc_sample.pkl.gz"))
mc_bkgd_hists = pickle.load(gzip.open("histos/some_bkgd_mc_sample.pkl.gz"))

h_sgnl = mc_sgnl_hists["l0pt"]
h_bkgd = mc_bkgd_hists["l0pt"]

h_sgnl.add(h_bkgd)

h_sgnl.set_wilson_coefficients(ctG=-0.2,ctW=0.8,ctZ=0.8,ctp=-2.5)
axis_bins = ["tHq","ttH","tllq","ttll","ttlnu","tttt"]
h_split = h_sgnl.split_by_terms(axis_bins,axis_name='sample')
```
The `h_split` histogram will then have bins for the `sample` sparse axis corresponding to each of the background MC samples that were included in `some_bkgd_mc_sample.pkl.gz` and one additional bin for each term of the quadratic parameterization built by summing together the samples specified by the `axis_bins` list, which in this case would've come from the histogram obtained from the `some_sgnl_mc_sample.pkl.gz` file.

**Note:** The strings in the `axis_bins` list are what get passed to the `regex_match()` function, so `ttll` will match a sample named exactly `ttll`, but would also match a sample called `ttllJet_privateUL17` for example.