### PR TITLE
construct conda environments using conda-forge as default

### DIFF
--- a/README_WORKQUEUE.md
+++ b/README_WORKQUEUE.md
@@ -40,10 +40,9 @@ Once `conda` is installed, open a new terminal and create the base python
 environment for topcoffea:
 
 ```sh
-# you may choose other python version, e.g. 3.9
-conda create --name topcoffea-env python=3.8
+# you may choose other python version, e.g. 3.8
+conda create --name topcoffea-env -c conda-forge python=3.9 coffea xrootd ndcctools dill conda conda-pack
 conda activate topcoffea-env
-conda install -c conda-forge coffea xrootd ndcctools dill conda-pack
 
 # install topcoffea via pip. We install it in editable mode to ease the test of
 # changes in development. From the root directory of the topcoffea repository:

--- a/analysis/topEFT/topeftenv.py
+++ b/analysis/topEFT/topeftenv.py
@@ -28,8 +28,8 @@ packages_json_template = string.Template('''
 {
     "base": {
         "conda": {
-            "defaults" : ["python=$py_version", "conda"],
-            "conda-forge" : ["conda-pack", "dill", "xrootd", "coffea"]
+            "defaults" : [],
+            "conda-forge" : ["python=$py_version", "conda", "conda-pack", "dill", "xrootd", "coffea"]
         }
     },
     "user": {
@@ -73,7 +73,7 @@ def _install_pip_requirements(base_env_tarball, env_path, pkg, location):
     _run_conda_command(
             env_path,
             'run',
-            'sh', '-c', 'cd {} && pip install . && pip uninstall --yes {}'.format(location, pkg))
+            'sh', '-c', 'cd {} && pip install  --use-feature=in-tree-build . && pip uninstall --yes {}'.format(location, pkg))
 
 def _create_base_env(packages_hash, pip_paths, force=False):
     pathlib.Path(env_dir_cache).mkdir(parents=True, exist_ok=True)
@@ -179,7 +179,7 @@ python_package_run -e {base_env_tarball} -u {env_dir} -- conda remove --yes --fo
 
 # install from pip local path
 set -e
-python_package_run -e {base_env_tarball} -u {env_dir} -- pip install {path}
+python_package_run -e {base_env_tarball} -u {env_dir} -- pip install  --use-feature=in-tree-build  {path}
     """.format(base_env_tarball=base_env_tarball, env_dir=env_dir, path=pip_path))
         pip_recipe.flush()
         try:

--- a/analysis/topEFT/topeftenv.py
+++ b/analysis/topEFT/topeftenv.py
@@ -60,6 +60,8 @@ def _run_conda_command(environment, command, *args):
 
 def _install_conda_packages(env_path, channel, pkgs, from_local_pip=[]):
     pkgs = [p for p in pkgs if p not in from_local_pip]
+    if not pkgs:
+        return
     logger.info("Installing {} into {} via conda".format(','.join(pkgs), env_path))
     return _run_conda_command(
             env_path,


### PR DESCRIPTION
This should reduce the change for a glibc conflict, as all the packages
will be obtained from the same channel build spec.