### PR TITLE
Add path entry to json sample files

### DIFF
--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016.json
@@ -20,5 +20,6 @@
   "nEvents": 5686987.0,
   "nGenEvents": 5686987.0,
   "nSumOfWeights": 5686987.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016B-ver1_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016.json
@@ -69,5 +69,6 @@
   "nEvents": 143073268.0,
   "nGenEvents": 143073268.0,
   "nSumOfWeights": 143073268.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODv9-v2/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016.json
@@ -34,5 +34,6 @@
   "nEvents": 47677856.0,
   "nGenEvents": 47677856.0,
   "nSumOfWeights": 47677856.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016.json
@@ -68,5 +68,6 @@
   "nEvents": 53324960.0,
   "nGenEvents": 53324960.0,
   "nSumOfWeights": 53324960.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016.json
@@ -38,5 +38,6 @@
   "nEvents": 49877710.0,
   "nGenEvents": 49877710.0,
   "nSumOfWeights": 49877710.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016.json
@@ -41,5 +41,6 @@
   "nEvents": 30216940.0,
   "nGenEvents": 30216940.0,
   "nSumOfWeights": 30216940.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_F-UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_F-UL2016.json
@@ -15,5 +15,6 @@
   "nEvents": 4360689.0,
   "nGenEvents": 4360689.0,
   "nSumOfWeights": 4360689.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016F-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_G-UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_G-UL2016.json
@@ -57,5 +57,6 @@
   "nEvents": 78797031.0,
   "nGenEvents": 78797031.0,
   "nSumOfWeights": 78797031.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016G-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleEG_H-UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_H-UL2016.json
@@ -96,5 +96,6 @@
   "nEvents": 85388673.0,
   "nGenEvents": 85388673.0,
   "nSumOfWeights": 85388673.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2016H-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016.json
@@ -13,5 +13,6 @@
   "nEvents": 4199947.0,
   "nGenEvents": 4199947.0,
   "nSumOfWeights": 4199947.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016B-ver1_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016.json
@@ -52,5 +52,6 @@
   "nEvents": 82535526.0,
   "nGenEvents": 82535526.0,
   "nSumOfWeights": 82535526.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016.json
@@ -30,5 +30,6 @@
   "nEvents": 27934629.0,
   "nGenEvents": 27934629.0,
   "nSumOfWeights": 27934629.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016.json
@@ -34,5 +34,6 @@
   "nEvents": 33861745.0,
   "nGenEvents": 33861745.0,
   "nSumOfWeights": 33861745.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016.json
@@ -25,5 +25,6 @@
   "nEvents": 28246946.0,
   "nGenEvents": 28246946.0,
   "nSumOfWeights": 28246946.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016.json
@@ -21,5 +21,6 @@
   "nEvents": 17900759.0,
   "nGenEvents": 17900759.0,
   "nSumOfWeights": 17900759.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_F-UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_F-UL2016.json
@@ -11,5 +11,6 @@
   "nEvents": 2429162.0,
   "nGenEvents": 2429162.0,
   "nSumOfWeights": 2429162.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016F-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_G-UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_G-UL2016.json
@@ -39,5 +39,6 @@
   "nEvents": 45235604.0,
   "nGenEvents": 45235604.0,
   "nSumOfWeights": 45235604.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016G-UL2016_MiniAODv2_NanoAODv9-v2/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/DoubleMuon_H-UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_H-UL2016.json
@@ -38,5 +38,6 @@
   "nEvents": 48912812.0,
   "nGenEvents": 48912812.0,
   "nSumOfWeights": 48912812.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2016H-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016.json
@@ -13,5 +13,6 @@
   "nEvents": 225271.0,
   "nGenEvents": 225271.0,
   "nSumOfWeights": 225271.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016B-ver1_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016.json
@@ -28,5 +28,6 @@
   "nEvents": 32727796.0,
   "nGenEvents": 32727796.0,
   "nSumOfWeights": 32727796.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016.json
@@ -19,5 +19,6 @@
   "nEvents": 15405678.0,
   "nGenEvents": 15405678.0,
   "nSumOfWeights": 15405678.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016.json
@@ -24,5 +24,6 @@
   "nEvents": 23482352.0,
   "nGenEvents": 23482352.0,
   "nSumOfWeights": 23482352.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016.json
