### PR TITLE
Add S_T hist binning info to datacard maker

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -34,7 +34,7 @@ class DatacardMaker():
         self.year = single_year
         self.do_sm = do_sm
         # Variables we have defined a binning for
-        self.known_var_lst = ['njets','ptbl','ht','ptz','o0pt','bl0pt','l0pt','lj0pt']
+        self.known_var_lst = ['njets','ptbl','ht','ptz','o0pt','bl0pt','l0pt','lj0pt','ljptsum']
 
     def read(self):
         '''
@@ -54,7 +54,9 @@ class DatacardMaker():
         if 'ptbl' in self.hists:
             self.analysis_bins['ptbl'] = [0, 100, 200, 400, self.hists['ptbl'].axis('ptbl').edges()[-1]]
         if 'ht' in self.hists:
-            self.analysis_bins['ht'] = [0, 100, 200, 300, 400, self.hists['ht'].axis('ht').edges()[-1]]
+            self.analysis_bins['ht'] = [0, 300, 500, 800, self.hists['ht'].axis('ht').edges()[-1]]
+        if 'ljptsum' in self.hists:
+            self.analysis_bins['ljptsum'] = [0, 400, 600, 1000, self.hists['ljptsum'].axis('ljptsum').edges()[-1]]
         if 'ptz' in self.hists:
             self.analysis_bins['ptz'] = [0, 80, 200, 320, 440, self.hists['ptz'].axis('ptz').edges()[-1]]
         if 'o0pt' in self.hists:


### PR DESCRIPTION
This PR just adds the binning info for the S_T histogram to the datacard maker. As discussed in Issue #172, this variable was found to provide comparable sensitivity to the other variables we've been considering, so it'd be good to have the datacard maker set up to easily produce data cards for this variable. (Note that the variable is called `ljptsum` in the code, since `st` is too hard to search.) 

Unrelatedly, this PR also adjusts the H_T binning to better match the shape of the H_T histogram (and to have 4 bins as the other histograms do). However, since H_T does not provide very good sensitivity, it will probably not be used anyway. 