### PR TITLE
Only loop over the systs that we need to

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -172,7 +172,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Update muon kinematics with Rochester corrections
         mu["pt_raw"]=mu.pt
         met_raw=met
-        if self._do_systematics : syst_var_list = ['ISRUp','ISRDown','FSRUp','FSRDown','renormUp','renormDown','factUp','factDown','renorm_factUp','renorm_factDown','MuonESUp','MuonESDown','JERUp','JERDown','JESUp','JESDown','nominal']
+        if self._do_systematics : syst_var_list = ['MuonESUp','MuonESDown','JERUp','JERDown','JESUp','JESDown','nominal']
         else: syst_var_list = ['nominal']
         for syst_var in syst_var_list:
           mu["pt"]=mu.pt_raw

--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -353,7 +353,9 @@ def ApplyJetSystematics(cleanedJets,syst_var):
   elif(syst_var == 'JERDown'): return cleanedJets.JER.down
   elif(syst_var == 'JESUp'): return cleanedJets.JES_jes.up
   elif(syst_var == 'JESDown'): return cleanedJets.JES_jes.down
-  else: return cleanedJets
+  elif(syst_var == 'nominal'): return cleanedJets
+  elif(syst_var in ['nominal','MuonESUp','MuonESDown']): return cleanedJets
+  else: raise Exception(f"Error: Unknown variation \"{syst_var}\".")
 ###### Muon Rochester corrections
 ################################################################
 # https://gitlab.cern.ch/akhukhun/roccor


### PR DESCRIPTION
This PR modifies the list of systematics that we loop over in the "outside" loop in the processor to limit this list to only those that should impact the selection. This should significantly improve the runtime when running the processor with the `_do_systematics ` option turned on (since we won't have to rerun all of the code in the processor for _all_ of the systematics). 

As a mostly unrelated update, the behavior of the `ApplyJetSystematics()` function of `corrections` has also been updated so that the `else` will now raise an exception. This is to avoid the scenario where we e.g. pass something like `JERup` to the function (when we had meant to pass `JERUp`). Currently this would result in the code silently returning `cleanedJets` instead of `cleanedJets.JER.up`. With this update, the code would now complain about an unknown `syst_var`.