### PR TITLE
Allow for different categories for different njet bins

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -496,50 +496,110 @@ class AnalysisProcessor(processor.ProcessorABC):
           # This dictionary keeps track of which selections go with which SR categories
           sr_cat_dict = {
             "2l" : {
-                "lep_chan_lst" : ["2lss_p" , "2lss_m"],
-                "lep_flav_lst" : ["ee" , "em" , "mm"],
-                "njets_lst"    : ["exactly_4j" , "exactly_5j" , "exactly_6j" , "atleast_7j"],
-                "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                "exactly_4j" : {
+                    "lep_chan_lst" : ["2lss_p" , "2lss_m"],
+                    "lep_flav_lst" : ["ee" , "em" , "mm"],
+                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                },
+                "exactly_5j" : {
+                    "lep_chan_lst" : ["2lss_p" , "2lss_m"],
+                    "lep_flav_lst" : ["ee" , "em" , "mm"],
+                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                },
+                "exactly_6j" : {
+                    "lep_chan_lst" : ["2lss_p" , "2lss_m"],
+                    "lep_flav_lst" : ["ee" , "em" , "mm"],
+                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                },
+                "atleast_7j" : {
+                    "lep_chan_lst" : ["2lss_p" , "2lss_m"],
+                    "lep_flav_lst" : ["ee" , "em" , "mm"],
+                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                },
             },
             "3l" : {
-                "lep_chan_lst" : ["3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b"],
-                "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                "njets_lst"    : ["exactly_2j" , "exactly_3j" , "exactly_4j" , "atleast_5j"],
-                "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                "exactly_2j" : {
+                    "lep_chan_lst" : [
+                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                    ],
+                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                },
+                "exactly_3j" : {
+                    "lep_chan_lst" : [
+                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                    ],
+                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                },
+                "exactly_4j" : {
+                    "lep_chan_lst" : [
+                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                    ],
+                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                },
+                "atleast_5j" : {
+                    "lep_chan_lst" : [
+                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                    ],
+                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                },
             },
             "4l" : {
-                "lep_chan_lst" : ["4l"],
-                "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                "njets_lst"    : ["exactly_2j" , "exactly_3j" , "atleast_4j"],
-                "appl_lst"     : ["isSR_4l"],
+                    "exactly_2j" : {
+                        "lep_chan_lst" : ["4l"],
+                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                        "appl_lst"     : ["isSR_4l"],
+                    },
+                    "exactly_3j" : {
+                        "lep_chan_lst" : ["4l"],
+                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                        "appl_lst"     : ["isSR_4l"],
+                    },
+                    "atleast_4j" : {
+                        "lep_chan_lst" : ["4l"],
+                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                        "appl_lst"     : ["isSR_4l"],
+                    },
             },
           }
 
           # This dictionary keeps track of which selections go with which CR categories
           cr_cat_dict = {
             "2l_CR" : {
-                "lep_chan_lst" : ["2lss_CR"],
-                "lep_flav_lst" : ["ee" , "em" , "mm"],
-                "njets_lst"    : ["exactly_1j" , "exactly_2j"],
-                "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                "exactly_1j" : {
+                    "lep_chan_lst" : ["2lss_CR"],
+                    "lep_flav_lst" : ["ee" , "em" , "mm"],
+                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                },
+                "exactly_2j" : {
+                    "lep_chan_lst" : ["2lss_CR"],
+                    "lep_flav_lst" : ["ee" , "em" , "mm"],
+                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                },
             },
             "3l_CR" : {
-                "lep_chan_lst" : ["3l_CR"],
-                "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                "njets_lst"    : ["atleast_1j"],
-                "appl_lst"     : ["isSR_3l" , "isAR_3l"],
+                "atleast_1j" : {
+                    "lep_chan_lst" : ["3l_CR"],
+                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                    "appl_lst"     : ["isSR_3l" , "isAR_3l"],
+                },
             },
             "2los_CRtt" : {
-                "lep_chan_lst" : ["2los_CRtt"],
-                "lep_flav_lst" : ["em"],
-                "njets_lst"    : ["exactly_2j"],
-                "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                "exactly_2j"   : {
+                    "lep_chan_lst" : ["2los_CRtt"],
+                    "lep_flav_lst" : ["em"],
+                    "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                },
             },
             "2los_CRZ" : {
-                "lep_chan_lst" : ["2los_CRZ"],
-                "lep_flav_lst" : ["ee", "mm"],
-                "njets_lst"    : ["atleast_0j"],
-                "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                "atleast_0j"   : {
+                    "lep_chan_lst" : ["2los_CRZ"],
+                    "lep_flav_lst" : ["ee", "mm"],
+                    "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                },
             }            
           }
 