@@ -30,5 +30,6 @@
   "nEvents": 22519303.0,
   "nGenEvents": 22519303.0,
   "nSumOfWeights": 22519303.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016.json
@@ -20,5 +20,6 @@
   "nEvents": 14100826.0,
   "nGenEvents": 14100826.0,
   "nSumOfWeights": 14100826.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_F-UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_F-UL2016.json
@@ -13,5 +13,6 @@
   "nEvents": 1901339.0,
   "nGenEvents": 1901339.0,
   "nSumOfWeights": 1901339.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016F-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_G-UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_G-UL2016.json
@@ -39,5 +39,6 @@
   "nEvents": 33854612.0,
   "nGenEvents": 33854612.0,
   "nSumOfWeights": 33854612.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016G-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/MuonEG_H-UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_H-UL2016.json
@@ -29,5 +29,6 @@
   "nEvents": 29236516.0,
   "nGenEvents": 29236516.0,
   "nSumOfWeights": 29236516.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2016H-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016.json
@@ -11,5 +11,6 @@
   "nEvents": 1422819.0,
   "nGenEvents": 1422819.0,
   "nSumOfWeights": 1422819.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016B-ver1_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016.json
@@ -118,5 +118,6 @@
   "nEvents": 246440440.0,
   "nGenEvents": 246440440.0,
   "nSumOfWeights": 246440440.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016.json
@@ -77,5 +77,6 @@
   "nEvents": 97259854.0,
   "nGenEvents": 97259854.0,
   "nSumOfWeights": 97259854.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016.json
@@ -78,5 +78,6 @@
   "nEvents": 148167727.0,
   "nGenEvents": 148167727.0,
   "nSumOfWeights": 148167727.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016.json
@@ -76,5 +76,6 @@
   "nEvents": 117269446.0,
   "nGenEvents": 117269446.0,
   "nSumOfWeights": 117269446.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016.json
@@ -51,5 +51,6 @@
   "nEvents": 61735326.0,
   "nGenEvents": 61735326.0,
   "nSumOfWeights": 61735326.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_F-UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_F-UL2016.json
@@ -15,5 +15,6 @@
   "nEvents": 8858206.0,
   "nGenEvents": 8858206.0,
   "nSumOfWeights": 8858206.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016F-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_G-UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_G-UL2016.json
@@ -81,5 +81,6 @@
   "nEvents": 153363109.0,
   "nGenEvents": 153363109.0,
   "nSumOfWeights": 153363109.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016G-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleElectron_H-UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_H-UL2016.json
@@ -90,5 +90,6 @@
   "nEvents": 129021893.0,
   "nGenEvents": 129021893.0,
   "nSumOfWeights": 129021893.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2016H-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016.json
@@ -15,5 +15,6 @@
   "nEvents": 2789243.0,
   "nGenEvents": 2789243.0,
   "nSumOfWeights": 2789243.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016B-ver1_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016.json
@@ -80,5 +80,6 @@
   "nEvents": 158145722.0,
   "nGenEvents": 158145722.0,
   "nSumOfWeights": 158145722.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016.json
@@ -38,5 +38,6 @@
   "nEvents": 67441308.0,
   "nGenEvents": 67441308.0,
   "nSumOfWeights": 67441308.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016.json
@@ -47,5 +47,6 @@
   "nEvents": 98017996.0,
   "nGenEvents": 98017996.0,
   "nSumOfWeights": 98017996.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016.json
@@ -53,5 +53,6 @@
   "nEvents": 90984718.0,
   "nGenEvents": 90984718.0,
   "nSumOfWeights": 90984718.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016.json
@@ -40,5 +40,6 @@
   "nEvents": 57465359.0,
   "nGenEvents": 57465359.0,
   "nSumOfWeights": 57465359.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_F-UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_F-UL2016.json
@@ -15,5 +15,6 @@
   "nEvents": 8024195.0,
   "nGenEvents": 8024195.0,
   "nSumOfWeights": 8024195.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016F-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_G-UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_G-UL2016.json
@@ -80,5 +80,6 @@
   "nEvents": 149916849.0,
   "nGenEvents": 149916849.0,
   "nSumOfWeights": 149916849.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016G-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2016/SingleMuon_H-UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_H-UL2016.json
