### PR TITLE
Fix bug where add() modifies up/down weights

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -330,431 +330,431 @@ class AnalysisProcessor(processor.ProcessorABC):
                 pDataDo = ak.prod(bJetEff_dataDo[isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff_dataDo[isNotBtagJetsMedium]), axis=-1)           
                 pMC      = ak.where(pMC==0,1,pMC) # removeing zeroes from denominator...
           
-          # Trigger SF
-          GetTriggerSF(year,events,l0,l1)
+            # Trigger SF
+            GetTriggerSF(year,events,l0,l1)
 
-          # We need weights for: normalization, lepSF, triggerSF, pileup, btagSF...
-          weights_dict = {}
-          if (isData or (eft_coeffs is not None)):
-              genw = np.ones_like(events["event"])
-          else:
-              genw = events["genWeight"]
-          for ch_name in ["2l", "2l_4t", "3l", "4l", "2l_CR", "3l_CR", "2los_CRtt", "2los_CRZ"]:
-              weights_dict[ch_name] = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
-              weights_dict[ch_name].add("norm",genw if isData else (xsec/sow)*genw)
-              if not isData:
+            # We need weights for: normalization, lepSF, triggerSF, pileup, btagSF...
+            weights_dict = {}
+            if (isData or (eft_coeffs is not None)):
+                genw = np.ones_like(events["event"])
+            else:
+                genw = events["genWeight"]
+            for ch_name in ["2l", "2l_4t", "3l", "4l", "2l_CR", "3l_CR", "2los_CRtt", "2los_CRZ"]:
+                weights_dict[ch_name] = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
+                weights_dict[ch_name].add("norm",genw if isData else (xsec/sow)*genw)
+                if not isData:
 
-                  ######### Event weights ###########
+                    ######### Event weights ###########
 
-                  # Attach PS weights (ISR/FSR)
-                  AttachPSWeights(events)
-                  # Attach scale weights (renormalization/factorization)
-                  AttachScaleWeights(events)
-                  # Attach PDF weights
-                  #AttachPdfWeights(events) # FIXME use these!
+                    # Attach PS weights (ISR/FSR)
+                    AttachPSWeights(events)
+                    # Attach scale weights (renormalization/factorization)
+                    AttachScaleWeights(events)
+                    # Attach PDF weights
+                    #AttachPdfWeights(events) # FIXME use these!
 
-                  # We only calculate these values if not isData
-                  weights_dict[ch_name].add("btagSF", pData/pMC, copy.deepcopy(pDataUp/pMC), copy.deepcopy(pDataDo/pMC))
-                  weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'up')), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'down')))
-                  # Prefiring weights only available in nanoAODv9**
-                  weights_dict[ch_name].add('PreFiring', events.L1PreFiringWeight.Nom,  copy.deepcopy(events.L1PreFiringWeight.Up),  copy.deepcopy(events.L1PreFiringWeight.Dn))
-                  # FSR/ISR weights
-                  weights_dict[ch_name].add('ISR', events.ISRnom, copy.deepcopy(events.ISRUp), copy.deepcopy(events.ISRDown))
-                  weights_dict[ch_name].add('FSR', events.FSRnom, copy.deepcopy(events.FSRUp), copy.deepcopy(events.FSRDown))
-                  # renorm/fact scale
-                  weights_dict[ch_name].add('renorm',      events.nom, copy.deepcopy(events.renormUp),      copy.deepcopy(events.renormDown))
-                  weights_dict[ch_name].add('fact',        events.nom, copy.deepcopy(events.factUp),        copy.deepcopy(events.factDown))
-                  weights_dict[ch_name].add('renorm_fact', events.nom, copy.deepcopy(events.renorm_factUp), copy.deepcopy(events.renorm_factDown))
-                  # Trigger SF
-                  weights_dict[ch_name].add('triggerSF', events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))
+                    # We only calculate these values if not isData
+                    weights_dict[ch_name].add("btagSF", pData/pMC, copy.deepcopy(pDataUp/pMC), copy.deepcopy(pDataDo/pMC))
+                    weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'up')), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'down')))
+                    # Prefiring weights only available in nanoAODv9**
+                    weights_dict[ch_name].add('PreFiring', events.L1PreFiringWeight.Nom,  copy.deepcopy(events.L1PreFiringWeight.Up),  copy.deepcopy(events.L1PreFiringWeight.Dn))
+                    # FSR/ISR weights
+                    weights_dict[ch_name].add('ISR', events.ISRnom, copy.deepcopy(events.ISRUp), copy.deepcopy(events.ISRDown))
+                    weights_dict[ch_name].add('FSR', events.FSRnom, copy.deepcopy(events.FSRUp), copy.deepcopy(events.FSRDown))
+                    # renorm/fact scale
+                    weights_dict[ch_name].add('renorm',      events.nom, copy.deepcopy(events.renormUp),      copy.deepcopy(events.renormDown))
+                    weights_dict[ch_name].add('fact',        events.nom, copy.deepcopy(events.factUp),        copy.deepcopy(events.factDown))
+                    weights_dict[ch_name].add('renorm_fact', events.nom, copy.deepcopy(events.renorm_factUp), copy.deepcopy(events.renorm_factDown))
+                    # Trigger SF
+                    weights_dict[ch_name].add('triggerSF', events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))
 
-              if "2l" in ch_name:
-                  weights_dict[ch_name].add("lepSF", events.sf_2l,         copy.deepcopy(events.sf_2l_hi),         copy.deepcopy(events.sf_2l_lo))
-                  weights_dict[ch_name].add("FF"   , events.fakefactor_2l, copy.deepcopy(events.fakefactor_2l_up), copy.deepcopy(events.fakefactor_2l_down))
-              if "3l" in ch_name:
-                  weights_dict[ch_name].add("lepSF", events.sf_3l,         copy.deepcopy(events.sf_3l_hi),         copy.deepcopy(events.sf_3l_lo))
-                  weights_dict[ch_name].add("FF"   , events.fakefactor_3l, copy.deepcopy(events.fakefactor_3l_up), copy.deepcopy(events.fakefactor_3l_down))
-              if "4l" in ch_name:
-                  weights_dict[ch_name].add("lepSF", events.sf_4l, copy.deepcopy(events.sf_4l_hi), copy.deepcopy(events.sf_4l_lo))
+                if "2l" in ch_name:
+                    weights_dict[ch_name].add("lepSF", events.sf_2l,         copy.deepcopy(events.sf_2l_hi),         copy.deepcopy(events.sf_2l_lo))
+                    weights_dict[ch_name].add("FF"   , events.fakefactor_2l, copy.deepcopy(events.fakefactor_2l_up), copy.deepcopy(events.fakefactor_2l_down))
+                if "3l" in ch_name:
+                    weights_dict[ch_name].add("lepSF", events.sf_3l,         copy.deepcopy(events.sf_3l_hi),         copy.deepcopy(events.sf_3l_lo))
+                    weights_dict[ch_name].add("FF"   , events.fakefactor_3l, copy.deepcopy(events.fakefactor_3l_up), copy.deepcopy(events.fakefactor_3l_down))
+                if "4l" in ch_name:
+                    weights_dict[ch_name].add("lepSF", events.sf_4l, copy.deepcopy(events.sf_4l_hi), copy.deepcopy(events.sf_4l_lo))
 
-          if isData and "2l" in ch_name:
-              weights_dict[ch_name].add("fliprate"   , events.flipfactor_2l)
-              
-          # Systematics
-          systList = ["nominal"]
-          if (self._do_systematics and not isData and syst_var == "nominal"): systList = systList + ["lepSFUp","lepSFDown","btagSFUp", "btagSFDown","PUUp","PUDown","PreFiringUp","PreFiringDown","FSRUp","FSRDown","ISRUp","ISRDown","renormUp","renormDown","factUp","factDown","renorm_factUp","renorm_factDown","triggerSFUp","triggerSFDown"]
-          elif (self._do_systematics and not isData and syst_var != 'nominal'): systList = [syst_var]
+            if isData and "2l" in ch_name:
+                weights_dict[ch_name].add("fliprate"   , events.flipfactor_2l)
+                
+            # Systematics
+            systList = ["nominal"]
+            if (self._do_systematics and not isData and syst_var == "nominal"): systList = systList + ["lepSFUp","lepSFDown","btagSFUp", "btagSFDown","PUUp","PUDown","PreFiringUp","PreFiringDown","FSRUp","FSRDown","ISRUp","ISRDown","renormUp","renormDown","factUp","factDown","renorm_factUp","renorm_factDown","triggerSFUp","triggerSFDown"]
+            elif (self._do_systematics and not isData and syst_var != 'nominal'): systList = [syst_var]
 
-          ######### Masks we need for the selection ##########
+            ######### Masks we need for the selection ##########
 
-          # Get mask for events that have two sf os leps close to z peak
-          sfosz_3l_mask = get_Z_peak_mask(l_fo_conept_sorted_padded[:,0:3],pt_window=10.0)
-          sfosz_2l_mask = get_Z_peak_mask(l_fo_conept_sorted_padded[:,0:2],pt_window=10.0)
+            # Get mask for events that have two sf os leps close to z peak
+            sfosz_3l_mask = get_Z_peak_mask(l_fo_conept_sorted_padded[:,0:3],pt_window=10.0)
+            sfosz_2l_mask = get_Z_peak_mask(l_fo_conept_sorted_padded[:,0:2],pt_window=10.0)
 