@@ -585,19 +645,19 @@ class AnalysisProcessor(processor.ProcessorABC):
 
                     # Get a mask for events that pass any of the njet requiremens in this nlep cat
                     # Useful in cases like njets hist where we don't store njets in a sparse axis
-                    njets_any_mask = selections.any(*cat_dict[nlep_cat]["njets_lst"])
+                    njets_any_mask = selections.any(*cat_dict[nlep_cat].keys())
 
-                    # Loop over the appropriate AR and SR for this channel
-                    for appl in cat_dict[nlep_cat]["appl_lst"]:
+                    # Loop over the njets list for each channel
+                    for njet_val in cat_dict[nlep_cat].keys():
 
-                        # Loop over the channels in each nlep cat (e.g. "3l_m_offZ_1b")
-                        for lep_chan in cat_dict[nlep_cat]["lep_chan_lst"]:
+                        # Loop over the appropriate AR and SR for this channel
+                        for appl in cat_dict[nlep_cat][njet_val]["appl_lst"]:
 
-                            # Loop over the njets list for each channel
-                            for njet_val in cat_dict[nlep_cat]["njets_lst"]:
+                            # Loop over the channels in each nlep cat (e.g. "3l_m_offZ_1b")
+                            for lep_chan in cat_dict[nlep_cat][njet_val]["lep_chan_lst"]:
 
                                 # Loop over the lep flavor list for each channel
-                                for lep_flav in cat_dict[nlep_cat]["lep_flav_lst"]:
+                                for lep_flav in cat_dict[nlep_cat][njet_val]["lep_flav_lst"]:
 
                                     # Construct the hist name
                                     flav_ch = None
@@ -643,8 +703,8 @@ class AnalysisProcessor(processor.ProcessorABC):
                                     # Do not loop over lep flavors if not self._split_by_lepton_flavor, it's a waste of time and also we'd fill the hists too many times
                                     if not self._split_by_lepton_flavor: break
 
-                                # Do not loop over njets if hist is njets (otherwise we'd fill the hist too many times)
-                                if dense_axis_name == "njets": break
+                        # Do not loop over njets if hist is njets (otherwise we'd fill the hist too many times)
+                        if dense_axis_name == "njets": break
 
         return hout
 


### PR DESCRIPTION
This PR rearranges how we define the selection categories in the processor (it is not supposed to change any of the outputs, just the way the code is internally structured). Previously, the `sr_cat_dict` (and `cr_cat_dict`) had been structured in such a way so as to require that all of the channels in the `lep_chan_lst` would all have the same njet bins. This PR reorganizes the `sr_cat_dict` (and `cr_cat_dict`) so that each njet bin may have a different list of selection channels.

Motivation for this PR:
*  Many of the optimization strategies we have been discussing involve different categories for different njet bins. This reorganization should make that easier to implement. 
* I had already implemented these changes in the branch I was working on for the hadronic top studies. However, as it seems that branch will not end up getting merged (since the hadronic top pt does not actually seem to improve our sensitivity), I thought that it might be good to get these changes merged since they are really independent of the hadronic top studies, are already written, and might be useful in the future. 