@@ -92,5 +92,6 @@
   "nEvents": 174035164.0,
   "nGenEvents": 174035164.0,
   "nSumOfWeights": 174035164.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2016H-UL2016_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleEG_B-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleEG_B-UL2017.json
@@ -39,5 +39,6 @@
   "nEvents": 58088760.0,
   "nGenEvents": 58088760.0,
   "nSumOfWeights": 58088760.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleEG_C-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleEG_C-UL2017.json
@@ -54,5 +54,6 @@
   "nEvents": 65181125.0,
   "nGenEvents": 65181125.0,
   "nSumOfWeights": 65181125.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleEG_D-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleEG_D-UL2017.json
@@ -24,5 +24,6 @@
   "nEvents": 25911432.0,
   "nGenEvents": 25911432.0,
   "nSumOfWeights": 25911432.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleEG_E-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleEG_E-UL2017.json
@@ -42,5 +42,6 @@
   "nEvents": 56241190.0,
   "nGenEvents": 56241190.0,
   "nSumOfWeights": 56241190.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleEG_F-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleEG_F-UL2017.json
@@ -64,5 +64,6 @@
   "nEvents": 74265012.0,
   "nGenEvents": 74265012.0,
   "nSumOfWeights": 74265012.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleEG/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleMuon_B-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleMuon_B-UL2017.json
@@ -18,5 +18,6 @@
   "nEvents": 14501767.0,
   "nGenEvents": 14501767.0,
   "nSumOfWeights": 14501767.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleMuon_C-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleMuon_C-UL2017.json
@@ -39,5 +39,6 @@
   "nEvents": 49636525.0,
   "nGenEvents": 49636525.0,
   "nSumOfWeights": 49636525.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleMuon_D-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleMuon_D-UL2017.json
@@ -26,5 +26,6 @@
   "nEvents": 23075733.0,
   "nGenEvents": 23075733.0,
   "nSumOfWeights": 23075733.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleMuon_E-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleMuon_E-UL2017.json
@@ -44,5 +44,6 @@
   "nEvents": 51531477.0,
   "nGenEvents": 51531477.0,
   "nSumOfWeights": 51531477.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/DoubleMuon_F-UL2017.json
+++ b/topcoffea/json/data_samples/2017/DoubleMuon_F-UL2017.json
@@ -70,5 +70,6 @@
   "nEvents": 79756560.0,
   "nGenEvents": 79756560.0,
   "nSumOfWeights": 79756560.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/MuonEG_B-UL2017.json
+++ b/topcoffea/json/data_samples/2017/MuonEG_B-UL2017.json
@@ -16,5 +16,6 @@
   "nEvents": 4453465.0,
   "nGenEvents": 4453465.0,
   "nSumOfWeights": 4453465.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/MuonEG_C-UL2017.json
+++ b/topcoffea/json/data_samples/2017/MuonEG_C-UL2017.json
@@ -27,5 +27,6 @@
   "nEvents": 15595214.0,
   "nGenEvents": 15595214.0,
   "nSumOfWeights": 15595214.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/MuonEG_D-UL2017.json
+++ b/topcoffea/json/data_samples/2017/MuonEG_D-UL2017.json
@@ -23,5 +23,6 @@
   "nEvents": 9164365.0,
   "nGenEvents": 9164365.0,
   "nSumOfWeights": 9164365.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/MuonEG_E-UL2017.json
+++ b/topcoffea/json/data_samples/2017/MuonEG_E-UL2017.json
@@ -25,5 +25,6 @@
   "nEvents": 19043421.0,
   "nGenEvents": 19043421.0,
   "nSumOfWeights": 19043421.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/MuonEG_F-UL2017.json
+++ b/topcoffea/json/data_samples/2017/MuonEG_F-UL2017.json
@@ -33,5 +33,6 @@
   "nEvents": 25776363.0,
   "nGenEvents": 25776363.0,
   "nSumOfWeights": 25776363.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleElectron_B-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleElectron_B-UL2017.json
@@ -42,5 +42,6 @@
   "nEvents": 60537490.0,
   "nGenEvents": 60537490.0,
   "nSumOfWeights": 60537490.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleElectron_C-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleElectron_C-UL2017.json
