### PR TITLE
Fix typos in key names

### DIFF
--- a/topcoffea/modules/objects.py
+++ b/topcoffea/modules/objects.py
@@ -27,8 +27,8 @@ def smoothBFlav(jetpt,ptmin,ptmax,year,scale_loose=1.0):
 
     # Get the btag wp for the year
     if ((year == "2016") or (year == "2016APV")):
-        wploose  = get_param("btag_wp_loose_L16")
-        wpmedium = get_param("btag_wp_medium_L16")
+        wploose  = get_param("btag_wp_loose_UL16")
+        wpmedium = get_param("btag_wp_medium_UL16")
     elif (year == "2017"):
         wploose  = get_param("btag_wp_loose_UL17")
         wpmedium = get_param("btag_wp_medium_UL17")
@@ -77,7 +77,7 @@ def isFOElec(conept, jetBTagDeepFlav, ttH_idEmu_cuts_E3, convVeto, lostHits, mva
 
     # Get the btag cut for the year
     if ((year == "2016") or (year == "2016APV")):
-        bTagCut = get_param("btag_wp_medium_L16")
+        bTagCut = get_param("btag_wp_medium_UL16")
     elif (year == "2017"):
         bTagCut = get_param("btag_wp_medium_UL17")
     elif (year == "2018"):
@@ -96,7 +96,7 @@ def isFOMuon(pt, conept, jetBTagDeepFlav, mvaTTH, jetRelIso, year):
 
     # Get the btag cut for the year
     if ((year == "2016") or (year == "2016APV")):
-        bTagCut = get_param("btag_wp_medium_L16")
+        bTagCut = get_param("btag_wp_medium_UL16")
     elif (year == "2017"):
         bTagCut = get_param("btag_wp_medium_UL17")
     elif (year == "2018"):


### PR DESCRIPTION
This PR fixes some typos in UL16 key names in the `objects.py` file that were noticed when testing with 2016 samples with the systematics turned on.