-          # Pass trigger mask
-          pass_trg = trgPassNoOverlap(events,isData,dataset,str(year))
+            # Pass trigger mask
+            pass_trg = trgPassNoOverlap(events,isData,dataset,str(year))
 
-          # b jet masks
-          bmask_atleast1med_atleast2loose = ((nbtagsm>=1)&(nbtagsl>=2)) # Used for 2lss and 4l
-          bmask_exactly0med = (nbtagsm==0) # Used for 3l CR and 2los Z CR
-          bmask_exactly1med = (nbtagsm==1) # Used for 3l SR and 2lss CR
-          bmask_exactly2med = (nbtagsm==2) # Used for CRtt
-          bmask_atleast2med = (nbtagsm>=2) # Used for 3l SR
-          bmask_atmost3med = (nbtagsm < 3)  # Used to make 2lss mutually exclusive from tttt enriched
-          bmask_atleast3med = (nbtagsm>=3) # Used for tttt enriched
+            # b jet masks
+            bmask_atleast1med_atleast2loose = ((nbtagsm>=1)&(nbtagsl>=2)) # Used for 2lss and 4l
+            bmask_exactly0med = (nbtagsm==0) # Used for 3l CR and 2los Z CR
+            bmask_exactly1med = (nbtagsm==1) # Used for 3l SR and 2lss CR
+            bmask_exactly2med = (nbtagsm==2) # Used for CRtt
+            bmask_atleast2med = (nbtagsm>=2) # Used for 3l SR
+            bmask_atmost3med = (nbtagsm < 3)  # Used to make 2lss mutually exclusive from tttt enriched
+            bmask_atleast3med = (nbtagsm>=3) # Used for tttt enriched
 
-          # Charge masks
-          chargel0_p = ak.fill_none(((l0.charge)>0),False)
-          chargel0_m = ak.fill_none(((l0.charge)<0),False)
-          charge2l_0 = ak.fill_none(((l0.charge+l1.charge)==0),False)
-          charge2l_1 = ak.fill_none(((l0.charge+l1.charge)!=0),False)
-          charge3l_p = ak.fill_none(((l0.charge+l1.charge+l2.charge)>0),False)
-          charge3l_m = ak.fill_none(((l0.charge+l1.charge+l2.charge)<0),False)
+            # Charge masks
+            chargel0_p = ak.fill_none(((l0.charge)>0),False)
+            chargel0_m = ak.fill_none(((l0.charge)<0),False)
+            charge2l_0 = ak.fill_none(((l0.charge+l1.charge)==0),False)
+            charge2l_1 = ak.fill_none(((l0.charge+l1.charge)!=0),False)
+            charge3l_p = ak.fill_none(((l0.charge+l1.charge+l2.charge)>0),False)
+            charge3l_m = ak.fill_none(((l0.charge+l1.charge+l2.charge)<0),False)
 
 
-          ######### Store boolean masks with PackedSelection ##########
+            ######### Store boolean masks with PackedSelection ##########
 
-          selections = PackedSelection(dtype='uint64')
+            selections = PackedSelection(dtype='uint64')
 
-          # Lumi mask (for data)
-          selections.add("is_good_lumi",lumi_mask)
+            # Lumi mask (for data)
+            selections.add("is_good_lumi",lumi_mask)
 
