### PR TITLE
Variable binning

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -219,10 +219,10 @@ class DatacardMaker():
                 elif '3l' in channel: h_base = h_base.rebin('njets', hist.Bin("njets",  "Jet multiplicity ", [2,3,4,5]))
                 elif '4l' in channel: h_base = h_base.rebin('njets', hist.Bin("njets",  "Jet multiplicity ", [2,3,4]))
             if 'ht' in variable:
-                h_base = h_base.rebin('ht', hist.Bin("ht", "H$_{T}$ (GeV)", 10, h_base.axis(variable).edges()[0], h_base.axis(variable).edges()[-1]))
+                h_base = h_base.rebin('ht', hist.Bin("ht", "H$_{T}$ (GeV)", [0, 100, 200, 300, 400, 600, 800, 1400, 2000]))
             if 'ptbl' in variable:
-                h_base = h_base.rebin('ptbl', hist.Bin("ptbl", "$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$", 10, h_base.axis(variable).edges()[0], h_base.axis(variable).edges()[-1]))
-            # Save the SM plot
+                h_base = h_base.rebin('ptbl', hist.Bin("ptbl", "$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$", [0, 50, 100, 200, 400, 2000]))
+            #Save the SM plot
             h_bases = {syst: h_base.integrate('systematic', syst) for syst in self.syst}
             h_base = h_base.integrate('systematic', 'nominal')
             h_sm = h_bases

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -219,7 +219,7 @@ class DatacardMaker():
                 elif '3l' in channel: h_base = h_base.rebin('njets', hist.Bin("njets",  "Jet multiplicity ", [2,3,4,5]))
                 elif '4l' in channel: h_base = h_base.rebin('njets', hist.Bin("njets",  "Jet multiplicity ", [2,3,4]))
             if 'ht' in variable:
-                h_base = h_base.rebin('ht', hist.Bin("ht", "H$_{T}$ (GeV)", [0, 100, 200, 300, 400, 600, 800, 1400, 2000]))
+                h_base = h_base.rebin('ht', hist.Bin("ht", "H$_{T}$ (GeV)", [0, 100, 200, 300, 400, 600, 800, 2000]))
             if 'ptbl' in variable:
                 h_base = h_base.rebin('ptbl', hist.Bin("ptbl", "$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$", [0, 50, 100, 200, 400, 2000]))
             #Save the SM plot

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -219,7 +219,7 @@ class DatacardMaker():
                 elif '3l' in channel: h_base = h_base.rebin('njets', hist.Bin("njets",  "Jet multiplicity ", [2,3,4,5]))
                 elif '4l' in channel: h_base = h_base.rebin('njets', hist.Bin("njets",  "Jet multiplicity ", [2,3,4]))
             if 'ht' in variable:
-                h_base = h_base.rebin('ht', hist.Bin("ht", "H$_{T}$ (GeV)", [0, 100, 200, 300, 400, 600, 800, 2000]))
+                h_base = h_base.rebin('ht', hist.Bin("ht", "H$_{T}$ (GeV)", [0, 100, 200, 300, 400, 2000]))
             if 'ptbl' in variable:
                 h_base = h_base.rebin('ptbl', hist.Bin("ptbl", "$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$", [0, 50, 100, 200, 400, 2000]))
             #Save the SM plot

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -222,7 +222,7 @@ class DatacardMaker():
                 h_base = h_base.rebin('ht', hist.Bin("ht", "H$_{T}$ (GeV)", [0, 100, 200, 300, 400, 2000]))
             if 'ptbl' in variable:
                 h_base = h_base.rebin('ptbl', hist.Bin("ptbl", "$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$", [0, 50, 100, 200, 400, 2000]))
-            #Save the SM plot
+            # Save the SM plot
             h_bases = {syst: h_base.integrate('systematic', syst) for syst in self.syst}
             h_base = h_base.integrate('systematic', 'nominal')
             h_sm = h_bases


### PR DESCRIPTION
This PR adds the first, stable, version of variable binning for `ptbl` and `ht`. These give smooth scans (currently with `3l onZ 2b 5j`) excluded. Also, since we haven't processed a pkl file with the new `ext` fix yet, I've been adding
```python
if '_ext' not in proc and proc+'_ext' in self.samples: continue
```
after [L197](https://github.com/TopEFT/topcoffea/blob/8550e747a29e8cd0a9e2ccc9cb6316d8a73ae7d0/analysis/topEFT/datacard_maker.py#L197) in the datacard maker to only process extension samples, if they exist.