### PR TITLE
Fix background process numbers

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -445,7 +445,7 @@ class DatacardMaker():
         # Create the ROOT file
         fname = f'histos/ttx_multileptons-{cat}.root'
         fout = TFile(fname, 'recreate')
-        signalcount=0; bkgcount=0; iproc = {}; systMap = {}; allyields = {'data_obs' : 0.}
+        signalcount=0; bkgcount=1; iproc = {}; systMap = {}; allyields = {'data_obs' : 0.}
         data_obs = []
         d_sigs = {} # Store signals for summing
         d_bkgs = {} # Store backgrounds for summing


### PR DESCRIPTION
This PR fixes a bug in the background process numbers. `<=0` is treated as signal in combine, so `bkgcount` should start at 1. 