-          # 2lss selection (drained of 4 top)
-          selections.add("2lss_p", (events.is2l & chargel0_p & bmask_atleast1med_atleast2loose & pass_trg & bmask_atmost3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
-          selections.add("2lss_m", (events.is2l & chargel0_m & bmask_atleast1med_atleast2loose & pass_trg & bmask_atmost3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
+            # 2lss selection (drained of 4 top)
+            selections.add("2lss_p", (events.is2l & chargel0_p & bmask_atleast1med_atleast2loose & pass_trg & bmask_atmost3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
+            selections.add("2lss_m", (events.is2l & chargel0_m & bmask_atleast1med_atleast2loose & pass_trg & bmask_atmost3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
 
-          # 2lss selection (enriched in 4 top)
-          selections.add("2lss_4t_p", (events.is2l & chargel0_p & bmask_atleast1med_atleast2loose & pass_trg & bmask_atleast3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
-          selections.add("2lss_4t_m", (events.is2l & chargel0_m & bmask_atleast1med_atleast2loose & pass_trg & bmask_atleast3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
+            # 2lss selection (enriched in 4 top)
+            selections.add("2lss_4t_p", (events.is2l & chargel0_p & bmask_atleast1med_atleast2loose & pass_trg & bmask_atleast3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
+            selections.add("2lss_4t_m", (events.is2l & chargel0_m & bmask_atleast1med_atleast2loose & pass_trg & bmask_atleast3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
 		
-          # 2lss selection for CR
-          selections.add("2lss_CR", (events.is2l & (chargel0_p| chargel0_m) & bmask_exactly1med & pass_trg)) # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
+            # 2lss selection for CR
+            selections.add("2lss_CR", (events.is2l & (chargel0_p| chargel0_m) & bmask_exactly1med & pass_trg)) # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
 
-          # 2los selection
-          selections.add("2los_CRtt", (events.is2l & charge2l_0 & bmask_exactly2med & pass_trg))
-          selections.add("2los_CRZ", (events.is2l & charge2l_0 & sfosz_2l_mask & bmask_exactly0med & pass_trg))
+            # 2los selection
+            selections.add("2los_CRtt", (events.is2l & charge2l_0 & bmask_exactly2med & pass_trg))
+            selections.add("2los_CRZ", (events.is2l & charge2l_0 & sfosz_2l_mask & bmask_exactly0med & pass_trg))
 
-          # 3l selection
-          selections.add("3l_p_offZ_1b", (events.is3l & charge3l_p & ~sfosz_3l_mask & bmask_exactly1med & pass_trg))
-          selections.add("3l_m_offZ_1b", (events.is3l & charge3l_m & ~sfosz_3l_mask & bmask_exactly1med & pass_trg))
-          selections.add("3l_p_offZ_2b", (events.is3l & charge3l_p & ~sfosz_3l_mask & bmask_atleast2med & pass_trg))
-          selections.add("3l_m_offZ_2b", (events.is3l & charge3l_m & ~sfosz_3l_mask & bmask_atleast2med & pass_trg))
-          selections.add("3l_onZ_1b", (events.is3l & sfosz_3l_mask & bmask_exactly1med & pass_trg))
-          selections.add("3l_onZ_2b", (events.is3l & sfosz_3l_mask & bmask_atleast2med & pass_trg))
-          selections.add("3l_CR", (events.is3l & bmask_exactly0med & pass_trg))
+            # 3l selection
+            selections.add("3l_p_offZ_1b", (events.is3l & charge3l_p & ~sfosz_3l_mask & bmask_exactly1med & pass_trg))
+            selections.add("3l_m_offZ_1b", (events.is3l & charge3l_m & ~sfosz_3l_mask & bmask_exactly1med & pass_trg))
+            selections.add("3l_p_offZ_2b", (events.is3l & charge3l_p & ~sfosz_3l_mask & bmask_atleast2med & pass_trg))
+            selections.add("3l_m_offZ_2b", (events.is3l & charge3l_m & ~sfosz_3l_mask & bmask_atleast2med & pass_trg))
+            selections.add("3l_onZ_1b", (events.is3l & sfosz_3l_mask & bmask_exactly1med & pass_trg))
+            selections.add("3l_onZ_2b", (events.is3l & sfosz_3l_mask & bmask_atleast2med & pass_trg))
+            selections.add("3l_CR", (events.is3l & bmask_exactly0med & pass_trg))
 
-          # 4l selection
-          selections.add("4l", (events.is4l & bmask_atleast1med_atleast2loose & pass_trg))
+            # 4l selection
+            selections.add("4l", (events.is4l & bmask_atleast1med_atleast2loose & pass_trg))
 
-          # Lep flavor selection
-          selections.add("ee",  events.is_ee)
-          selections.add("em",  events.is_em)
-          selections.add("mm",  events.is_mm)
-          selections.add("eee", events.is_eee)
-          selections.add("eem", events.is_eem)
-          selections.add("emm", events.is_emm)
-          selections.add("mmm", events.is_mmm)
-          selections.add("llll", (events.is_eeee | events.is_eeem | events.is_eemm | events.is_emmm | events.is_mmmm | events.is_gr4l)) # Not keepting track of these separately
+            # Lep flavor selection
+            selections.add("ee",  events.is_ee)
+            selections.add("em",  events.is_em)
+            selections.add("mm",  events.is_mm)
+            selections.add("eee", events.is_eee)
+            selections.add("eem", events.is_eem)
+            selections.add("emm", events.is_emm)
+            selections.add("mmm", events.is_mmm)
+            selections.add("llll", (events.is_eeee | events.is_eeem | events.is_eemm | events.is_emmm | events.is_mmmm | events.is_gr4l)) # Not keepting track of these separately
 
-          # Njets selection
-          selections.add("exactly_1j", (njets==1))
-          selections.add("exactly_2j", (njets==2))
-          selections.add("exactly_3j", (njets==3))
-          selections.add("exactly_4j", (njets==4))
-          selections.add("exactly_5j", (njets==5))
-          selections.add("exactly_6j", (njets==6))
-          selections.add("atleast_1j", (njets>=1))
-          selections.add("atleast_4j", (njets>=4))
-          selections.add("atleast_5j", (njets>=5))
-          selections.add("atleast_7j", (njets>=7))
-          selections.add("atleast_0j", (njets>=0))
+            # Njets selection
+            selections.add("exactly_1j", (njets==1))
+            selections.add("exactly_2j", (njets==2))
+            selections.add("exactly_3j", (njets==3))
+            selections.add("exactly_4j", (njets==4))
+            selections.add("exactly_5j", (njets==5))
+            selections.add("exactly_6j", (njets==6))
+            selections.add("atleast_1j", (njets>=1))
+            selections.add("atleast_4j", (njets>=4))
+            selections.add("atleast_5j", (njets>=5))
+            selections.add("atleast_7j", (njets>=7))
+            selections.add("atleast_0j", (njets>=0))
 
-          # AR/SR categories
-          selections.add("isSR_2lSS", ( events.is2l_SR) & charge2l_1) 
-          selections.add("isAR_2lSS", (~events.is2l_SR) & charge2l_1) 
-          selections.add("isAR_2lSS_OS", ( events.is2l_SR) & charge2l_0) # we need another naming for the sideband for the charge flip
-          selections.add("isSR_2lOS", ( events.is2l_SR) & charge2l_0) 
-          selections.add("isAR_2lOS", (~events.is2l_SR) & charge2l_0) 
+            # AR/SR categories
+            selections.add("isSR_2lSS", ( events.is2l_SR) & charge2l_1) 
+            selections.add("isAR_2lSS", (~events.is2l_SR) & charge2l_1) 
+            selections.add("isAR_2lSS_OS", ( events.is2l_SR) & charge2l_0) # we need another naming for the sideband for the charge flip
+            selections.add("isSR_2lOS", ( events.is2l_SR) & charge2l_0) 
+            selections.add("isAR_2lOS", (~events.is2l_SR) & charge2l_0) 
 
-          selections.add("isSR_3l",  events.is3l_SR)
-          selections.add("isAR_3l", ~events.is3l_SR)
-          selections.add("isSR_4l",  events.is4l_SR)
-
-
-          ######### Variables for the dense axes of the hists ##########
-
-          # Calculate ptbl
-          ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
-          ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt,axis=-1,keepdims=True)] # Only save hardest b-jet
-          ptbl_lep = l_fo_conept_sorted
-          ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
-          ptbl = ak.values_astype(ak.fill_none(ptbl, -1), np.float32)
-
-          # Z pt (pt of the ll pair that form the Z for the onZ categories)
-          ptz = get_Z_pt(l_fo_conept_sorted_padded[:,0:3],10.0)
-
-          # Leading (b+l) pair pt
-          bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
-          bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted})
-          blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
-          bl0pt = ak.flatten(blpt[ak.argmax(blpt,axis=-1,keepdims=True)])
-
-          # Collection of all objects (leptons and jets)
-          l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets], axis=1),"PtEtaPhiMCollection")
-
-          # Leading object (j or l) pt
-          o0pt = ak.max(l_j_collection.pt,axis=-1)
-
-          # Pairs of l+j
-          l_j_pairs = ak.combinations(l_j_collection,2,fields=["o0","o1"])
-          l_j_pairs_pt = (l_j_pairs.o0 + l_j_pairs.o1).pt
-          l_j_pairs_mass = (l_j_pairs.o0 + l_j_pairs.o1).mass
-          lj0pt = ak.max(l_j_pairs_pt,axis=-1)
-
-          # Define invariant mass hists
-          mll_0_1 = (l0+l1).mass # Invmass for leading two leps
-
-          # ST (but "st" is too hard to search in the code, so call it ljptsum)
-          ljptsum = ak.sum(l_j_collection.pt,axis=-1)
-          if self._ecut_threshold is not None:
-              ecut_mask = (ljptsum<self._ecut_threshold)
-
-          # Counts
-          counts = np.ones_like(events['event'])
-
-          # Variables we will loop over when filling hists
-          varnames = {}
-          varnames["ht"]      = ht
-          varnames["met"]     = met.pt
-          varnames["ljptsum"] = ljptsum
-          varnames["l0pt"]    = l0.conept
-          varnames["l0eta"]   = l0.eta
-          varnames["j0pt"]    = ak.flatten(j0.pt)
-          varnames["j0eta"]   = ak.flatten(j0.eta)
-          varnames["njets"]   = njets
-          varnames["nbtagsl"] = nbtagsl
-          varnames["invmass"] = mll_0_1
-          varnames["ptbl"]    = ak.flatten(ptbl)
-          varnames["ptz"]     = ptz
-          varnames["b0pt"]    = ak.flatten(ptbl_bjet.pt)
-          varnames["bl0pt"]   = bl0pt
-          varnames["o0pt"]    = o0pt
-          varnames["lj0pt"]   = lj0pt
+            selections.add("isSR_3l",  events.is3l_SR)
+            selections.add("isAR_3l", ~events.is3l_SR)
+            selections.add("isSR_4l",  events.is4l_SR)
 
 
-          ########## Fill the histograms ##########
+            ######### Variables for the dense axes of the hists ##########
 
-          # This dictionary keeps track of which selections go with which SR categories
-          sr_cat_dict = {
-            "2l" : {
-                "exactly_4j" : {
-                    "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                    "lep_flav_lst" : ["ee" , "em" , "mm"],
-                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                },
-                "exactly_5j" : {
-                    "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                    "lep_flav_lst" : ["ee" , "em" , "mm"],
-                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                },
-                "exactly_6j" : {
-                    "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                    "lep_flav_lst" : ["ee" , "em" , "mm"],
-                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                },
-                "atleast_7j" : {
-                    "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                    "lep_flav_lst" : ["ee" , "em" , "mm"],
-                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                },
-            },
-            "3l" : {
-                "exactly_2j" : {
-                    "lep_chan_lst" : [
-                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                    ],
-                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                },
-                "exactly_3j" : {
-                    "lep_chan_lst" : [
-                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                    ],
-                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                },
-                "exactly_4j" : {
-                    "lep_chan_lst" : [
-                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                    ],
-                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                },
-                "atleast_5j" : {
-                    "lep_chan_lst" : [
-                        "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                    ],
-                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                    "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                },
-            },
-            "4l" : {
-                    "exactly_2j" : {
-                        "lep_chan_lst" : ["4l"],
-                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                        "appl_lst"     : ["isSR_4l"],
-                    },
-                    "exactly_3j" : {
-                        "lep_chan_lst" : ["4l"],
-                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                        "appl_lst"     : ["isSR_4l"],
-                    },
-                    "atleast_4j" : {
-                        "lep_chan_lst" : ["4l"],
-                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                        "appl_lst"     : ["isSR_4l"],
-                    },
-            },
-          }
+            # Calculate ptbl
+            ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
+            ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt,axis=-1,keepdims=True)] # Only save hardest b-jet
+            ptbl_lep = l_fo_conept_sorted
+            ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
+            ptbl = ak.values_astype(ak.fill_none(ptbl, -1), np.float32)
 
-          # This dictionary keeps track of which selections go with which CR categories
-          cr_cat_dict = {
-            "2l_CR" : {
-                "exactly_1j" : {
-                    "lep_chan_lst" : ["2lss_CR"],
-                    "lep_flav_lst" : ["ee" , "em" , "mm"],
-                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                },
-                "exactly_2j" : {
-                    "lep_chan_lst" : ["2lss_CR"],
-                    "lep_flav_lst" : ["ee" , "em" , "mm"],
-                    "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                },
-            },
-            "3l_CR" : {
-                "atleast_1j" : {
-                    "lep_chan_lst" : ["3l_CR"],
-                    "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                    "appl_lst"     : ["isSR_3l" , "isAR_3l"],
-                },
-            },
-            "2los_CRtt" : {
-                "exactly_2j"   : {
-                    "lep_chan_lst" : ["2los_CRtt"],
-                    "lep_flav_lst" : ["em"],
-                    "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
-                },
-            },
-            "2los_CRZ" : {
-                "atleast_0j"   : {
-                    "lep_chan_lst" : ["2los_CRZ"],
-                    "lep_flav_lst" : ["ee", "mm"],
-                    "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
-                },
-            },
-          }
+            # Z pt (pt of the ll pair that form the Z for the onZ categories)
+            ptz = get_Z_pt(l_fo_conept_sorted_padded[:,0:3],10.0)
 
-          # Include SRs and CRs unless we asked to skip them
-          cat_dict = {}
-          if not self._skip_signal_regions:
-            cat_dict.update(sr_cat_dict)
-          if not self._skip_control_regions:
-            cat_dict.update(cr_cat_dict)
-          if (not self._skip_signal_regions and not self._skip_control_regions):
-            for k in sr_cat_dict:
-                if k in cr_cat_dict:
-                    raise Exception(f"The key {k} is in both CR and SR dictionaries.")
+            # Leading (b+l) pair pt
+            bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
+            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted})
+            blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
+            bl0pt = ak.flatten(blpt[ak.argmax(blpt,axis=-1,keepdims=True)])
+
+            # Collection of all objects (leptons and jets)
+            l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets], axis=1),"PtEtaPhiMCollection")
+
+            # Leading object (j or l) pt
+            o0pt = ak.max(l_j_collection.pt,axis=-1)
+
+            # Pairs of l+j
+            l_j_pairs = ak.combinations(l_j_collection,2,fields=["o0","o1"])
+            l_j_pairs_pt = (l_j_pairs.o0 + l_j_pairs.o1).pt
+            l_j_pairs_mass = (l_j_pairs.o0 + l_j_pairs.o1).mass
+            lj0pt = ak.max(l_j_pairs_pt,axis=-1)
+
+            # Define invariant mass hists
+            mll_0_1 = (l0+l1).mass # Invmass for leading two leps
+
+            # ST (but "st" is too hard to search in the code, so call it ljptsum)
+            ljptsum = ak.sum(l_j_collection.pt,axis=-1)
+            if self._ecut_threshold is not None:
+                ecut_mask = (ljptsum<self._ecut_threshold)
+
+            # Counts
+            counts = np.ones_like(events['event'])
+
+            # Variables we will loop over when filling hists
+            varnames = {}
+            varnames["ht"]      = ht
+            varnames["met"]     = met.pt
+            varnames["ljptsum"] = ljptsum
+            varnames["l0pt"]    = l0.conept
+            varnames["l0eta"]   = l0.eta
+            varnames["j0pt"]    = ak.flatten(j0.pt)
+            varnames["j0eta"]   = ak.flatten(j0.eta)
+            varnames["njets"]   = njets
+            varnames["nbtagsl"] = nbtagsl
+            varnames["invmass"] = mll_0_1
+            varnames["ptbl"]    = ak.flatten(ptbl)
+            varnames["ptz"]     = ptz
+            varnames["b0pt"]    = ak.flatten(ptbl_bjet.pt)
+            varnames["bl0pt"]   = bl0pt
+            varnames["o0pt"]    = o0pt
+            varnames["lj0pt"]   = lj0pt
 
 
+            ########## Fill the histograms ##########
+
+            # This dictionary keeps track of which selections go with which SR categories
+            sr_cat_dict = {
+              "2l" : {
+                  "exactly_4j" : {
+                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                      "lep_flav_lst" : ["ee" , "em" , "mm"],
+                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                  },
+                  "exactly_5j" : {
+                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                      "lep_flav_lst" : ["ee" , "em" , "mm"],
+                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                  },
+                  "exactly_6j" : {
+                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                      "lep_flav_lst" : ["ee" , "em" , "mm"],
+                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                  },
+                  "atleast_7j" : {
+                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                      "lep_flav_lst" : ["ee" , "em" , "mm"],
+                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                  },
+              },
+              "3l" : {
+                  "exactly_2j" : {
+                      "lep_chan_lst" : [
+                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                      ],
+                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                  },
+                  "exactly_3j" : {
+                      "lep_chan_lst" : [
+                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                      ],
+                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                  },
+                  "exactly_4j" : {
+                      "lep_chan_lst" : [
+                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                      ],
+                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                  },
+                  "atleast_5j" : {
+                      "lep_chan_lst" : [
+                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                      ],
+                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                  },
+              },
+              "4l" : {
+                      "exactly_2j" : {
+                          "lep_chan_lst" : ["4l"],
+                          "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                          "appl_lst"     : ["isSR_4l"],
+                      },
+                      "exactly_3j" : {
+                          "lep_chan_lst" : ["4l"],
+                          "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                          "appl_lst"     : ["isSR_4l"],
+                      },
+                      "atleast_4j" : {
+                          "lep_chan_lst" : ["4l"],
+                          "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                          "appl_lst"     : ["isSR_4l"],
+                      },
+              },
+            }
+
+            # This dictionary keeps track of which selections go with which CR categories
+            cr_cat_dict = {
+              "2l_CR" : {
+                  "exactly_1j" : {
+                      "lep_chan_lst" : ["2lss_CR"],
+                      "lep_flav_lst" : ["ee" , "em" , "mm"],
+                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                  },
+                  "exactly_2j" : {
+                      "lep_chan_lst" : ["2lss_CR"],
+                      "lep_flav_lst" : ["ee" , "em" , "mm"],
+                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                  },
+              },
+              "3l_CR" : {
+                  "atleast_1j" : {
+                      "lep_chan_lst" : ["3l_CR"],
+                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                      "appl_lst"     : ["isSR_3l" , "isAR_3l"],
+                  },
+              },
+              "2los_CRtt" : {
+                  "exactly_2j"   : {
+                      "lep_chan_lst" : ["2los_CRtt"],
+                      "lep_flav_lst" : ["em"],
+                      "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                  },
+              },
+              "2los_CRZ" : {
+                  "atleast_0j"   : {
+                      "lep_chan_lst" : ["2los_CRZ"],
+                      "lep_flav_lst" : ["ee", "mm"],
+                      "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                  },
+              },
+            }
+
+            # Include SRs and CRs unless we asked to skip them
+            cat_dict = {}
+            if not self._skip_signal_regions:
+              cat_dict.update(sr_cat_dict)
+            if not self._skip_control_regions:
+              cat_dict.update(cr_cat_dict)
+            if (not self._skip_signal_regions and not self._skip_control_regions):
+              for k in sr_cat_dict:
+                  if k in cr_cat_dict:
+                      raise Exception(f"The key {k} is in both CR and SR dictionaries.")
 
 
-          # Loop over the hists we want to fill
-          for dense_axis_name, dense_axis_vals in varnames.items():
-            if dense_axis_name not in self._hist_lst:
-                print(f"Skipping \"{dense_axis_name}\", it is not in the list of hists to include.")
-                continue
 
-            # Loop over the systematics
-            for syst in systList:
-                # In the case of "nominal", or the jet energy systematics, no weight systematic variation is used (weight_fluct=None)
-                weight_fluct = syst
-                if syst in ["nominal","JERUp","JERDown","JESUp","JESDown","MuonESUp","MuonESDown"]: weight_fluct = None # No weight systematic for these variations
 
-                # Loop over nlep categories "2l", "3l", "4l"
-                for nlep_cat in cat_dict.keys():
+            # Loop over the hists we want to fill
+            for dense_axis_name, dense_axis_vals in varnames.items():
+              if dense_axis_name not in self._hist_lst:
+                  print(f"Skipping \"{dense_axis_name}\", it is not in the list of hists to include.")
+                  continue
 
-                    # Get the appropriate Weights object for the nlep cat and get the weight to be used when filling the hist
-                    weights_object = weights_dict[nlep_cat]
-                    if isData : weight = weights_object.partial_weight(include=["FF"] + (["fliprate"] if nlep_cat in ["2l","2l_4t", "2l_CR"] else [])) # for data, must include the FF. The flip rate we only apply to 2lss regions
-                    else      : weight = weights_object.weight(weight_fluct) # For MC
+              # Loop over the systematics
+              for syst in systList:
+                  # In the case of "nominal", or the jet energy systematics, no weight systematic variation is used (weight_fluct=None)
+                  weight_fluct = syst
+                  if syst in ["nominal","JERUp","JERDown","JESUp","JESDown","MuonESUp","MuonESDown"]: weight_fluct = None # No weight systematic for these variations
 
-                    # Get a mask for events that pass any of the njet requiremens in this nlep cat
-                    # Useful in cases like njets hist where we don't store njets in a sparse axis
-                    njets_any_mask = selections.any(*cat_dict[nlep_cat].keys())
+                  # Loop over nlep categories "2l", "3l", "4l"
+                  for nlep_cat in cat_dict.keys():
 
-                    # Loop over the njets list for each channel
-                    for njet_val in cat_dict[nlep_cat].keys():
+                      # Get the appropriate Weights object for the nlep cat and get the weight to be used when filling the hist
+                      weights_object = weights_dict[nlep_cat]
+                      if isData : weight = weights_object.partial_weight(include=["FF"] + (["fliprate"] if nlep_cat in ["2l","2l_4t", "2l_CR"] else [])) # for data, must include the FF. The flip rate we only apply to 2lss regions
+                      else      : weight = weights_object.weight(weight_fluct) # For MC
 
-                        # Loop over the appropriate AR and SR for this channel
-                        for appl in cat_dict[nlep_cat][njet_val]["appl_lst"]:
+                      # Get a mask for events that pass any of the njet requiremens in this nlep cat
+                      # Useful in cases like njets hist where we don't store njets in a sparse axis
+                      njets_any_mask = selections.any(*cat_dict[nlep_cat].keys())
 
-                            # Loop over the channels in each nlep cat (e.g. "3l_m_offZ_1b")
-                            for lep_chan in cat_dict[nlep_cat][njet_val]["lep_chan_lst"]:
+                      # Loop over the njets list for each channel
+                      for njet_val in cat_dict[nlep_cat].keys():
 
-                                # Loop over the lep flavor list for each channel
-                                for lep_flav in cat_dict[nlep_cat][njet_val]["lep_flav_lst"]:
+                          # Loop over the appropriate AR and SR for this channel
+                          for appl in cat_dict[nlep_cat][njet_val]["appl_lst"]:
 
-                                    # Construct the hist name
-                                    flav_ch = None
-                                    njet_ch = None
-                                    cuts_lst = [appl,lep_chan]
-                                    if isData:
-                                        cuts_lst.append("is_good_lumi")
-                                    if self._split_by_lepton_flavor:
-                                        flav_ch = lep_flav
-                                        cuts_lst.append(lep_flav)
-                                    if dense_axis_name != "njets":
-                                        njet_ch = njet_val
-                                        cuts_lst.append(njet_val)
-                                    ch_name = construct_cat_name(lep_chan,njet_str=njet_ch,flav_str=flav_ch)
+                              # Loop over the channels in each nlep cat (e.g. "3l_m_offZ_1b")
+                              for lep_chan in cat_dict[nlep_cat][njet_val]["lep_chan_lst"]:
 
-                                    # Get the cuts mask for all selections
-                                    if dense_axis_name == "njets":
-                                        all_cuts_mask = (selections.all(*cuts_lst) & njets_any_mask)
-                                    else:
-                                        all_cuts_mask = selections.all(*cuts_lst)
+                                  # Loop over the lep flavor list for each channel
+                                  for lep_flav in cat_dict[nlep_cat][njet_val]["lep_flav_lst"]:
 
-                                    # Apply the optional cut on energy of the event
-                                    if self._ecut_threshold is not None:
-                                        all_cuts_mask = (all_cuts_mask & ecut_mask)
+                                      # Construct the hist name
+                                      flav_ch = None
+                                      njet_ch = None
+                                      cuts_lst = [appl,lep_chan]
+                                      if isData:
+                                          cuts_lst.append("is_good_lumi")
+                                      if self._split_by_lepton_flavor:
+                                          flav_ch = lep_flav
+                                          cuts_lst.append(lep_flav)
+                                      if dense_axis_name != "njets":
+                                          njet_ch = njet_val
+                                          cuts_lst.append(njet_val)
+                                      ch_name = construct_cat_name(lep_chan,njet_str=njet_ch,flav_str=flav_ch)
 
-                                    # Weights and eft coeffs
-                                    weights_flat = weight[all_cuts_mask]
-                                    eft_coeffs_cut = eft_coeffs[all_cuts_mask] if eft_coeffs is not None else None
-                                    eft_w2_coeffs_cut = eft_w2_coeffs[all_cuts_mask] if eft_w2_coeffs is not None else None
+                                      # Get the cuts mask for all selections
+                                      if dense_axis_name == "njets":
+                                          all_cuts_mask = (selections.all(*cuts_lst) & njets_any_mask)
+                                      else:
+                                          all_cuts_mask = selections.all(*cuts_lst)
 
-                                    # Fill the histos
-                                    axes_fill_info_dict = {
-                                        dense_axis_name : dense_axis_vals[all_cuts_mask],
-                                        "channel"       : ch_name,
-                                        "appl"          : appl,
-                                        "sample"        : histAxisName,
-                                        "systematic"    : syst,
-                                        "weight"        : weights_flat,
-                                        "eft_coeff"     : eft_coeffs_cut,
-                                        "eft_err_coeff" : eft_w2_coeffs_cut,
-                                    }
+                                      # Apply the optional cut on energy of the event
+                                      if self._ecut_threshold is not None:
+                                          all_cuts_mask = (all_cuts_mask & ecut_mask)
 
-                                    if (("j0" in dense_axis_name) & ("CRZ" in ch_name)): continue
-                                    if (("ptz" in dense_axis_name) & ("onZ" not in lep_chan)): continue
-                                    if ((dense_axis_name in ["o0pt","b0pt","bl0pt","lj0pt"]) & ("CR" in ch_name)): continue
-                                    hout[dense_axis_name].fill(**axes_fill_info_dict)
+                                      # Weights and eft coeffs
+                                      weights_flat = weight[all_cuts_mask]
+                                      eft_coeffs_cut = eft_coeffs[all_cuts_mask] if eft_coeffs is not None else None
+                                      eft_w2_coeffs_cut = eft_w2_coeffs[all_cuts_mask] if eft_w2_coeffs is not None else None
 
-                                    # Do not loop over lep flavors if not self._split_by_lepton_flavor, it's a waste of time and also we'd fill the hists too many times
-                                    if not self._split_by_lepton_flavor: break
+                                      # Fill the histos
+                                      axes_fill_info_dict = {
+                                          dense_axis_name : dense_axis_vals[all_cuts_mask],
+                                          "channel"       : ch_name,
+                                          "appl"          : appl,
+                                          "sample"        : histAxisName,
+                                          "systematic"    : syst,
+                                          "weight"        : weights_flat,
+                                          "eft_coeff"     : eft_coeffs_cut,
+                                          "eft_err_coeff" : eft_w2_coeffs_cut,
+                                      }
 
-                        # Do not loop over njets if hist is njets (otherwise we'd fill the hist too many times)
-                        if dense_axis_name == "njets": break
+                                      if (("j0" in dense_axis_name) & ("CRZ" in ch_name)): continue
+                                      if (("ptz" in dense_axis_name) & ("onZ" not in lep_chan)): continue
+                                      if ((dense_axis_name in ["o0pt","b0pt","bl0pt","lj0pt"]) & ("CR" in ch_name)): continue
+                                      hout[dense_axis_name].fill(**axes_fill_info_dict)
+
+                                      # Do not loop over lep flavors if not self._split_by_lepton_flavor, it's a waste of time and also we'd fill the hists too many times
+                                      if not self._split_by_lepton_flavor: break
+
+                          # Do not loop over njets if hist is njets (otherwise we'd fill the hist too many times)
+                          if dense_axis_name == "njets": break
 
         return hout
 

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -185,150 +185,150 @@ class AnalysisProcessor(processor.ProcessorABC):
         if self._do_systematics : syst_var_list = ['MuonESUp','MuonESDown','JERUp','JERDown','JESUp','JESDown','nominal']
         else: syst_var_list = ['nominal']
         for syst_var in syst_var_list:
-          mu["pt"]=mu.pt_raw
-          if syst_var == 'MuonESUp': mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='up')
-          elif syst_var == 'MuonESDown': mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='down')
-          else: mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='nominal')
-          # Muon selection
-          mu["isPres"] = isPresMuon(mu.dxy, mu.dz, mu.sip3d, mu.eta, mu.pt, mu.miniPFRelIso_all)
-          mu["isLooseM"] = isLooseMuon(mu.miniPFRelIso_all,mu.sip3d,mu.looseId)
-          mu["isFO"] = isFOMuon(mu.pt, mu.conept, mu.btagDeepFlavB, mu.mvaTTH, mu.jetRelIso, year)
-          mu["isTightLep"]= tightSelMuon(mu.isFO, mu.mediumId, mu.mvaTTH)
-          # Build loose collections
-          m_loose = mu[mu.isPres & mu.isLooseM]
-          e_loose = e[e.isPres & e.isLooseE]
-          l_loose = ak.with_name(ak.concatenate([e_loose, m_loose], axis=1), 'PtEtaPhiMCandidate')
+            mu["pt"]=mu.pt_raw
+            if syst_var == 'MuonESUp': mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='up')
+            elif syst_var == 'MuonESDown': mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='down')
+            else: mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='nominal')
+            # Muon selection
+            mu["isPres"] = isPresMuon(mu.dxy, mu.dz, mu.sip3d, mu.eta, mu.pt, mu.miniPFRelIso_all)
+            mu["isLooseM"] = isLooseMuon(mu.miniPFRelIso_all,mu.sip3d,mu.looseId)
+            mu["isFO"] = isFOMuon(mu.pt, mu.conept, mu.btagDeepFlavB, mu.mvaTTH, mu.jetRelIso, year)
+            mu["isTightLep"]= tightSelMuon(mu.isFO, mu.mediumId, mu.mvaTTH)
+            # Build loose collections
+            m_loose = mu[mu.isPres & mu.isLooseM]
+            e_loose = e[e.isPres & e.isLooseE]
+            l_loose = ak.with_name(ak.concatenate([e_loose, m_loose], axis=1), 'PtEtaPhiMCandidate')
 
-          # Compute pair invariant masses, for all flavors all signes
-          llpairs = ak.combinations(l_loose, 2, fields=["l0","l1"])
-          events["minMllAFAS"] = ak.min( (llpairs.l0+llpairs.l1).mass, axis=-1)
+            # Compute pair invariant masses, for all flavors all signes
+            llpairs = ak.combinations(l_loose, 2, fields=["l0","l1"])
+            events["minMllAFAS"] = ak.min( (llpairs.l0+llpairs.l1).mass, axis=-1)
 
-          # Build FO collection
-          m_fo = mu[mu.isPres & mu.isLooseM & mu.isFO]
-          e_fo = e[e.isPres & e.isLooseE & e.isFO]
+            # Build FO collection
+            m_fo = mu[mu.isPres & mu.isLooseM & mu.isFO]
+            e_fo = e[e.isPres & e.isLooseE & e.isFO]
 
-          # Attach the lepton SFs to the electron and muons collections
-          AttachElectronSF(e_fo,year=year)
-          AttachMuonSF(m_fo,year=year)
+            # Attach the lepton SFs to the electron and muons collections
+            AttachElectronSF(e_fo,year=year)
+            AttachMuonSF(m_fo,year=year)
 
-          # Attach per lepton fake rates
-          AttachPerLeptonFR(e_fo, flavor = "Elec", year=year)
-          AttachPerLeptonFR(m_fo, flavor = "Muon", year=year)
-          m_fo['convVeto'] = ak.ones_like(m_fo.charge); 
-          m_fo['lostHits'] = ak.zeros_like(m_fo.charge); 
-          l_fo = ak.with_name(ak.concatenate([e_fo, m_fo], axis=1), 'PtEtaPhiMCandidate')
-          l_fo_conept_sorted = l_fo[ak.argsort(l_fo.conept, axis=-1,ascending=False)]
+            # Attach per lepton fake rates
+            AttachPerLeptonFR(e_fo, flavor = "Elec", year=year)
+            AttachPerLeptonFR(m_fo, flavor = "Muon", year=year)
+            m_fo['convVeto'] = ak.ones_like(m_fo.charge); 
+            m_fo['lostHits'] = ak.zeros_like(m_fo.charge); 
+            l_fo = ak.with_name(ak.concatenate([e_fo, m_fo], axis=1), 'PtEtaPhiMCandidate')
+            l_fo_conept_sorted = l_fo[ak.argsort(l_fo.conept, axis=-1,ascending=False)]
 
-          # Tau selection
-          tau["isPres"]  = isPresTau(tau.pt, tau.eta, tau.dxy, tau.dz, tau.idDeepTau2017v2p1VSjet, minpt=20)
-          tau["isClean"] = isClean(tau, l_loose, drmin=0.3)
-          tau["isGood"]  =  tau["isClean"] & tau["isPres"]
-          tau = tau[tau.isGood] # use these to clean jets
-          tau["isTight"] = isTightTau(tau.idDeepTau2017v2p1VSjet) # use these to veto
+            # Tau selection
+            tau["isPres"]  = isPresTau(tau.pt, tau.eta, tau.dxy, tau.dz, tau.idDeepTau2017v2p1VSjet, minpt=20)
+            tau["isClean"] = isClean(tau, l_loose, drmin=0.3)
+            tau["isGood"]  =  tau["isClean"] & tau["isPres"]
+            tau = tau[tau.isGood] # use these to clean jets
+            tau["isTight"] = isTightTau(tau.idDeepTau2017v2p1VSjet) # use these to veto
 
-          #################### Jets ####################
+            #################### Jets ####################
 
-          # Jet cleaning, before any jet selection
-          #vetos_tocleanjets = ak.with_name( ak.concatenate([tau, l_fo], axis=1), "PtEtaPhiMCandidate")
-          vetos_tocleanjets = ak.with_name( l_fo, "PtEtaPhiMCandidate")
-          tmp = ak.cartesian([ak.local_index(jets.pt), vetos_tocleanjets.jetIdx], nested=True)
-          cleanedJets = jets[~ak.any(tmp.slot0 == tmp.slot1, axis=-1)] # this line should go before *any selection*, otherwise lep.jetIdx is not aligned with the jet index
+            # Jet cleaning, before any jet selection
+            #vetos_tocleanjets = ak.with_name( ak.concatenate([tau, l_fo], axis=1), "PtEtaPhiMCandidate")
+            vetos_tocleanjets = ak.with_name( l_fo, "PtEtaPhiMCandidate")
+            tmp = ak.cartesian([ak.local_index(jets.pt), vetos_tocleanjets.jetIdx], nested=True)
+            cleanedJets = jets[~ak.any(tmp.slot0 == tmp.slot1, axis=-1)] # this line should go before *any selection*, otherwise lep.jetIdx is not aligned with the jet index
 
-          # Selecting jets and cleaning them
-          jetptname = "pt_nom" if hasattr(cleanedJets, "pt_nom") else "pt"
+            # Selecting jets and cleaning them
+            jetptname = "pt_nom" if hasattr(cleanedJets, "pt_nom") else "pt"
 
-          # Jet energy corrections
-          if not isData:
-            cleanedJets["pt_raw"] = (1 - cleanedJets.rawFactor)*cleanedJets.pt
-            cleanedJets["mass_raw"] = (1 - cleanedJets.rawFactor)*cleanedJets.mass
-            cleanedJets["pt_gen"] =ak.values_astype(ak.fill_none(cleanedJets.matched_gen.pt, 0), np.float32)
-            cleanedJets["rho"] = ak.broadcast_arrays(events.fixedGridRhoFastjetAll, cleanedJets.pt)[0]
-            events_cache = events.caches[0]
-            cleanedJets = ApplyJetCorrections(year, corr_type='jets').build(cleanedJets, lazy_cache=events_cache)
-            # SYSTEMATICS
-            cleanedJets=ApplyJetSystematics(cleanedJets,syst_var)
-            met=ApplyJetCorrections(year, corr_type='met').build(met_raw, cleanedJets, lazy_cache=events_cache)
-          cleanedJets["isGood"] = isTightJet(getattr(cleanedJets, jetptname), cleanedJets.eta, cleanedJets.jetId, jetPtCut=30.) # temporary at 25 for synch, TODO: Do we want 30 or 25?
-          goodJets = cleanedJets[cleanedJets.isGood]
+            # Jet energy corrections
+            if not isData:
+                cleanedJets["pt_raw"] = (1 - cleanedJets.rawFactor)*cleanedJets.pt
+                cleanedJets["mass_raw"] = (1 - cleanedJets.rawFactor)*cleanedJets.mass
+                cleanedJets["pt_gen"] =ak.values_astype(ak.fill_none(cleanedJets.matched_gen.pt, 0), np.float32)
+                cleanedJets["rho"] = ak.broadcast_arrays(events.fixedGridRhoFastjetAll, cleanedJets.pt)[0]
+                events_cache = events.caches[0]
+                cleanedJets = ApplyJetCorrections(year, corr_type='jets').build(cleanedJets, lazy_cache=events_cache)
+                # SYSTEMATICS
+                cleanedJets=ApplyJetSystematics(cleanedJets,syst_var)
+                met=ApplyJetCorrections(year, corr_type='met').build(met_raw, cleanedJets, lazy_cache=events_cache)
+            cleanedJets["isGood"] = isTightJet(getattr(cleanedJets, jetptname), cleanedJets.eta, cleanedJets.jetId, jetPtCut=30.) # temporary at 25 for synch, TODO: Do we want 30 or 25?
+            goodJets = cleanedJets[cleanedJets.isGood]
 
-          # Count jets
-          njets = ak.num(goodJets)
-          ht = ak.sum(goodJets.pt,axis=-1)
-          j0 = goodJets[ak.argmax(goodJets.pt,axis=-1,keepdims=True)]
-          
-          # Loose DeepJet WP
-          if year == "2017":
-            btagwpl = get_param("btag_wp_loose_UL17")
-          elif year == "2018":
-            btagwpl = get_param("btag_wp_loose_UL18")
-          elif year=="2016":
-            btagwpl = get_param("btag_wp_loose_UL16")          
-          elif year=="2016APV":
-            btagwpl = get_param("btag_wp_loose_UL16APV")
-          else:
-            raise ValueError(f"Error: Unknown year \"{year}\".")
-          isBtagJetsLoose = (goodJets.btagDeepFlavB > btagwpl)
-          isNotBtagJetsLoose = np.invert(isBtagJetsLoose)
-          nbtagsl = ak.num(goodJets[isBtagJetsLoose])
+            # Count jets
+            njets = ak.num(goodJets)
+            ht = ak.sum(goodJets.pt,axis=-1)
+            j0 = goodJets[ak.argmax(goodJets.pt,axis=-1,keepdims=True)]
+            
+            # Loose DeepJet WP
+            if year == "2017":
+                btagwpl = get_param("btag_wp_loose_UL17")
+            elif year == "2018":
+                btagwpl = get_param("btag_wp_loose_UL18")
+            elif year=="2016":
+                btagwpl = get_param("btag_wp_loose_UL16")          
+            elif year=="2016APV":
+                btagwpl = get_param("btag_wp_loose_UL16APV")
+            else:
+                raise ValueError(f"Error: Unknown year \"{year}\".")
+            isBtagJetsLoose = (goodJets.btagDeepFlavB > btagwpl)
+            isNotBtagJetsLoose = np.invert(isBtagJetsLoose)
+            nbtagsl = ak.num(goodJets[isBtagJetsLoose])
 
-          # Medium DeepJet WP
-          if year == "2017": 
-            btagwpm = get_param("btag_wp_medium_UL17")
-          elif year == "2018":
-            btagwpm = get_param("btag_wp_medium_UL18")
-          elif year=="2016":
-            btagwpm = get_param("btag_wp_medium_UL16")
-          elif year=="2016APV":
-            btagwpm = get_param("btag_wp_medium_UL16APV")
-          else:
-            raise ValueError(f"Error: Unknown year \"{year}\".")
-          isBtagJetsMedium = (goodJets.btagDeepFlavB > btagwpm)
-          isNotBtagJetsMedium = np.invert(isBtagJetsMedium)
-          nbtagsm = ak.num(goodJets[isBtagJetsMedium])
+            # Medium DeepJet WP
+            if year == "2017": 
+                btagwpm = get_param("btag_wp_medium_UL17")
+            elif year == "2018":
+                btagwpm = get_param("btag_wp_medium_UL18")
+            elif year=="2016":
+                btagwpm = get_param("btag_wp_medium_UL16")
+            elif year=="2016APV":
+                btagwpm = get_param("btag_wp_medium_UL16APV")
+            else:
+                raise ValueError(f"Error: Unknown year \"{year}\".")
+            isBtagJetsMedium = (goodJets.btagDeepFlavB > btagwpm)
+            isNotBtagJetsMedium = np.invert(isBtagJetsMedium)
+            nbtagsm = ak.num(goodJets[isBtagJetsMedium])
 
 
-          #################### Add variables into event object so that they persist ####################
+            #################### Add variables into event object so that they persist ####################
 
-          # Put njets and l_fo_conept_sorted into events
-          events["njets"] = njets
-          events["l_fo_conept_sorted"] = l_fo_conept_sorted
+            # Put njets and l_fo_conept_sorted into events
+            events["njets"] = njets
+            events["l_fo_conept_sorted"] = l_fo_conept_sorted
 
-          # The event selection
-          add2lMaskAndSFs(events, year, isData, sampleType)
-          add3lMaskAndSFs(events, year, isData, sampleType)
-          add4lMaskAndSFs(events, year, isData)
-          addLepCatMasks(events)
+            # The event selection
+            add2lMaskAndSFs(events, year, isData, sampleType)
+            add3lMaskAndSFs(events, year, isData, sampleType)
+            add4lMaskAndSFs(events, year, isData)
+            addLepCatMasks(events)
 
-          # Convenient to have l0, l1, l2 on hand
-          l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted, 3)
-          l0 = l_fo_conept_sorted_padded[:,0]
-          l1 = l_fo_conept_sorted_padded[:,1]
-          l2 = l_fo_conept_sorted_padded[:,2]
+            # Convenient to have l0, l1, l2 on hand
+            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted, 3)
+            l0 = l_fo_conept_sorted_padded[:,0]
+            l1 = l_fo_conept_sorted_padded[:,1]
+            l2 = l_fo_conept_sorted_padded[:,2]
 