@@ -69,5 +69,6 @@
   "nEvents": 136637888.0,
   "nGenEvents": 136637888.0,
   "nSumOfWeights": 136637888.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleElectron_D-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleElectron_D-UL2017.json
@@ -47,5 +47,6 @@
   "nEvents": 51512837.0,
   "nGenEvents": 51512837.0,
   "nSumOfWeights": 51512837.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleElectron_E-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleElectron_E-UL2017.json
@@ -61,5 +61,6 @@
   "nEvents": 102122055.0,
   "nGenEvents": 102122055.0,
   "nSumOfWeights": 102122055.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleElectron_F-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleElectron_F-UL2017.json
@@ -76,5 +76,6 @@
   "nEvents": 128467223.0,
   "nGenEvents": 128467223.0,
   "nSumOfWeights": 128467223.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleElectron/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleMuon_B-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleMuon_B-UL2017.json
@@ -89,5 +89,6 @@
   "nEvents": 136300266.0,
   "nGenEvents": 136300266.0,
   "nSumOfWeights": 136300266.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleMuon_C-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleMuon_C-UL2017.json
@@ -127,5 +127,6 @@
   "nEvents": 165652756.0,
   "nGenEvents": 165652756.0,
   "nSumOfWeights": 165652756.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleMuon_D-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleMuon_D-UL2017.json
@@ -57,5 +57,6 @@
   "nEvents": 70361660.0,
   "nGenEvents": 70361660.0,
   "nSumOfWeights": 70361660.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleMuon_E-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleMuon_E-UL2017.json
@@ -88,5 +88,6 @@
   "nEvents": 154618774.0,
   "nGenEvents": 154618774.0,
   "nSumOfWeights": 154618774.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2017/SingleMuon_F-UL2017.json
+++ b/topcoffea/json/data_samples/2017/SingleMuon_F-UL2017.json
@@ -125,5 +125,6 @@
   "nEvents": 242140980.0,
   "nGenEvents": 242140980.0,
   "nSumOfWeights": 242140980.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/DoubleMuon_A-UL2018.json
+++ b/topcoffea/json/data_samples/2018/DoubleMuon_A-UL2018.json
@@ -64,5 +64,6 @@
   "nEvents": 75491789.0,
   "nGenEvents": 75491789.0,
   "nSumOfWeights": 75491789.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2018A-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/DoubleMuon_B-UL2018.json
+++ b/topcoffea/json/data_samples/2018/DoubleMuon_B-UL2018.json
@@ -30,5 +30,6 @@
   "nEvents": 35057758.0,
   "nGenEvents": 35057758.0,
   "nSumOfWeights": 35057758.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2018B-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/DoubleMuon_C-UL2018.json
+++ b/topcoffea/json/data_samples/2018/DoubleMuon_C-UL2018.json
@@ -35,5 +35,6 @@
   "nEvents": 34565869.0,
   "nGenEvents": 34565869.0,
   "nSumOfWeights": 34565869.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/DoubleMuon_D-UL2018.json
+++ b/topcoffea/json/data_samples/2018/DoubleMuon_D-UL2018.json
@@ -117,5 +117,6 @@
   "nEvents": 168600679.0,
   "nGenEvents": 168600679.0,
   "nSumOfWeights": 168600679.0,
-  "isData": true
+  "isData": true,
+  "path": "/DoubleMuon/Run2018D-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/EGamma_A-UL2018.json
+++ b/topcoffea/json/data_samples/2018/EGamma_A-UL2018.json
@@ -236,5 +236,6 @@
   "nEvents": 339013231.0,
   "nGenEvents": 339013231.0,
   "nSumOfWeights": 339013231.0,
-  "isData": true
+  "isData": true,
+  "path": "/EGamma/Run2018A-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/EGamma_B-UL2018.json
+++ b/topcoffea/json/data_samples/2018/EGamma_B-UL2018.json
@@ -84,5 +84,6 @@
   "nEvents": 153792795.0,
   "nGenEvents": 153792795.0,
   "nSumOfWeights": 153792795.0,
-  "isData": true
+  "isData": true,
+  "path": "/EGamma/Run2018B-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/EGamma_C-UL2018.json
+++ b/topcoffea/json/data_samples/2018/EGamma_C-UL2018.json
@@ -93,5 +93,6 @@
   "nEvents": 147827904.0,
   "nGenEvents": 147827904.0,
   "nSumOfWeights": 147827904.0,
