### PR TITLE
Datacard maker overflow updates

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -334,7 +334,17 @@ class DatacardMaker():
             xmin = h.GetXaxis().GetXmin()
             xmax = h.GetXaxis().GetXmax()
             xwidth = h.GetXaxis().GetBinWidth(1)
-            h.GetXaxis().SetRangeUser(xmin, xmax + 1.5*xwidth) #Include overflow bin in ROOT
+
+            # Fold overflow bin in ROOT into last bin (combine does NOT use the overflow bin)
+            last = h.GetBinContent(h.GetNbinsX())                  # Last bin
+            over = h.GetBinContent(h.GetNbinsX()+1)                # Overflow
+            e_last = h.GetBinError(h.GetNbinsX())                  # Last bin error
+            e_over = h.GetBinError(h.GetNbinsX()+1)                # Overflow error
+            h.SetBinContent(h.GetNbinsX(), last+over)              # Add overflow to last bin
+            h.SetBinError(h.GetNbinsX(),(e_last**2+e_over**2)**.5) # Add overflow error in quadrature to last bin
+            h.SetBinContent(h.GetNbinsX()+1, 0.0)                  # Set overflow to 0
+            h.SetBinError(h.GetNbinsX()+1,0.0)                     # Set overflow error to 0
+
             return deepcopy(h) # to protect d_hists from modifications 
 
         def processSyst(process, systMap, d_hists, fout):

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -329,22 +329,30 @@ class DatacardMaker():
         ``Q`` is built from the ``WC=0``, ``WC=1``, and ``WC=2`` pieces
         ``S+L_i+L_j+Q_i+Q_j+2 M_IJ`` set ``WC_i=1``, ``WC_j=1`` and the rest to ``0``
         '''
+
+        # Loops through a dict of hists and takes care of the overflow bins
+        # Returns a new hist (should not modify original), with overflow combined with last bin
+        # In principle would probably be better for this function to act on a hist, not a dict of hists
+        def getOverflowMergedHists(in_dict):
+            ret_dict = {}
+            loop_dict = deepcopy(in_dict) # Make sure we do not modify the input dict
+            for loop_name,loop_histo in loop_dict.items():
+                last   = loop_histo.GetBinContent(loop_histo.GetNbinsX())                # Last bin
+                over   = loop_histo.GetBinContent(loop_histo.GetNbinsX()+1)              # Overflow
+                e_last = loop_histo.GetBinError(loop_histo.GetNbinsX())                  # Last bin error
+                e_over = loop_histo.GetBinError(loop_histo.GetNbinsX()+1)                # Overflow error
+                loop_histo.SetBinContent(loop_histo.GetNbinsX(), last+over)              # Add overflow to last bin
+                loop_histo.SetBinContent(loop_histo.GetNbinsX()+1, 0.0)                  # Set overflow to 0
+                loop_histo.SetBinError(loop_histo.GetNbinsX(),(e_last**2+e_over**2)**.5) # Add overflow error in quadrature to last bin
+                loop_histo.SetBinError(loop_histo.GetNbinsX()+1,0.0)                     # Set overflow error to 0
+                ret_dict[loop_name] = loop_histo
+            return ret_dict
+
         def getHist(d_hists,name):
             h = d_hists[name]
             xmin = h.GetXaxis().GetXmin()
             xmax = h.GetXaxis().GetXmax()
             xwidth = h.GetXaxis().GetBinWidth(1)
-
-            # Fold overflow bin in ROOT into last bin (combine does NOT use the overflow bin)
-            last = h.GetBinContent(h.GetNbinsX())                  # Last bin
-            over = h.GetBinContent(h.GetNbinsX()+1)                # Overflow
-            e_last = h.GetBinError(h.GetNbinsX())                  # Last bin error
-            e_over = h.GetBinError(h.GetNbinsX()+1)                # Overflow error
-            h.SetBinContent(h.GetNbinsX(), last+over)              # Add overflow to last bin
-            h.SetBinError(h.GetNbinsX(),(e_last**2+e_over**2)**.5) # Add overflow error in quadrature to last bin
-            h.SetBinContent(h.GetNbinsX()+1, 0.0)                  # Set overflow to 0
-            h.SetBinError(h.GetNbinsX()+1,0.0)                     # Set overflow error to 0
-
             return deepcopy(h) # to protect d_hists from modifications 
 
         def processSyst(process, systMap, d_hists, fout):
@@ -404,15 +412,20 @@ class DatacardMaker():
                 cat = '_'.join([channel, variable])  
             else:
                 cat = '_'.join([channel, nbjet, variable])
-        #Open temp ROOT file
+
+        # Open temp ROOT file
         fname = f'histos/tmp_ttx_multileptons-{cat}.root'
         fin = TFile(fname)
-        d_hists = {k.GetName(): fin.Get(k.GetName()) for k in fin.GetListOfKeys()}
-        [h.SetDirectory(0) for h in d_hists.values()]
+        d_hists_withoverflow = {k.GetName(): fin.Get(k.GetName()) for k in fin.GetListOfKeys()}
+        [h.SetDirectory(0) for h in d_hists_withoverflow.values()]
         fin.Close()
-        #Delete temp ROOT file
+        # Delete temp ROOT file
         os.system(f'rm {fname}')
-        #Create the ROOT file
+
+        # Fold overflow bin in ROOT into last bin (combine does NOT use the overflow bin)
+        d_hists = getOverflowMergedHists(d_hists_withoverflow)
+
+        # Create the ROOT file
         fname = f'histos/ttx_multileptons-{cat}.root'
         fout = TFile(fname, 'recreate')
         signalcount=0; bkgcount=0; iproc = {}; systMap = {}; allyields = {'data_obs' : 0.}


### PR DESCRIPTION
This PR fixes the overflow issue in the datacard maker. The issue was that the overflow bins in the coffea histograms were being included as overflow in the ROOT histograms as well. This is problematic since combine ignores overflow bins.

There are probably many ways of handling this issue, but the approach taken in this PR is to perform the modifications on the ROOT histograms (as opposed to the coffea histograms) at the start of the `makeCardLevel()` method. For each hist, the contents of the overflow bin are added to the last bin in the hist, the contents of the overflow bin's error is added in quadrature to the last bin's error, the overflow bin's contents are set to 0, and the overflow's error is set to 0. 