-          print("The number of events passing FO 2l, 3l, and 4l selection:", ak.num(events[events.is2l],axis=0),ak.num(events[events.is3l],axis=0),ak.num(events[events.is4l],axis=0))
+            print("The number of events passing FO 2l, 3l, and 4l selection:", ak.num(events[events.is2l],axis=0),ak.num(events[events.is3l],axis=0),ak.num(events[events.is4l],axis=0))
 
-          ######### SFs, weights, systematics ##########
+            ######### SFs, weights, systematics ##########
 
-          # Btag SF following 1a) in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods
-          btagSF   = np.ones_like(ht)
-          btagSFUp = np.ones_like(ht)
-          btagSFDo = np.ones_like(ht)
-          if not isData:
-            pt = goodJets.pt; abseta = np.abs(goodJets.eta); flav = goodJets.hadronFlavour
+            # Btag SF following 1a) in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods
+            btagSF   = np.ones_like(ht)
+            btagSFUp = np.ones_like(ht)
+            btagSFDo = np.ones_like(ht)
+            if not isData:
+                pt = goodJets.pt; abseta = np.abs(goodJets.eta); flav = goodJets.hadronFlavour
 
-            bJetSF   = GetBTagSF(abseta, pt, flav, year)
-            bJetSFUp = GetBTagSF(abseta, pt, flav, year, sys='up')
-            bJetSFDo = GetBTagSF(abseta, pt, flav, year, sys='down')
-            bJetEff  = GetBtagEff(pt, abseta, flav, year)
-            bJetEff_data   = bJetEff*bJetSF
-            bJetEff_dataUp = bJetEff*bJetSFUp
-            bJetEff_dataDo = bJetEff*bJetSFDo
+                bJetSF   = GetBTagSF(abseta, pt, flav, year)
+                bJetSFUp = GetBTagSF(abseta, pt, flav, year, sys='up')
+                bJetSFDo = GetBTagSF(abseta, pt, flav, year, sys='down')
+                bJetEff  = GetBtagEff(pt, abseta, flav, year)
+                bJetEff_data   = bJetEff*bJetSF
+                bJetEff_dataUp = bJetEff*bJetSFUp
+                bJetEff_dataDo = bJetEff*bJetSFDo
 