-  "isData": true
+  "isData": true,
+  "path": "/EGamma/Run2018C-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/EGamma_D-UL2018.json
+++ b/topcoffea/json/data_samples/2018/EGamma_D-UL2018.json
@@ -365,5 +365,6 @@
   "nEvents": 752524583.0,
   "nGenEvents": 752524583.0,
   "nSumOfWeights": 752524583.0,
-  "isData": true
+  "isData": true,
+  "path": "/EGamma/Run2018D-UL2018_MiniAODv2_NanoAODv9-v3/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/MuonEG_A-UL2018.json
+++ b/topcoffea/json/data_samples/2018/MuonEG_A-UL2018.json
@@ -43,5 +43,6 @@
   "nEvents": 32958503.0,
   "nGenEvents": 32958503.0,
   "nSumOfWeights": 32958503.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2018A-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/MuonEG_B-UL2018.json
+++ b/topcoffea/json/data_samples/2018/MuonEG_B-UL2018.json
@@ -30,5 +30,6 @@
   "nEvents": 16211567.0,
   "nGenEvents": 16211567.0,
   "nSumOfWeights": 16211567.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2018B-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/MuonEG_C-UL2018.json
+++ b/topcoffea/json/data_samples/2018/MuonEG_C-UL2018.json
@@ -32,5 +32,6 @@
   "nEvents": 15652198.0,
   "nGenEvents": 15652198.0,
   "nSumOfWeights": 15652198.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2018C-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/MuonEG_D-UL2018.json
+++ b/topcoffea/json/data_samples/2018/MuonEG_D-UL2018.json
@@ -73,5 +73,6 @@
   "nEvents": 71952025.0,
   "nGenEvents": 71952025.0,
   "nSumOfWeights": 71952025.0,
-  "isData": true
+  "isData": true,
+  "path": "/MuonEG/Run2018D-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/SingleMuon_A-UL2018.json
+++ b/topcoffea/json/data_samples/2018/SingleMuon_A-UL2018.json
@@ -102,5 +102,6 @@
   "nEvents": 241608232.0,
   "nGenEvents": 241608232.0,
   "nSumOfWeights": 241608232.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2018A-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/SingleMuon_B-UL2018.json
+++ b/topcoffea/json/data_samples/2018/SingleMuon_B-UL2018.json
@@ -61,5 +61,6 @@
   "nEvents": 119918017.0,
   "nGenEvents": 119918017.0,
   "nSumOfWeights": 119918017.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2018B-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/SingleMuon_C-UL2018.json
+++ b/topcoffea/json/data_samples/2018/SingleMuon_C-UL2018.json
@@ -66,5 +66,6 @@
   "nEvents": 109986009.0,
   "nGenEvents": 109986009.0,
   "nSumOfWeights": 109986009.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD"
 }

--- a/topcoffea/json/data_samples/2018/SingleMuon_D-UL2018.json
+++ b/topcoffea/json/data_samples/2018/SingleMuon_D-UL2018.json
@@ -204,5 +204,6 @@
   "nEvents": 513909894.0,
   "nGenEvents": 513909894.0,
   "nSumOfWeights": 513909894.0,
-  "isData": true
+  "isData": true,
+  "path": "/SingleMuon/Run2018D-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD"
 }

--- a/topcoffea/modules/createJSON.py
+++ b/topcoffea/modules/createJSON.py
@@ -149,6 +149,7 @@ def main():
   sampdic['nGenEvents']    = nGenEvents
   sampdic['nSumOfWeights'] = nSumOfWeights
   sampdic['isData']        = isData
+  sampdic['path']          = path
 
   if outname == '':
     outname = sample


### PR DESCRIPTION
This PR introduces a new entry to the json making code called `path`. This entry is intended to indicate the location from which the root files were originally found.

This is mostly only relevant for the central samples and the unskimmed data, as those files are obtained via their DAS dataset names. The private samples would have their Hadoop '/store` path stored instead, which of course could already be inferred from the list of files in the json record to begin with.

The PR only updates the json files for the data samples. Since this is a pure addition to the repo, _not_ updating the other json files shouldn't pose any issues since nothing should depend on it yet and we can just make piecemeal updates as they become necessary or just naturally due to other future updates to the files.