### PR TITLE
wq install: use --strict-channel-priority

### DIFF
--- a/README_WORKQUEUE.md
+++ b/README_WORKQUEUE.md
@@ -41,7 +41,7 @@ environment for topcoffea:
 
 ```sh
 # you may choose other python version, e.g. 3.8
-conda create --name topcoffea-env -c conda-forge python=3.9 coffea xrootd ndcctools dill conda conda-pack
+conda create --name topcoffea-env -c conda-forge --strict-channel-priority python=3.9 coffea xrootd ndcctools dill conda conda-pack
 conda activate topcoffea-env
 
 # install topcoffea via pip. We install it in editable mode to ease the test of


### PR DESCRIPTION
It gives a hint to conda that makes environment creation and package
installation a little bit faster.

This will be the default in an upcoming conda version.