-            pMC     = ak.prod(bJetEff       [isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff       [isNotBtagJetsMedium]), axis=-1)
-            pData   = ak.prod(bJetEff_data  [isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff_data  [isNotBtagJetsMedium]), axis=-1)
-            pDataUp = ak.prod(bJetEff_dataUp[isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff_dataUp[isNotBtagJetsMedium]), axis=-1)
-            pDataDo = ak.prod(bJetEff_dataDo[isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff_dataDo[isNotBtagJetsMedium]), axis=-1)           
-            pMC      = ak.where(pMC==0,1,pMC) # removeing zeroes from denominator...
+                pMC     = ak.prod(bJetEff       [isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff       [isNotBtagJetsMedium]), axis=-1)
+                pData   = ak.prod(bJetEff_data  [isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff_data  [isNotBtagJetsMedium]), axis=-1)
+                pDataUp = ak.prod(bJetEff_dataUp[isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff_dataUp[isNotBtagJetsMedium]), axis=-1)
+                pDataDo = ak.prod(bJetEff_dataDo[isBtagJetsMedium], axis=-1) * ak.prod((1-bJetEff_dataDo[isNotBtagJetsMedium]), axis=-1)           
+                pMC      = ak.where(pMC==0,1,pMC) # removeing zeroes from denominator...
           
           # Trigger SF
           GetTriggerSF(year,events,l0,l1)
