### PR TITLE
Fix crash when processing data, and fix normalization bug

### DIFF
--- a/analysis/topEFT/run.py
+++ b/analysis/topEFT/run.py
@@ -161,7 +161,7 @@ if __name__ == '__main__':
 
   # Run the processor and get the output
   tstart = time.time()
-  output = processor.run_uproot_job(flist, treename=treename, processor_instance=processor_instance, executor=processor.futures_executor, executor_args={"schema": NanoAODSchema,'workers': nworkers, 'pre_workers': 1}, chunksize=chunksize, maxchunks=nchunks)
+  output = processor.run_uproot_job(flist, treename=treename, processor_instance=processor_instance, executor=processor.futures_executor, executor_args={"schema": NanoAODSchema,'workers': nworkers}, chunksize=chunksize, maxchunks=nchunks)
   dt = time.time() - tstart
 
   nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -328,7 +328,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             weights_dict[ch_name] = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
             weights_dict[ch_name].add("norm",genw if isData else (xsec/sow)*genw)
             weights_dict[ch_name].add("btagSF", btagSF, btagSFUp, btagSFDo)
-            weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), GetPUSF(events.Pileup.nTrueInt, year, 1), GetPUSF(events.Pileup.nTrueInt, year, -1))
+            if not isData:
+                # Trying to calculate PU SFs for data causes a crash, and we don't apply this for data anyway, so just skip it in the case of data
+                weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), GetPUSF(events.Pileup.nTrueInt, year, 1), GetPUSF(events.Pileup.nTrueInt, year, -1))
             if "2l" in ch_name:
                 weights_dict[ch_name].add("lepSF", events.sf_2l, events.sf_2l_hi, events.sf_2l_lo)
                 weights_dict[ch_name].add("FF"   , events.fakefactor_2l, events.fakefactor_2l_up, events.fakefactor_2l_down )

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -306,8 +306,12 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # We need weights for: normalization, lepSF, triggerSF, pileup, btagSF...
         weights_dict = {}
-        genw = np.ones_like(events["event"]) if (isData or len(self._wc_names_lst)>0) else events["genWeight"]
-        if len(self._wc_names_lst) > 0: sow = np.ones_like(sow) # Not valid in nanoAOD for EFT samples, MUST use SumOfEFTweights at analysis level
+        if (isData or len(self._wc_names_lst)>0):
+            genw = np.ones_like(events["event"])
+        else:
+            genw = events["genWeight"]
+        if len(self._wc_names_lst) > 0:
+            sow = np.ones_like(sow) # Not valid in nanoAOD for EFT samples, MUST use SumOfEFTweights at analysis level
         for ch_name in ["2l", "3l", "4l", "2l_CR", "3l_CR", "2los_CRtt", "2los_CRZ"]:
             weights_dict[ch_name] = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
             weights_dict[ch_name].add("norm",genw if isData else (xsec/sow)*genw)

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -276,6 +276,18 @@ class AnalysisProcessor(processor.ProcessorABC):
         print("The number of events passing FO 2l, 3l, and 4l selection:", ak.num(events[events.is2l],axis=0),ak.num(events[events.is3l],axis=0),ak.num(events[events.is4l],axis=0))
 
 
+        ######### EFT coefficients ##########
+
+        # Extract the EFT quadratic coefficients and optionally use them to calculate the coefficients on the w**2 quartic function
+        # eft_coeffs is never Jagged so convert immediately to numpy for ease of use.
+        eft_coeffs = ak.to_numpy(events["EFTfitCoefficients"]) if hasattr(events, "EFTfitCoefficients") else None
+        if eft_coeffs is not None:
+            # Check to see if the ordering of WCs for this sample matches what want
+            if self._samples[dataset]["WCnames"] != self._wc_names_lst:
+                eft_coeffs = efth.remap_coeffs(self._samples[dataset]["WCnames"], self._wc_names_lst, eft_coeffs)
+        eft_w2_coeffs = efth.calc_w2_coeffs(eft_coeffs,self._dtype) if (self._do_errors and eft_coeffs is not None) else None
+
+
         ######### SFs, weights, systematics ##########
 
         # Btag SF following 1a) in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods
@@ -306,11 +318,11 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # We need weights for: normalization, lepSF, triggerSF, pileup, btagSF...
         weights_dict = {}
-        if (isData or len(self._wc_names_lst)>0):
+        if (isData or (eft_coeffs is not None)):
             genw = np.ones_like(events["event"])
         else:
             genw = events["genWeight"]
-        if len(self._wc_names_lst) > 0:
+        if (eft_coeffs is not None):
             sow = np.ones_like(sow) # Not valid in nanoAOD for EFT samples, MUST use SumOfEFTweights at analysis level
         for ch_name in ["2l", "3l", "4l", "2l_CR", "3l_CR", "2los_CRtt", "2los_CRZ"]:
             weights_dict[ch_name] = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
@@ -329,17 +341,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Systematics
         systList = ["nominal"]
         if self._do_systematics and not isData: systList = systList + ["lepSFUp","lepSFDown","btagSFUp", "btagSFDown"]
-
-        ######### EFT coefficients ##########
-
-        # Extract the EFT quadratic coefficients and optionally use them to calculate the coefficients on the w**2 quartic function
-        # eft_coeffs is never Jagged so convert immediately to numpy for ease of use.
-        eft_coeffs = ak.to_numpy(events["EFTfitCoefficients"]) if hasattr(events, "EFTfitCoefficients") else None
-        if eft_coeffs is not None:
-            # Check to see if the ordering of WCs for this sample matches what want
-            if self._samples[dataset]["WCnames"] != self._wc_names_lst:
-                eft_coeffs = efth.remap_coeffs(self._samples[dataset]["WCnames"], self._wc_names_lst, eft_coeffs)
-        eft_w2_coeffs = efth.calc_w2_coeffs(eft_coeffs,self._dtype) if (self._do_errors and eft_coeffs is not None) else None
 
 
         ######### Masks we need for the selection ##########
@@ -522,7 +523,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # Fill sum of weights hist
         normweights = weights_dict["2l"].partial_weight(include=["norm"]) # Here we could have used 2l, 3l, or 4l, as the "norm" weights should be identical for all three
-        if len(self._wc_names_lst)>0: sowweights = np.ones_like(normweights)
+        if (eft_coeffs is not None): sowweights = np.ones_like(normweights)
         else: sowweights = normweights
         hout["SumOfEFTweights"].fill(sample=histAxisName, SumOfEFTweights=counts, weight=sowweights, eft_coeff=eft_coeffs, eft_err_coeff=eft_w2_coeffs)
 


### PR DESCRIPTION
This branch is supposed to fix two bugs:
* After merging PR #98, the code was crashing [here](https://github.com/TopEFT/topcoffea/blob/master/analysis/topEFT/topeft.py#L315) when processing data. Even though we do not use the PU SFs for data, the code was still trying to calculate them, which would be fine (since they do not actually get applied), except for the fact that it was crashing in the process. To work around this, I just put the PU SF calculation inside an `if not isData` statement. 
* Also, as @bryates pointed out last week, the issue with trying to use the length of the WC list to determine if we're dealing with an EFT sample or not also showed up in the processor. That check does not work when processing eft and non-EFT samples together, since all histograms will have a WC list that is the superset of all WCs in all of the samples being processed. As a quick fix, I just swapped out that check with an `eft_coeffs is not None` check, as we already set the `eft_coeffs` variable [here](https://github.com/TopEFT/topcoffea/blob/master/analysis/topEFT/topeft.py#L333), so it seems like we might as well use it.