@@ -336,46 +336,46 @@ class AnalysisProcessor(processor.ProcessorABC):
           # We need weights for: normalization, lepSF, triggerSF, pileup, btagSF...
           weights_dict = {}
           if (isData or (eft_coeffs is not None)):
-            genw = np.ones_like(events["event"])
+              genw = np.ones_like(events["event"])
           else:
-            genw = events["genWeight"]
+              genw = events["genWeight"]
           for ch_name in ["2l", "2l_4t", "3l", "4l", "2l_CR", "3l_CR", "2los_CRtt", "2los_CRZ"]:
-            weights_dict[ch_name] = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
-            weights_dict[ch_name].add("norm",genw if isData else (xsec/sow)*genw)
-            if not isData:
+              weights_dict[ch_name] = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
+              weights_dict[ch_name].add("norm",genw if isData else (xsec/sow)*genw)
+              if not isData:
 
-                ######### Event weights ###########
+                  ######### Event weights ###########
 
-                # Attach PS weights (ISR/FSR)
-                AttachPSWeights(events)
-                # Attach scale weights (renormalization/factorization)
-                AttachScaleWeights(events)
-                # Attach PDF weights
-                #AttachPdfWeights(events) # FIXME use these!
+                  # Attach PS weights (ISR/FSR)
+                  AttachPSWeights(events)
+                  # Attach scale weights (renormalization/factorization)
+                  AttachScaleWeights(events)
+                  # Attach PDF weights
+                  #AttachPdfWeights(events) # FIXME use these!
 
-                # We only calculate these values if not isData
-                weights_dict[ch_name].add("btagSF", pData/pMC, copy.deepcopy(pDataUp/pMC), copy.deepcopy(pDataDo/pMC))
-                weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'up')), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'down')))
-                # Prefiring weights only available in nanoAODv9**
-                weights_dict[ch_name].add('PreFiring', events.L1PreFiringWeight.Nom,  copy.deepcopy(events.L1PreFiringWeight.Up),  copy.deepcopy(events.L1PreFiringWeight.Dn))
-                # FSR/ISR weights
-                weights_dict[ch_name].add('ISR', events.ISRnom, copy.deepcopy(events.ISRUp), copy.deepcopy(events.ISRDown))
-                weights_dict[ch_name].add('FSR', events.FSRnom, copy.deepcopy(events.FSRUp), copy.deepcopy(events.FSRDown))
-                # renorm/fact scale
-                weights_dict[ch_name].add('renorm',      events.nom, copy.deepcopy(events.renormUp),      copy.deepcopy(events.renormDown))
-                weights_dict[ch_name].add('fact',        events.nom, copy.deepcopy(events.factUp),        copy.deepcopy(events.factDown))
-                weights_dict[ch_name].add('renorm_fact', events.nom, copy.deepcopy(events.renorm_factUp), copy.deepcopy(events.renorm_factDown))
-                # Trigger SF
-                weights_dict[ch_name].add('triggerSF', events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))
+                  # We only calculate these values if not isData
+                  weights_dict[ch_name].add("btagSF", pData/pMC, copy.deepcopy(pDataUp/pMC), copy.deepcopy(pDataDo/pMC))
+                  weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'up')), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'down')))
+                  # Prefiring weights only available in nanoAODv9**
+                  weights_dict[ch_name].add('PreFiring', events.L1PreFiringWeight.Nom,  copy.deepcopy(events.L1PreFiringWeight.Up),  copy.deepcopy(events.L1PreFiringWeight.Dn))
+                  # FSR/ISR weights
+                  weights_dict[ch_name].add('ISR', events.ISRnom, copy.deepcopy(events.ISRUp), copy.deepcopy(events.ISRDown))
+                  weights_dict[ch_name].add('FSR', events.FSRnom, copy.deepcopy(events.FSRUp), copy.deepcopy(events.FSRDown))
+                  # renorm/fact scale
+                  weights_dict[ch_name].add('renorm',      events.nom, copy.deepcopy(events.renormUp),      copy.deepcopy(events.renormDown))
+                  weights_dict[ch_name].add('fact',        events.nom, copy.deepcopy(events.factUp),        copy.deepcopy(events.factDown))
+                  weights_dict[ch_name].add('renorm_fact', events.nom, copy.deepcopy(events.renorm_factUp), copy.deepcopy(events.renorm_factDown))
+                  # Trigger SF
+                  weights_dict[ch_name].add('triggerSF', events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))
 
-            if "2l" in ch_name:
-                weights_dict[ch_name].add("lepSF", events.sf_2l,         copy.deepcopy(events.sf_2l_hi),         copy.deepcopy(events.sf_2l_lo))
-                weights_dict[ch_name].add("FF"   , events.fakefactor_2l, copy.deepcopy(events.fakefactor_2l_up), copy.deepcopy(events.fakefactor_2l_down))
-            if "3l" in ch_name:
-                weights_dict[ch_name].add("lepSF", events.sf_3l,         copy.deepcopy(events.sf_3l_hi),         copy.deepcopy(events.sf_3l_lo))
-                weights_dict[ch_name].add("FF"   , events.fakefactor_3l, copy.deepcopy(events.fakefactor_3l_up), copy.deepcopy(events.fakefactor_3l_down))
-            if "4l" in ch_name:
-                weights_dict[ch_name].add("lepSF", events.sf_4l, copy.deepcopy(events.sf_4l_hi), copy.deepcopy(events.sf_4l_lo))
+              if "2l" in ch_name:
+                  weights_dict[ch_name].add("lepSF", events.sf_2l,         copy.deepcopy(events.sf_2l_hi),         copy.deepcopy(events.sf_2l_lo))
+                  weights_dict[ch_name].add("FF"   , events.fakefactor_2l, copy.deepcopy(events.fakefactor_2l_up), copy.deepcopy(events.fakefactor_2l_down))
+              if "3l" in ch_name:
+                  weights_dict[ch_name].add("lepSF", events.sf_3l,         copy.deepcopy(events.sf_3l_hi),         copy.deepcopy(events.sf_3l_lo))
+                  weights_dict[ch_name].add("FF"   , events.fakefactor_3l, copy.deepcopy(events.fakefactor_3l_up), copy.deepcopy(events.fakefactor_3l_down))
+              if "4l" in ch_name:
+                  weights_dict[ch_name].add("lepSF", events.sf_4l, copy.deepcopy(events.sf_4l_hi), copy.deepcopy(events.sf_4l_lo))
 
           if isData and "2l" in ch_name:
               weights_dict[ch_name].add("fliprate"   , events.flipfactor_2l)

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -3,6 +3,7 @@ import lz4.frame as lz4f
 import cloudpickle
 import json
 import pprint
+import copy
 import coffea
 import numpy as np
 import awkward as ak
@@ -353,28 +354,29 @@ class AnalysisProcessor(processor.ProcessorABC):
                 #AttachPdfWeights(events) # FIXME use these!
 
                 # We only calculate these values if not isData
-                weights_dict[ch_name].add("btagSF", pData/pMC, pDataUp/pMC, pDataDo/pMC)
-                # Trying to calculate PU SFs for data causes a crash, and we don't apply this for data anyway, so just skip it in the case of data
-                weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), GetPUSF(events.Pileup.nTrueInt, year, 'up'), GetPUSF(events.Pileup.nTrueInt, year, 'down'))
+                weights_dict[ch_name].add("btagSF", pData/pMC, copy.deepcopy(pDataUp/pMC), copy.deepcopy(pDataDo/pMC))
+                weights_dict[ch_name].add('PU', GetPUSF((events.Pileup.nTrueInt), year), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'up')), copy.deepcopy(GetPUSF(events.Pileup.nTrueInt, year, 'down')))
                 # Prefiring weights only available in nanoAODv9**
-                weights_dict[ch_name].add('PreFiring', events.L1PreFiringWeight.Nom,  events.L1PreFiringWeight.Up,  events.L1PreFiringWeight.Dn)
+                weights_dict[ch_name].add('PreFiring', events.L1PreFiringWeight.Nom,  copy.deepcopy(events.L1PreFiringWeight.Up),  copy.deepcopy(events.L1PreFiringWeight.Dn))
                 # FSR/ISR weights
-                weights_dict[ch_name].add('ISR', events.ISRnom, events.ISRUp, events.ISRDown)
-                weights_dict[ch_name].add('FSR', events.FSRnom, events.FSRUp, events.FSRDown)
+                weights_dict[ch_name].add('ISR', events.ISRnom, copy.deepcopy(events.ISRUp), copy.deepcopy(events.ISRDown))
+                weights_dict[ch_name].add('FSR', events.FSRnom, copy.deepcopy(events.FSRUp), copy.deepcopy(events.FSRDown))
                 # renorm/fact scale
-                weights_dict[ch_name].add('renorm', events.nom, events.renormUp, events.renormDown)
-                weights_dict[ch_name].add('fact',   events.nom, events.factUp,   events.factDown)
-                weights_dict[ch_name].add('renorm_fact', events.nom, events.renorm_factUp, events.renorm_factDown)
+                weights_dict[ch_name].add('renorm',      events.nom, copy.deepcopy(events.renormUp),      copy.deepcopy(events.renormDown))
+                weights_dict[ch_name].add('fact',        events.nom, copy.deepcopy(events.factUp),        copy.deepcopy(events.factDown))
+                weights_dict[ch_name].add('renorm_fact', events.nom, copy.deepcopy(events.renorm_factUp), copy.deepcopy(events.renorm_factDown))
                 # Trigger SF
-                weights_dict[ch_name].add('triggerSF', events.trigger_sf, events.trigger_sfUp, events.trigger_sfDown)
+                weights_dict[ch_name].add('triggerSF', events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))
+
             if "2l" in ch_name:
-                weights_dict[ch_name].add("lepSF", events.sf_2l, events.sf_2l_hi, events.sf_2l_lo)
-                weights_dict[ch_name].add("FF"   , events.fakefactor_2l, events.fakefactor_2l_up, events.fakefactor_2l_down )
+                weights_dict[ch_name].add("lepSF", events.sf_2l,         copy.deepcopy(events.sf_2l_hi),         copy.deepcopy(events.sf_2l_lo))
+                weights_dict[ch_name].add("FF"   , events.fakefactor_2l, copy.deepcopy(events.fakefactor_2l_up), copy.deepcopy(events.fakefactor_2l_down))
             if "3l" in ch_name:
-                weights_dict[ch_name].add("lepSF", events.sf_3l, events.sf_3l_hi, events.sf_3l_lo)
-                weights_dict[ch_name].add("FF"   , events.fakefactor_3l, events.fakefactor_3l_up, events.fakefactor_3l_down)
+                weights_dict[ch_name].add("lepSF", events.sf_3l,         copy.deepcopy(events.sf_3l_hi),         copy.deepcopy(events.sf_3l_lo))
+                weights_dict[ch_name].add("FF"   , events.fakefactor_3l, copy.deepcopy(events.fakefactor_3l_up), copy.deepcopy(events.fakefactor_3l_down))
             if "4l" in ch_name:
-                weights_dict[ch_name].add("lepSF", events.sf_4l, events.sf_4l_hi, events.sf_4l_lo)
+                weights_dict[ch_name].add("lepSF", events.sf_4l, copy.deepcopy(events.sf_4l_hi), copy.deepcopy(events.sf_4l_lo))
+
           if isData and "2l" in ch_name:
               weights_dict[ch_name].add("fliprate"   , events.flipfactor_2l)
               


### PR DESCRIPTION
This PR fixes an issue related to the `add()` method of `coffea.analysis_tools.Weights`.  As mentioned in the [documentation](https://coffeateam.github.io/coffea/api/coffea.analysis_tools.Weights.html) this method can actually modify the up/down values that are passed. To avoid this issue, we're now passing copies of the variables instead of the variables themselves. For us, this issue was apparently only affecting the `L1PreFiringWeight` systematic (for unknown reasons). 

Unrelatedly, this PR also attempts to restore 4-space indents throughout the processor (as it had become a mix of 2-space indents and 4-space indents).  However, it does make it difficult to see what was actually changed in this PR, so please refer to [this commit](https://github.com/TopEFT/topcoffea/commit/4051d80b57a2a3e03133ffcb161cf7757819f21d) for the relevant `add()` changes. 