### PR TITLE
Various updates for looking at systematics

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -720,7 +720,7 @@ class DatacardMaker():
         # Case for a single wc
         elif (isinstance(wc,list) and (len(wc)==1)):
             wc = wc[0] # Grab the str from the list
-            wcpt.append([f'lin_{wc}', {wc: 0.0}])
+            wcpt.append([f'lin_{wc}', {wc: 1.0}])
             wcpt.append([f'quad_{wc}', {wc: 2.0}])
         # Case for 2+ wcs
         elif (isinstance(wc,list) and (len(wc)>1)):
@@ -847,17 +847,19 @@ if __name__ == '__main__':
     # Set up cards lst
     for var in include_var_lst:
         if var == 'ptz': continue # This var only applies to a subset of the channels
-        cards = [{'channel':'2lss', 'appl':'isSR_2lSS', 'charges':'ch+', 'systematics':'nominal', 'variable':var, 'bins':card.ch2lssj},
-                 {'channel':'2lss', 'appl':'isSR_2lSS', 'charges':'ch-', 'systematics':'nominal', 'variable':var, 'bins':card.ch2lssj},
-                 {'channel': '2lss_4t', 'appl': 'isSR_2lSS', 'charges': 'ch+', 'systematics': 'nominal', 'variable': var, 'bins': card.ch2lss_4tj},
-                 {'channel': '2lss_4t', 'appl': 'isSR_2lSS', 'charges': 'ch-', 'systematics': 'nominal', 'variable': var, 'bins': card.ch2lss_4tj},
-                 {'channel':'3l1b', 'appl':'isSR_3l', 'charges':'ch+', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
-                 {'channel':'3l1b', 'appl':'isSR_3l', 'charges':'ch-', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
-                 {'channel':'3l2b', 'appl':'isSR_3l', 'charges':'ch+', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
-                 {'channel':'3l2b', 'appl':'isSR_3l', 'charges':'ch-', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
-                 {'channel':'3l_sfz_1b', 'appl':'isSR_3l', 'charges':['ch+','ch-'], 'systematics':'nominal', 'variable':var, 'bins':card.ch3lsfzj},
-                 {'channel':'3l_sfz_2b', 'appl':'isSR_3l', 'charges':['ch+','ch-'], 'systematics':'nominal', 'variable':var, 'bins':card.ch3lsfzj},
-                 {'channel':'4l', 'appl':'isSR_4l', 'charges':['ch+','ch0','ch-'], 'systematics':'nominal', 'variable':var, 'bins':card.ch4lj}]
+        cards = [
+            {'channel':'2lss', 'appl':'isSR_2lSS', 'charges':'ch+', 'systematics':'nominal', 'variable':var, 'bins':card.ch2lssj},
+            {'channel':'2lss', 'appl':'isSR_2lSS', 'charges':'ch-', 'systematics':'nominal', 'variable':var, 'bins':card.ch2lssj},
+            {'channel': '2lss_4t', 'appl': 'isSR_2lSS', 'charges': 'ch+', 'systematics': 'nominal', 'variable': var, 'bins': card.ch2lss_4tj},
+            {'channel': '2lss_4t', 'appl': 'isSR_2lSS', 'charges': 'ch-', 'systematics': 'nominal', 'variable': var, 'bins': card.ch2lss_4tj},
+            {'channel':'3l1b', 'appl':'isSR_3l', 'charges':'ch+', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
+            {'channel':'3l1b', 'appl':'isSR_3l', 'charges':'ch-', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
+            {'channel':'3l2b', 'appl':'isSR_3l', 'charges':'ch+', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
+            {'channel':'3l2b', 'appl':'isSR_3l', 'charges':'ch-', 'systematics':'nominal', 'variable':var, 'bins':card.ch3lj},
+            {'channel':'3l_sfz_1b', 'appl':'isSR_3l', 'charges':['ch+','ch-'], 'systematics':'nominal', 'variable':var, 'bins':card.ch3lsfzj},
+            {'channel':'3l_sfz_2b', 'appl':'isSR_3l', 'charges':['ch+','ch-'], 'systematics':'nominal', 'variable':var, 'bins':card.ch3lsfzj},
+            {'channel':'4l', 'appl':'isSR_4l', 'charges':['ch+','ch0','ch-'], 'systematics':'nominal', 'variable':var, 'bins':card.ch4lj}
+        ]
         jobs.append(cards)
     if 'ptz' in include_var_lst:
         cards = [

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -718,27 +718,23 @@ class DatacardMaker():
         if len(wc)==0:
             wcpt = None
         # Case for a single wc
-        elif isinstance(wc, str):
-            wl = {k:0 for k in self.coeffs}
-            wl[wc] = 1.
-            wcpt.append([f'lin_{wc}', wl])
-        elif len(wc)==1:
-            wl = {k:0 for k in self.coeffs}
-            wl[wc] = 1.
-            wcpt.append([f'lin_{wc}', wl])
+        elif (isinstance(wc,list) and (len(wc)==1)):
+            wc = wc[0] # Grab the str from the list
+            wcpt.append([f'lin_{wc}', {wc: 0.0}])
+            wcpt.append([f'quad_{wc}', {wc: 2.0}])
         # Case for 2+ wcs
-        else:
+        elif (isinstance(wc,list) and (len(wc)>1)):
             pairs = [[wc[w1],wc[w2]] for w1 in range(len(wc)) for w2 in range(0, w1+1)]
             wcpt = []
             lin = []
             quad = []
             mixed = []
-            #linear terms
+            # Linear terms
             for n,w in enumerate(wc):
                 wl = {k:0 for k in self.coeffs}
                 wl[w] = 1.
                 wcpt.append([f'lin_{w}', wl])
-            #quadratic terms
+                # Quadratic terms
                 for m,w in enumerate([[w,wc[w2]] for w2 in range(0, n+1)]):
                     wc1 = w[0]
                     wc2 = w[1]
@@ -749,6 +745,8 @@ class DatacardMaker():
                         wl[wc1] = 1.; wl[wc2] = 1.;
                     if(wc1==wc2):  wcpt.append([f'quad_{wc1}', wl])
                     else: wcpt.append([f'quad_mixed_{wc1}_{wc2}', wl])
+        else:
+            raise Exception(f"Error: the WCs \"{wc}\" are specified in an unknown format")
         self.wcs     = wcpt
         return wcpt
     def condor_job(self, pklfile, njobs, wcs, do_nuisance, do_sm, var_lst):

--- a/analysis/topEFT/make_1d_quad_plots.py
+++ b/analysis/topEFT/make_1d_quad_plots.py
@@ -33,7 +33,6 @@ def main():
         save_dir_path = os.path.join(args.output_path,outdir_name)
 
     # Open an example naod file
-    # Maybe should pass this as an argument? Or even pass a cfg file like the run script does
     redirector = args.redirector
     in_file = args.input_path
     in_file = redirector + in_file
@@ -63,7 +62,7 @@ def main():
         fit_coeffs_1d = qft.get_1d_fit(wc_fit_dict,wc_name)
         xaxis_lims = qft.ARXIV1901_LIMS.get(wc_name,qft.TOP19001_LIMS.get(wc_name,[-10,10])) # Use lim from 1901 theory paper if it exists, or TOP-19-001 if it exists, or -10,10 otherwise
         qft.make_1d_quad_plot(
-            fit_coeffs_1d,
+            {wc_name: fit_coeffs_1d},
             wc_name,
             yaxis_str,
             title=wc_name,

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -26,7 +26,7 @@
 #     Li   = lin_i - S - Qi 
 #          = lin_i - sm - quad_i
 #     2Mij = mixed_ij - S - Qi - Qj - Li - Lj
-#          = mixed_ij - sm - quad_i - quad_j - (lin_i - S - Qi) - (lin_j - sm - quad_j)
+#          = mixed_ij - sm - quad_i - quad_j - (lin_i - sm - Qi) - (lin_j - sm - quad_j)
 
 # To run this script:
 #     - The script is currently very basic and hard coded
@@ -210,7 +210,7 @@ def quad_wrapper(proc,njets,save_path="quad_fits"):
         #proc_fit_dict[sys_var] = qft.scale_to_sm(proc_fit_dict[sys_var]) # If we want to scale to sm
 
     # For validation, can evaluate the fit at a given point in EFT space
-    #wcpt = { }
+    #wcpt = {"cpt":11.1}
     #print(proc_fit_dict["nom"])
     #print(qft.eval_fit(proc_fit_dict["nom"],wcpt))
     #exit()

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -41,9 +41,9 @@ import topcoffea.modules.QuadFitTools as qft
 from topcoffea.plotter.make_html import make_html
 
 # Load the input dict (with all of the values from the template histos)
-import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets.ttx_multileptons_2lss_p_2b_theta01 as template_vals_dict_file
-#IN_DICT = template_vals_dict_file.template_vals_dict
-IN_DICT = template_vals_dict_file.p
+# Note this is a PLACEHOLDER (should be a command line argument?)
+import path_to_your_file.file_name as template_vals_dict_file
+IN_DICT = template_vals_dict_file.template_vals_dict
 
 
 PROC_LST = [ "ttH", "ttlnu", "ttll", "tllq", "tHq", "tttt" ]
@@ -241,7 +241,7 @@ def main():
     #os.mkdir("tmp_quad_fits")
     #quad_wrapper("ttH",4,"tmp_quad_fits")
 
-    # Specify the save dir (would be a lot better to pass this as a command line argument)
+    # Specify the save dir (would be a lot better to pass this as a command line argument), note this is a PLACEHOLDER
     www_loc = "path/to/somewhere/in/your/www/area"
     base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_p_2b") # For example
 

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -242,7 +242,7 @@ def main():
     #quad_wrapper("ttH",4,"tmp_quad_fits")
 
     # Specify the save dir (would be a lot better to pass this as a command line argument)
-    www_loc = "/afs/crc.nd.edu/user/k/kmohrman/www/EFT/TopCoffea/testing/mar04"
+    www_loc = "path/to/somewhere/in/your/www/area"
     base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_p_2b") # For example
 
     # Run the wrapper for all processes and all jet cateogires and all WCs

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -87,7 +87,8 @@ def get_decomp_term_sm(decomp_lst):
 def get_decomp_term_lin(decomp_lst,wc):
     ret = None
     for decomp_term_name in decomp_lst:
-        if ("lin" in decomp_term_name) and (wc in decomp_term_name):
+        substr_lst = decomp_term_name.split("_")
+        if ("lin" in decomp_term_name) and (wc in substr_lst):
             ret = decomp_term_name
     if ret is None: raise Exception("Error, no lin term found")
     else: return ret
@@ -96,7 +97,8 @@ def get_decomp_term_lin(decomp_lst,wc):
 def get_decomp_term_quad(decomp_lst,wc):
     ret = None
     for decomp_term_name in decomp_lst:
-        if ("quad" in decomp_term_name) and ("mix" not in decomp_term_name) and (wc in decomp_term_name):
+        substr_lst = decomp_term_name.split("_")
+        if ("quad" in decomp_term_name) and ("mix" not in decomp_term_name) and (wc in substr_lst):
             ret = decomp_term_name
     if ret is None: raise Exception("Error, no mixed term found")
     else: return ret
@@ -105,7 +107,8 @@ def get_decomp_term_quad(decomp_lst,wc):
 def get_decomp_term_mix(decomp_lst,wc0,wc1):
     ret = None
     for decomp_term_name in decomp_lst:
-        if ("mix" in decomp_term_name) and (wc0 in decomp_term_name) and (wc1 in decomp_term_name):
+        substr_lst = decomp_term_name.split("_")
+        if ("mix" in decomp_term_name) and (wc0 in substr_lst) and (wc1 in substr_lst):
             ret = decomp_term_name
     if ret is None: raise Exception("Error, no mixed term found")
     else: return ret
@@ -148,7 +151,7 @@ def get_param_value(quad_term,decomp_term_name_lst):
         val_quad0 = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc0)]
         val_quad1 = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc1)]
 
-        val_ret = (val_mix - val_sm - val_lin0 - val_lin1 - val_quad0 - val_quad1)/2.0
+        val_ret = (val_mix - val_sm - (val_lin0 - val_sm - val_quad0) - (val_lin1 - val_sm - val_quad1) - val_quad0 - val_quad1)/2.0
 
     # looking for the L term
     else:
@@ -221,9 +224,9 @@ def quad_wrapper(proc,njets,save_path="quad_fits",shift=None):
         #"cQt1"   : -1.24,
 
     }
-    #wcpt = {"ctZ":-5.0,"cpt":3.0}
+    wcpt = {"ctZ":-5.0,"cpt":3.0}
     #wcpt = {"ctZ":-5.0}
-    wcpt = {"cpt":3.0}
+    #wcpt = {"cpt":3.0}
     print(proc_fit_dict["nom"])
     print(qft.eval_fit(proc_fit_dict["nom"],wcpt))
     exit()

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -1,0 +1,294 @@
+import numpy as np
+import os
+import topcoffea.modules.QuadFitTools as qft
+from topcoffea.plotter.make_html import make_html
+
+# Load the in dict
+#import tmp_quad as q
+#IN_DICT = q.fit_pieces_dict
+#import decomp_fit_terms_test as q
+#IN_DICT = q.decomp_terms_in_dict
+
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_2lss_4t_m_2b as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_2lss_4t_p_2b as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_2lss_m_2b as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_2lss_p_2b as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_3l1b_m as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_3l1b_p as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_3l2b_m as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_3l2b_p as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_3l_sfz_1b as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_3l_sfz_2b as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets_theta22.ttx_multileptons_4l_2b as q
+#IN_DICT = q.p
+
+import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets.ttx_multileptons_2lss_p_2b_theta01 as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets.ttx_multileptons_2lss_p_2b_theta05 as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets.ttx_multileptons_2lss_p_2b_theta22 as q
+#import fit_params_mar06_fullR2_sig_njets_lj0pt_withSys_renormfact_njets.ttx_multileptons_2lss_p_2b_theta22_FLIP as q
+IN_DICT = q.p
+
+
+PROC_LST = [ "ttH", "ttlnu", "ttll", "tllq", "tHq", "tttt" ]
+#WC_LST = ['ctW','ctZ','ctp','cpQM','ctG','cbW','cpQ3','cptb','cpt','cQl3i','cQlMi','cQei','ctli','ctei','ctlSi','ctlTi', 'cQq13', 'cQq83', 'cQq11', 'ctq1', 'cQq81', 'ctq8', 'ctt1', 'cQQ1', 'cQt8', 'cQt1']
+#WC_LST = ['ctG','ctq8']
+#WC_LST = ['cpt']
+WC_LST = ['ctZ','cpt']
+
+# Get WC lst for each process
+def get_wc_lst_for_proc(proc,all_decomp_terms):
+    proc_lst = []
+    for decomp_term in all_decomp_terms.keys():
+        if proc not in decomp_term: continue
+        for wc in WC_LST:
+            if wc in decomp_term:
+                if wc not in proc_lst:
+                    proc_lst.append(wc)
+    return proc_lst
+
+
+######### Getting names from list of decomposed names #########
+
+# Takes dict dumped by cpp and returns a list of the relevant ones
+def get_term_lst(in_dict,proc_to_get,var_to_get,njets_to_get):
+
+    # Get up/down/nom variation of term
+    def get_variation(in_str):
+        if   ("Up" in in_str): return "up"
+        elif ("Down" in in_str): return "down"
+        else: return "nom"
+
+    # Fill the dict
+    term_lst = []
+    for term_name, val in in_dict.items():
+        #print("\n",term_name)
+        # Get the info
+        var_str = get_variation(term_name)
+        njets = term_name[-1]
+        # Skip ones we don't care about
+        if proc_to_get not in term_name: continue
+        if var_str != var_to_get: continue
+        if njets != str(njets_to_get): continue
+        # Append to return lst
+        term_lst.append(term_name)
+
+    return term_lst
+
+# Get term: sm = S
+def get_decomp_term_sm(decomp_lst):
+    ret = None
+    for decomp_term_name in decomp_lst:
+        if "sm" in decomp_term_name:
+            ret = decomp_term_name
+    if ret is None: raise Exception("Error, no sm term found")
+    else: return ret
+
+# Get term: lin = S + Li + Qi
+def get_decomp_term_lin(decomp_lst,wc):
+    ret = None
+    for decomp_term_name in decomp_lst:
+        if ("lin" in decomp_term_name) and (wc in decomp_term_name):
+            ret = decomp_term_name
+    if ret is None: raise Exception("Error, no lin term found")
+    else: return ret
+
+# Get term: quad = Qi
+def get_decomp_term_quad(decomp_lst,wc):
+    ret = None
+    for decomp_term_name in decomp_lst:
+        if ("quad" in decomp_term_name) and ("mix" not in decomp_term_name) and (wc in decomp_term_name):
+            ret = decomp_term_name
+    if ret is None: raise Exception("Error, no mixed term found")
+    else: return ret
+
+# Get term: mix = S + Li + lj + Qi + Qj + 2Mij
+def get_decomp_term_mix(decomp_lst,wc0,wc1):
+    ret = None
+    for decomp_term_name in decomp_lst:
+        if ("mix" in decomp_term_name) and (wc0 in decomp_term_name) and (wc1 in decomp_term_name):
+            ret = decomp_term_name
+    if ret is None: raise Exception("Error, no mixed term found")
+    else: return ret
+
+
+######### Finding fit coeffecients from the decomposed components #########
+
+# Construct the keys e.g. ctG*ctp for the quad fit for a given set of WCs
+def get_quad_keys(wc_lst):
+    quad_terms_lst = []
+    if "sm" not in wc_lst: wc_lst = ["sm"] + wc_lst
+    for i,wc_row in enumerate(wc_lst):
+        for j,wc_col in enumerate(wc_lst):
+            if j>i: continue
+            quad_terms_lst.append(wc_row+"*"+wc_col)
+    return quad_terms_lst
+
+# Takes e.g. "ctG*ctp" and reconstructs the value from the values in the decomposed dict
+def get_param_value(quad_term,decomp_term_name_lst):
+
+    wc0 = quad_term.split("*")[0]
+    wc1 = quad_term.split("*")[1]
+
+    decomp_name_sm = get_decomp_term_sm(decomp_term_name_lst)
+    val_sm = IN_DICT[decomp_name_sm]
+
+    # Looking for the S term
+    if quad_term == "sm*sm":
+        val_ret = val_sm
+
+    # Looking for the Q term
+    elif wc0 == wc1:
+        val_ret = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc0)]
+
+    # Looking for the M term
+    elif "sm" not in quad_term:
+        val_mix   = IN_DICT[get_decomp_term_mix(decomp_term_name_lst,wc0,wc1)]
+        val_lin0  = IN_DICT[get_decomp_term_lin(decomp_term_name_lst,wc0)]
+        val_lin1  = IN_DICT[get_decomp_term_lin(decomp_term_name_lst,wc1)]
+        val_quad0 = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc0)]
+        val_quad1 = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc1)]
+
+        val_ret = (val_mix - val_sm - val_lin0 - val_lin1 - val_quad0 - val_quad1)/2.0
+
+    # looking for the L term
+    else:
+        if wc0 != "sm": wc_nonsm = wc0
+        elif wc1 != "sm": wc_nonsm = wc1
+        else: raise Exception("This should not be possible")
+        val_lin  = IN_DICT[get_decomp_term_lin(decomp_term_name_lst,wc_nonsm)]
+        val_quad = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc_nonsm)]
+        val_ret = val_lin - val_sm - val_quad
+
+    return val_ret
+
+# Find fit param values for terms e.g. ["sm*sm","sm*ctG"...] from the values mapped to the decomposed lst names
+# Really just a wrapper for get_param_value()
+def get_fit_param_val_dict(quad_term_name_lst,decomp_terms_lst):
+    ret_dict = {}
+    for quad_term_name in quad_term_name_lst:
+        val = get_param_value(quad_term_name,decomp_terms_lst)
+        ret_dict[quad_term_name] = val
+    return ret_dict
+
+
+# Main wrapper to read the values and make plots
+def quad_wrapper(proc,njets,save_path="quad_fits",shift=None):
+
+    wc_lst_for_proc = get_wc_lst_for_proc(proc,IN_DICT)
+
+    # Get the names of the fit params for the given list of WCs
+    quad_terms_lst = get_quad_keys(wc_lst_for_proc)
+
+    # Get an example subset
+    decomp_terms_dict = {
+        "nom"  : get_term_lst(IN_DICT,proc,"nom",njets),
+        "up"   : get_term_lst(IN_DICT,proc,"up",njets),
+        "down" : get_term_lst(IN_DICT,proc,"down",njets),
+    }
+
+    # For each fit param calculate val
+    proc_fit_dict = {}
+    for sys_var,decomp_terms_lst in decomp_terms_dict.items():
+        proc_fit_dict[sys_var] = get_fit_param_val_dict(quad_terms_lst,decomp_terms_lst)
+        #proc_fit_dict[sys_var] = qft.scale_to_sm(proc_fit_dict[sys_var]) # If we want to scale to sm
+
+    wcpt = {
+        #"ctW": -0.74,
+        #"ctZ": -0.86,
+        #"ctp": 24.5,
+        #"cpQM": -0.27,
+        #"ctG": -0.81,
+        #"cbW": 3.03,
+        #"cpQ3": -1.71,
+        #"cptb": 0.13,
+        #"cpt": -3.72,
+        #"cQl3i": -4.47,
+        #"cQlMi": 0.51,
+        #"cQei": 0.05,
+        #"ctli": 0.33,
+        #"ctei": 0.33,
+        #"ctlSi": -0.07,
+        #"ctlTi": -0.01,
+        #"cQq13"  : -0.05,
+        #"cQq83"  : -0.15,
+        #"cQq11"  : -0.15,
+        #"ctq1"   : -0.20,
+        #"cQq81"  : -0.50,
+        #"ctq8"   : -0.50,
+        #"ctt1"   : -0.71,
+        #"cQQ1"   : -1.35,
+        #"cQt8"   : -2.89,
+        #"cQt1"   : -1.24,
+
+    }
+    #wcpt = {"ctZ":-5.0,"cpt":3.0}
+    #wcpt = {"ctZ":-5.0}
+    wcpt = {"cpt":3.0}
+    print(proc_fit_dict["nom"])
+    print(qft.eval_fit(proc_fit_dict["nom"],wcpt))
+    exit()
+
+    # Make the plots
+    for wc in wc_lst_for_proc:
+        plot_name = "fit_" + proc + "_njets" + str(njets) + "_" + wc
+        qft.make_1d_quad_plot(
+            quad_params_dict = {
+                "nom" : qft.get_1d_fit(proc_fit_dict["nom"],wc),
+                "up"  : qft.get_1d_fit(proc_fit_dict["up"],wc),
+                "down": qft.get_1d_fit(proc_fit_dict["down"],wc),
+            },
+            xaxis_name = wc,
+            yaxis_name = "Yld",
+            title = plot_name,
+            xaxis_range = qft.FIT_RANGES[wc],
+            save_dir = save_path,
+            shift_var = shift,
+        )
+
+
+
+######### Main function, get values for the quad fits #########
+
+def main():
+
+    # Run the wrapper for all processes and all jet cateogires and all WCs
+    #www_loc = "/afs/crc.nd.edu/user/k/kmohrman/www/EFT/TopCoffea/fitting/sys_checks/mar03_fullR2-sig_processorMaster-dcmakerBeforeCor_fitting/sys_individual/check_renormfact/mar06_fullR2-sig_njets-lj0pt_withSys-renormfact/njets_template-hisots/test"
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_p_2b_fits")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_p_2b_fits_theta22_test_flip_u_d")
+
+    '''
+    www_loc = "/afs/crc.nd.edu/user/k/kmohrman/www/EFT/TopCoffea/fitting/sys_checks/mar03_fullR2-sig_processorMaster-dcmakerBeforeCor_fitting/sys_individual/check_renormfact/mar06_fullR2-sig_njets-lj0pt_withSys-renormfact/njets_template-hisots/all_cats_theta22"
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_4t_m_2b")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_4t_p_2b")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_m_2b")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-2lss_p_2b")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-3l1b_m")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-3l1b_p")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-3l2b_m")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-3l2b_p")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-3l_sfz_1b")
+    #base_dir = os.path.join(www_loc,"ttx_multileptons-3l_sfz_2b")
+    base_dir = os.path.join(www_loc,"ttx_multileptons-4l_2b")
+
+    #os.mkdir(base_dir)
+    save_dir = os.path.join(base_dir) # TMP
+    os.makedirs(save_dir) # TMP
+    for proc in PROC_LST:
+        print("proc:",proc)
+        ##os.mkdir(os.path.join(base_dir,proc))
+        #for njets in [4,5,6,7]:
+        #for njets in [2,3,4,5]:
+        for njets in [2,3,4]:
+            print("njets:",njets)
+            ##save_dir = os.path.join(os.path.join(base_dir,proc),"njets"+str(njets))
+            ##os.mkdir(save_dir)
+            quad_wrapper(proc,njets,save_dir) # Run the wrapper
+            make_html(save_dir)
+    '''
+
+    # Make a single set of plots
+    #os.mkdir("tmp_quad_fits")
+    quad_wrapper("ttH",4,"tmp_quad_fits")
+
+
+main()

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -12,6 +12,22 @@
 #     - That dictionary that we import is a global variable called IN_DICT in the script
 #     - Note that so far this script assumes the templates are just njets (i.e. none of the naming and conventions etc. are 
 #       currently set up to work with e.g. bins in lj0pt)
+
+# Some notes on the naming conventions for the decomposed and reconstructed quadratic parameterization
+# This is based on Eqn 5 of CMS AN-20-204 ("EFT model for SMP measurements")
+# The terms of the quadratic are: S, L, Q, M, and the decomposed terms in the template dict are defines as follows:
+#     sm       = S
+#     quad_i   = Qi
+#     lin_i    = S + Li + Qi
+#     mixed_ij = S + Li + Lj + Qi + Qj + 2Mij
+# Thus, to reconstruct the quadratic parameterization, we need the following combinations of decomposed terms:
+#     S    = sm
+#     Qi   = quad_i
+#     Li   = lin_i - S - Qi 
+#          = lin_i - sm - quad_i
+#     2Mij = mixed_ij - S - Qi - Qj - Li - Lj
+#          = mixed_ij - sm - quad_i - quad_j - (lin_i - S - Qi) - (lin_j - sm - quad_j)
+
 # To run this script:
 #     - The script is currently very basic and hard coded
 #     - The inputs dictionary is hardcoded, also where to save the output plots is hard coded
@@ -42,7 +58,8 @@ def get_wc_lst_for_proc(proc,all_decomp_terms):
     for decomp_term in all_decomp_terms.keys():
         if proc not in decomp_term: continue
         for wc in WC_LST:
-            if wc in decomp_term:
+            substr_lst = decomp_term.split("_")
+            if wc in substr_lst:
                 if wc not in proc_lst:
                     proc_lst.append(wc)
     return proc_lst
@@ -78,7 +95,9 @@ def get_decomp_term_sm(decomp_lst):
     for decomp_term_name in decomp_lst:
         if "sm" in decomp_term_name:
             ret = decomp_term_name
-    if ret is None: raise Exception("Error, no sm term found")
+    if ret is None:
+        print(f"\nError: Can't find term for wc \"{wc}\" in this list of terms: {decomp_lst}")
+        raise Exception("Error, no sm term found")
     else: return ret
 
 # Get lin term (lin = S + Li + Qi)
@@ -89,7 +108,7 @@ def get_decomp_term_lin(decomp_lst,wc):
         if ("lin" in decomp_term_name) and (wc in substr_lst):
             ret = decomp_term_name
     if ret is None:
-        print(wc,decomp_lst)
+        print(f"\nError: Can't find term for wc \"{wc}\" in this list of terms: {decomp_lst}")
         raise Exception("Error, no lin term found")
     else: return ret
 
@@ -100,7 +119,9 @@ def get_decomp_term_quad(decomp_lst,wc):
         substr_lst = decomp_term_name.split("_")
         if ("quad" in decomp_term_name) and ("mix" not in decomp_term_name) and (wc in substr_lst):
             ret = decomp_term_name
-    if ret is None: raise Exception("Error, no mixed term found")
+    if ret is None:
+        print(f"\nError: Can't find term for wc \"{wc}\" in this list of terms: {decomp_lst}")
+        raise Exception("Error, no mixed term found")
     else: return ret
 
 # Get mix term (mix = S + Li + lj + Qi + Qj + 2Mij)
@@ -110,7 +131,9 @@ def get_decomp_term_mix(decomp_lst,wc0,wc1):
         substr_lst = decomp_term_name.split("_")
         if ("mix" in decomp_term_name) and (wc0 in substr_lst) and (wc1 in substr_lst):
             ret = decomp_term_name
-    if ret is None: raise Exception("Error, no mixed term found")
+    if ret is None:
+        print(f"\nError: Can't find term for wc \"{wc}\" in this list of terms: {decomp_lst}")
+        raise Exception("Error, no mixed term found")
     else: return ret
 
 

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -30,10 +30,7 @@ IN_DICT = q.p
 
 
 PROC_LST = [ "ttH", "ttlnu", "ttll", "tllq", "tHq", "tttt" ]
-#WC_LST = ['ctW','ctZ','ctp','cpQM','ctG','cbW','cpQ3','cptb','cpt','cQl3i','cQlMi','cQei','ctli','ctei','ctlSi','ctlTi', 'cQq13', 'cQq83', 'cQq11', 'ctq1', 'cQq81', 'ctq8', 'ctt1', 'cQQ1', 'cQt8', 'cQt1']
-#WC_LST = ['ctG','ctq8']
-#WC_LST = ['cpt']
-WC_LST = ['ctZ','cpt']
+WC_LST = ['ctW','ctZ','ctp','cpQM','ctG','cbW','cpQ3','cptb','cpt','cQl3i','cQlMi','cQei','ctli','ctei','ctlSi','ctlTi', 'cQq13', 'cQq83', 'cQq11', 'ctq1', 'cQq81', 'ctq8', 'ctt1', 'cQQ1', 'cQt8', 'cQt1']
 
 # Get WC lst for each process
 def get_wc_lst_for_proc(proc,all_decomp_terms):
@@ -175,7 +172,7 @@ def get_fit_param_val_dict(quad_term_name_lst,decomp_terms_lst):
 
 
 # Main wrapper to read the values and make plots
-def quad_wrapper(proc,njets,save_path="quad_fits",shift=None):
+def quad_wrapper(proc,njets,save_path="quad_fits"):
 
     wc_lst_for_proc = get_wc_lst_for_proc(proc,IN_DICT)
 
@@ -196,35 +193,34 @@ def quad_wrapper(proc,njets,save_path="quad_fits",shift=None):
         #proc_fit_dict[sys_var] = qft.scale_to_sm(proc_fit_dict[sys_var]) # If we want to scale to sm
 
     wcpt = {
-        #"ctW": -0.74,
-        #"ctZ": -0.86,
-        #"ctp": 24.5,
-        #"cpQM": -0.27,
-        #"ctG": -0.81,
-        #"cbW": 3.03,
-        #"cpQ3": -1.71,
-        #"cptb": 0.13,
-        #"cpt": -3.72,
-        #"cQl3i": -4.47,
-        #"cQlMi": 0.51,
-        #"cQei": 0.05,
-        #"ctli": 0.33,
-        #"ctei": 0.33,
-        #"ctlSi": -0.07,
-        #"ctlTi": -0.01,
-        #"cQq13"  : -0.05,
-        #"cQq83"  : -0.15,
-        #"cQq11"  : -0.15,
-        #"ctq1"   : -0.20,
-        #"cQq81"  : -0.50,
-        #"ctq8"   : -0.50,
-        #"ctt1"   : -0.71,
-        #"cQQ1"   : -1.35,
-        #"cQt8"   : -2.89,
-        #"cQt1"   : -1.24,
-
+        "ctW": -0.74,
+        "ctZ": -0.86,
+        "ctp": 24.5,
+        "cpQM": -0.27,
+        "ctG": -0.81,
+        "cbW": 3.03,
+        "cpQ3": -1.71,
+        "cptb": 0.13,
+        "cpt": -3.72,
+        "cQl3i": -4.47,
+        "cQlMi": 0.51,
+        "cQei": 0.05,
+        "ctli": 0.33,
+        "ctei": 0.33,
+        "ctlSi": -0.07,
+        "ctlTi": -0.01,
+        "cQq13"  : -0.05,
+        "cQq83"  : -0.15,
+        "cQq11"  : -0.15,
+        "ctq1"   : -0.20,
+        "cQq81"  : -0.50,
+        "ctq8"   : -0.50,
+        "ctt1"   : -0.71,
+        "cQQ1"   : -1.35,
+        "cQt8"   : -2.89,
+        "cQt1"   : -1.24,
     }
-    wcpt = {"ctZ":-5.0,"cpt":3.0}
+    #wcpt = {"ctZ":-5.0,"cpt":3.0,"cptb":55.5}
     #wcpt = {"ctZ":-5.0}
     #wcpt = {"cpt":3.0}
     print(proc_fit_dict["nom"])
@@ -245,7 +241,6 @@ def quad_wrapper(proc,njets,save_path="quad_fits",shift=None):
             title = plot_name,
             xaxis_range = qft.FIT_RANGES[wc],
             save_dir = save_path,
-            shift_var = shift,
         )
 
 

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -4,7 +4,8 @@ import topcoffea.modules.QuadFitTools as qft
 from topcoffea.plotter.make_html import make_html
 
 # Load the in dict
-#import tmp_quad as q
+#import tmp as q
+#IN_DICT = q.p
 #IN_DICT = q.fit_pieces_dict
 #import decomp_fit_terms_test as q
 #IN_DICT = q.decomp_terms_in_dict
@@ -148,7 +149,8 @@ def get_param_value(quad_term,decomp_term_name_lst):
         val_quad0 = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc0)]
         val_quad1 = IN_DICT[get_decomp_term_quad(decomp_term_name_lst,wc1)]
 
-        val_ret = (val_mix - val_sm - (val_lin0 - val_sm - val_quad0) - (val_lin1 - val_sm - val_quad1) - val_quad0 - val_quad1)/2.0
+        # Note, don't divide by 2 here (since we don't keep e.g. ctG*ctp and ctp*ctG, the ctG*ctp term needs the factor of 2)
+        val_ret = val_mix - val_sm - (val_lin0 - val_sm - val_quad0) - (val_lin1 - val_sm - val_quad1) - val_quad0 - val_quad1
 
     # looking for the L term
     else:
@@ -220,9 +222,6 @@ def quad_wrapper(proc,njets,save_path="quad_fits"):
         "cQt8"   : -2.89,
         "cQt1"   : -1.24,
     }
-    #wcpt = {"ctZ":-5.0,"cpt":3.0,"cptb":55.5}
-    #wcpt = {"ctZ":-5.0}
-    #wcpt = {"cpt":3.0}
     print(proc_fit_dict["nom"])
     print(qft.eval_fit(proc_fit_dict["nom"],wcpt))
     exit()

--- a/analysis/topEFT/make_cr_and_sr_plots.py
+++ b/analysis/topEFT/make_cr_and_sr_plots.py
@@ -251,7 +251,7 @@ def make_cr_fig(h_mc,h_data,unit_norm_bool,set_x_lim=None):
 # Takes a hist with one sparse axis and one dense axis, overlays everything on the sparse axis
 def make_single_fig(histo,unit_norm_bool):
     #print("\nPlotting values:",histo.values())
-    fig, ax = plt.subplots(1, 1, figsize=(11,7))
+    fig, ax = plt.subplots(1, 1, figsize=(7,7))
     hist.plot1d(
         histo,
         stack=False,
@@ -259,6 +259,50 @@ def make_single_fig(histo,unit_norm_bool):
         clear=False,
     )
     ax.autoscale(axis='y')
+    return fig
+
+# Takes a hist with one sparse axis (axis_name) and one dense axis, overlays everything on the sparse axis
+# Makes a ratio of each cateogory on the sparse axis with respect to ref_cat
+def make_single_fig_with_ratio(histo,axis_name,cat_ref):
+
+    # Create the figure
+    fig, (ax, rax) = plt.subplots(
+        nrows=2,
+        ncols=1,
+        figsize=(7,7),
+        gridspec_kw={"height_ratios": (3, 1)},
+        sharex=True
+    )
+    fig.subplots_adjust(hspace=.07)
+
+    # Make the main plot
+    hist.plot1d(
+        histo,
+        ax=ax,
+        stack=False,
+        clear=False,
+    )
+
+    # Make the ratio plot
+    for cat_name in yt.get_cat_lables(histo,axis_name):
+        #h = histo.copy()
+        hist.plotratio(
+            #num = h.integrate(axis_name,cat_name),
+            #denom = h.integrate(axis_name,cat_ref),
+            num = histo.integrate(axis_name,cat_name),
+            denom = histo.integrate(axis_name,cat_ref),
+            ax = rax,
+            unc = 'num',
+            error_opts= {'linestyle': 'none','marker': '.', 'markersize': 10, 'elinewidth': 0},
+            clear = False,
+        )
+
+    # Style
+    ax.set_xlabel('')
+    rax.axhline(1.0,linestyle="-",color="k",linewidth=1)
+    rax.set_ylabel('Ratio')
+    rax.autoscale(axis='y')
+
     return fig
 
 ###################### Wrapper function for example SR plots with systematics ######################
@@ -332,7 +376,8 @@ def make_all_sr_sys_plots(dict_of_hists,year,unit_norm_bool,save_dir_path):
                 hist_sig_grouped_tmp = hist_sig_grouped_tmp.integrate("channel",grouped_hist_cat)
 
                 # Make plots
-                fig = make_single_fig(hist_sig_grouped_tmp,unit_norm_bool)
+                #fig = make_single_fig(hist_sig_grouped_tmp,unit_norm_bool)
+                fig = make_single_fig_with_ratio(hist_sig_grouped_tmp,"systematic","nominal")
                 title = proc_name+"_"+grouped_hist_cat+"_"+var_name
                 if unit_norm_bool: title = title + "_unitnorm"
                 fig.savefig(os.path.join(save_dir_path_tmp,title))

--- a/analysis/topEFT/make_cr_and_sr_plots.py
+++ b/analysis/topEFT/make_cr_and_sr_plots.py
@@ -332,11 +332,13 @@ def make_single_fig_with_ratio(histo,axis_name,cat_ref):
 
     return fig
 
+
+
 ###################### Wrapper function for example SR plots with systematics ######################
 # Wrapper function to loop over all SR categories and make plots for all variables
 # Right now this function will only plot the signal samples
 # By default, will make plots that show all systematics in the pkl file
-def make_all_sr_sys_plots(dict_of_hists,year,unit_norm_bool,save_dir_path):
+def make_all_sr_sys_plots(dict_of_hists,year,save_dir_path):
 
     # If selecting a year, append that year to the wight list
     sig_wl = ["private"]
@@ -379,6 +381,13 @@ def make_all_sr_sys_plots(dict_of_hists,year,unit_norm_bool,save_dir_path):
             sample_lumi_dict[sample_name] = get_lumi_for_sample(sample_name)
         hist_sig.scale(sample_lumi_dict,axis="sample")
 
+        # If we only want to look at a subset of the systematics (Probably should be an option? For now, just uncomment if you want to use it)
+        syst_subset_dict = {
+            "nominal":["nominal"],
+            "renormfactUp":["renormfactUp"],"renormfactDown":["renormfactDown"],
+        }
+        #hist_sig  = group_bins(hist_sig,syst_subset_dict,"systematic",drop_unspecified=True)
+
         # Make plots for each process
         for proc_name in sig_sample_lst:
 
@@ -399,17 +408,17 @@ def make_all_sr_sys_plots(dict_of_hists,year,unit_norm_bool,save_dir_path):
                 hist_sig_grouped_tmp = hist_sig_grouped_tmp.integrate("sample",proc_name)
                 hist_sig_grouped_tmp = hist_sig_grouped_tmp.integrate("channel",grouped_hist_cat)
 
-                # Reweight
+                # Reweight (Probably should be an option? For now, just uncomment if you want to use it)
                 #hist_sig_grouped_tmp.set_wilson_coefficients(**WCPT)
 
                 # Make plots
                 fig = make_single_fig_with_ratio(hist_sig_grouped_tmp,"systematic","nominal")
                 title = proc_name+"_"+grouped_hist_cat+"_"+var_name
-                if unit_norm_bool: title = title + "_unitnorm"
                 fig.savefig(os.path.join(save_dir_path_tmp,title))
 
             # Make an index.html file if saving to web area
             if "www" in save_dir_path_tmp: make_html(save_dir_path_tmp)
+
 
 
 ###################### Wrapper function for example SR plots ######################
@@ -684,7 +693,7 @@ def main():
     # Make the plots
     #make_all_cr_plots(hin_dict,args.year,unit_norm_bool,save_dir_path)
     #make_all_sr_plots(hin_dict,args.year,unit_norm_bool,save_dir_path)
-    make_all_sr_sys_plots(hin_dict,args.year,unit_norm_bool,save_dir_path)
+    make_all_sr_sys_plots(hin_dict,args.year,save_dir_path)
 
 if __name__ == "__main__":
     main()

--- a/analysis/topEFT/make_cr_and_sr_plots.py
+++ b/analysis/topEFT/make_cr_and_sr_plots.py
@@ -89,7 +89,7 @@ CR_GRP_MAP = {
 
 # Best fit point from TOP-19-001 with madup numbers for the 10 new WCs
 WCPT_EXAMPLE = {
-   "ctW": -0.74,
+    "ctW": -0.74,
     "ctZ": -0.86,
     "ctp": 24.5,
     "cpQM": -0.27,
@@ -409,7 +409,7 @@ def make_all_sr_sys_plots(dict_of_hists,year,save_dir_path):
                 hist_sig_grouped_tmp = hist_sig_grouped_tmp.integrate("channel",grouped_hist_cat)
 
                 # Reweight (Probably should be an option? For now, just uncomment if you want to use it)
-                #hist_sig_grouped_tmp.set_wilson_coefficients(**WCPT)
+                #hist_sig_grouped_tmp.set_wilson_coefficients(**WCPT_EXAMPLE)
 
                 # Make plots
                 fig = make_single_fig_with_ratio(hist_sig_grouped_tmp,"systematic","nominal")
@@ -691,9 +691,9 @@ def main():
     #exit()
 
     # Make the plots
-    #make_all_cr_plots(hin_dict,args.year,unit_norm_bool,save_dir_path)
+    make_all_cr_plots(hin_dict,args.year,unit_norm_bool,save_dir_path)
     #make_all_sr_plots(hin_dict,args.year,unit_norm_bool,save_dir_path)
-    make_all_sr_sys_plots(hin_dict,args.year,save_dir_path)
+    #make_all_sr_sys_plots(hin_dict,args.year,save_dir_path)
 
 if __name__ == "__main__":
     main()

--- a/analysis/topEFT/make_cr_and_sr_plots.py
+++ b/analysis/topEFT/make_cr_and_sr_plots.py
@@ -276,8 +276,8 @@ def make_all_sr_plots(dict_of_hists,year,unit_norm_bool,save_dir_path,split_by_c
     elif year == "2016": sig_wl.append("UL16") # NOTE: Right now this will plot both UL16 an UL16APV
     else: raise Exception
 
-    # Get the list of samples to actually plot
-    all_samples = yt.get_cat_lables(dict_of_hists,"sample")
+    # Get the list of samples to actually plot (finding sample list from first hist in the dict)
+    all_samples = yt.get_cat_lables(dict_of_hists,"sample",h_name=yt.get_hist_list(dict_of_hists)[0])
     sig_sample_lst = filter_lst_of_strs(all_samples,substr_whitelist=sig_wl)
     if len(sig_sample_lst) == 0: raise Exception("Error: No signal samples to plot.")
     samples_to_rm_from_sig_hist = []
@@ -349,7 +349,7 @@ def make_all_sr_plots(dict_of_hists,year,unit_norm_bool,save_dir_path,split_by_c
                 hist_sig_grouped = group_bins(hist_sig,sr_cat_dict,"channel",drop_unspecified=True)
 
                 # Make the plots
-                for grouped_hist_cat in yt.get_cat_lables(hist_sig_grouped,"channel"):
+                for grouped_hist_cat in yt.get_cat_lables(hist_sig_grouped,axis="channel",h_name=var_name):
 
                     # Integrate
                     hist_sig_grouped_tmp = copy.deepcopy(hist_sig_grouped)
@@ -525,7 +525,7 @@ def main():
     os.mkdir(save_dir_path)
 
     # Get the histograms
-    hin_dict = yt.get_hist_from_pkl(args.pkl_file_path)
+    hin_dict = yt.get_hist_from_pkl(args.pkl_file_path,allow_empty=False)
 
     # Print info about histos
     #yt.print_hist_info(args.pkl_file_path,"nbtagsl")

--- a/analysis/topEFT/make_cr_and_sr_plots.py
+++ b/analysis/topEFT/make_cr_and_sr_plots.py
@@ -87,6 +87,36 @@ CR_GRP_MAP = {
     "Data" : [],
 }
 
+# Best fit point from TOP-19-001 with madup numbers for the 10 new WCs
+WCPT_EXAMPLE = {
+   "ctW": -0.74,
+    "ctZ": -0.86,
+    "ctp": 24.5,
+    "cpQM": -0.27,
+    "ctG": -0.81,
+    "cbW": 3.03,
+    "cpQ3": -1.71,
+    "cptb": 0.13,
+    "cpt": -3.72,
+    "cQl3i": -4.47,
+    "cQlMi": 0.51,
+    "cQei": 0.05,
+    "ctli": 0.33,
+    "ctei": 0.33,
+    "ctlSi": -0.07,
+    "ctlTi": -0.01,
+    "cQq13"  : -0.05,
+    "cQq83"  : -0.15,
+    "cQq11"  : -0.15,
+    "ctq1"   : -0.20,
+    "cQq81"  : -0.50,
+    "ctq8"   : -0.50,
+    "ctt1"   : -0.71,
+    "cQQ1"   : -1.35,
+    "cQt8"   : -2.89,
+    "cQt1"   : -1.24,
+}
+
 
 yt = YieldTools()
 
@@ -285,10 +315,7 @@ def make_single_fig_with_ratio(histo,axis_name,cat_ref):
 
     # Make the ratio plot
     for cat_name in yt.get_cat_lables(histo,axis_name):
-        #h = histo.copy()
         hist.plotratio(
-            #num = h.integrate(axis_name,cat_name),
-            #denom = h.integrate(axis_name,cat_ref),
             num = histo.integrate(axis_name,cat_name),
             denom = histo.integrate(axis_name,cat_ref),
             ax = rax,
@@ -333,7 +360,7 @@ def make_all_sr_sys_plots(dict_of_hists,year,unit_norm_bool,save_dir_path):
     # Loop over hists and make plots
     skip_lst = [] # Skip this hist
     for idx,var_name in enumerate(dict_of_hists.keys()):
-        #if yt.is_split_by_lepflav(dict_of_hists): raise Exception("Not set up to plot lep flav for SR, though could probably do it without too much work")
+        if yt.is_split_by_lepflav(dict_of_hists): raise Exception("Not set up to plot lep flav for SR, though could probably do it without too much work")
         if (var_name in skip_lst): continue
         if (var_name == "njets"):
             # We do not keep track of jets in the sparse axis for the njets hists
@@ -363,9 +390,6 @@ def make_all_sr_sys_plots(dict_of_hists,year,unit_norm_bool,save_dir_path):
             # Group categories
             hist_sig_grouped = group_bins(hist_sig,sr_cat_dict,"channel",drop_unspecified=True)
 
-            #print(hist_sig_grouped.values())
-            #exit()
-
             # Make the plots
             for grouped_hist_cat in yt.get_cat_lables(hist_sig_grouped,axis="channel",h_name=var_name):
 
@@ -375,8 +399,10 @@ def make_all_sr_sys_plots(dict_of_hists,year,unit_norm_bool,save_dir_path):
                 hist_sig_grouped_tmp = hist_sig_grouped_tmp.integrate("sample",proc_name)
                 hist_sig_grouped_tmp = hist_sig_grouped_tmp.integrate("channel",grouped_hist_cat)
 
+                # Reweight
+                #hist_sig_grouped_tmp.set_wilson_coefficients(**WCPT)
+
                 # Make plots
-                #fig = make_single_fig(hist_sig_grouped_tmp,unit_norm_bool)
                 fig = make_single_fig_with_ratio(hist_sig_grouped_tmp,"systematic","nominal")
                 title = proc_name+"_"+grouped_hist_cat+"_"+var_name
                 if unit_norm_bool: title = title + "_unitnorm"

--- a/topcoffea/modules/QuadFitTools.py
+++ b/topcoffea/modules/QuadFitTools.py
@@ -108,7 +108,7 @@ def get_shifted_arr(y_arr_1,y_arr_2,x_arr,shift_factor):
     return shift_arr
 
 # Make a 1d plot
-def make_1d_quad_plot(quad_params_dict,xaxis_name,yaxis_name,title,xaxis_range=[-10,10],save_dir=".",shift_var=None):
+def make_1d_quad_plot(quad_params_dict,xaxis_name,yaxis_name,title,xaxis_range=[-10,10],save_dir="."):
 
     # Get a string of the fit equation
     def get_fit_str(tag,xvar,s0,s1,s2):
@@ -147,20 +147,6 @@ def make_1d_quad_plot(quad_params_dict,xaxis_name,yaxis_name,title,xaxis_range=[
         ymin = min(ymin,min(y_arr))
 
         quad_arr_dict[key_name] = [x_arr,y_arr]
-
-    # Get shifted up/down array (if using this to plot nom/up/down)
-    # Note: We can only do this if pass exactly three sets of quad params corresponding to nom, up, down
-    if shift_var != None:
-        if (len(quad_params_dict) !=3) or ("nom" not in quad_params_dict.keys()) or ("up" not in quad_params_dict.keys()) or ("down" not in quad_params_dict.keys()):
-            raise Exception("Cannot plot shifted up/down variations, do not have the right info in quad_params_dict.")
-        up_shift_str = "up"+str(shift_var)
-        do_shift_str = "down"+str(shift_var)
-        quad_arr_dict[up_shift_str] = {}
-        quad_arr_dict[do_shift_str] = {}
-        quad_arr_dict[up_shift_str][0] = quad_arr_dict["nom"][0]
-        quad_arr_dict[do_shift_str][0] = quad_arr_dict["nom"][0]
-        quad_arr_dict[up_shift_str][1] = get_shifted_arr(quad_arr_dict["up"][1],quad_arr_dict["nom"][1],quad_arr_dict["nom"][0],shift_var)
-        quad_arr_dict[do_shift_str][1] = get_shifted_arr(quad_arr_dict["down"][1],quad_arr_dict["nom"][1],quad_arr_dict["nom"][0],shift_var)
 
     # Loop over arr dict and make plots
     for key_name, quad_arr in quad_arr_dict.items():
@@ -269,7 +255,7 @@ def eval_fit(fit_dict,wcpt_dict):
             if wc1 == "sm":
                 wc1_val = 1.0
             else:
-                print(f"WARNING: No value specified for WC {wc}. Setting it to 0.")
+                print(f"WARNING: No value specified for WC {wc1}. Setting it to 0.")
                 wc1_val = 0.0
         else:
             wc1_val = wcpt_dict[wc1]
@@ -277,7 +263,7 @@ def eval_fit(fit_dict,wcpt_dict):
             if wc2 == "sm":
                 wc2_val = 1.0
             else:
-                print(f"WARNING: No value specified for WC {wc}. Setting it to 0.")
+                print(f"WARNING: No value specified for WC {wc2}. Setting it to 0.")
                 wc2_val = 0.0
         else:
             wc2_val = wcpt_dict[wc2]

--- a/topcoffea/modules/QuadFitTools.py
+++ b/topcoffea/modules/QuadFitTools.py
@@ -80,11 +80,27 @@ ARXIV1901_LIMS = {
     "cQt8" : [-12.0,10.0]
 }
 
+FIT_RANGES = {  
+    'ctW':(-4,4),     'ctZ':(-5,5),
+    'cpt':(-40,30),   'ctp':(-35,65),
+    'ctli':(-10,10),  'ctlSi':(-10,10),
+    'cQl3i':(-10,10), 'cptb':(-20,20),
+    'ctG':(-2,2),     'cpQM':(-10,30),
+    'ctlTi':(-2,2),   'ctei':(-10,10),
+    'cQei':(-10,10),  'cQlMi':(-10,10),
+    'cpQ3':(-15,10),  'cbW':(-5,5),
+    'cQq13': (-1,1),  'cQq83': (-2,2),
+    'cQq11': (-2,2),  'ctq1': (-2,2),
+    'cQq81': (-5,5),  'ctq8': (-5,5),
+    'ctt1': (-5,5),   'cQQ1': (-10,10),
+    'cQt8': (-20,20), 'cQt1': (-10,10)
+}
+
 
 ########## Plotting tools ##########
 
-#def make_1d_quad_plot(s0,s1,s2,tag,x_lims=[-10,10],,x_axis_name,y_axis_name):
-def make_1d_quad_plot(quad_params,xaxis_name,yaxis_name,title,xaxis_range=[-10,10],save_dir="."):
+# Make a 1d plot
+def make_1d_quad_plot(quad_params_dict,xaxis_name,yaxis_name,title,xaxis_range=[-10,10],save_dir="."):
 
     # Get a string of the fit equation
     def get_fit_str(tag,xvar,s0,s1,s2):
@@ -93,17 +109,6 @@ def make_1d_quad_plot(quad_params,xaxis_name,yaxis_name,title,xaxis_range=[-10,1
         s2 = str(round(s2,2))
         rstr = f"{tag}: {s0} + {s1}*{xvar} + {s2}*{xvar}$^2$"
         return rstr
-
-    # Get the quad fit params from the list
-    if len(quad_params) != 3:
-        raise Exception(f"Error: Wrong number of parameters specified for 1d quadratic. Require 3, received {len(quad_params)}.")
-    s0 = quad_params[0] 
-    s1 = quad_params[1]
-    s2 = quad_params[2]
-
-    # Find x and y points
-    x_arr = np.linspace(xaxis_range[0], xaxis_range[1], 1000)
-    y_arr = s0 + s1*x_arr + s2*x_arr*x_arr
 
     # Make the figure
     fig, ax = plt.subplots(nrows=1, ncols=1)
@@ -114,12 +119,35 @@ def make_1d_quad_plot(quad_params,xaxis_name,yaxis_name,title,xaxis_range=[-10,1
     ax.set_ylabel(yaxis_name)
     ax.set_title(title)
 
+    # Loop over all of the fits we want to plot
+    ymax = 0
+    ymin = 99999999
+    for key_name, quad_params in quad_params_dict.items():
+
+        # Get the quad fit params from the list
+        if len(quad_params) != 3:
+            raise Exception(f"Error: Wrong number of parameters specified for 1d quadratic. Require 3, received {len(quad_params)}.")
+        s0 = quad_params[0] 
+        s1 = quad_params[1]
+        s2 = quad_params[2]
+
+        # Find x and y points
+        x_arr = np.linspace(xaxis_range[0], xaxis_range[1], 1000)
+        y_arr = s0 + s1*x_arr + s2*x_arr*x_arr
+
+        # Plot the points
+        if key_name != "none": tag = key_name + " "
+        else: tag = ""
+        ax.plot(x_arr,y_arr,label=get_fit_str(tag+"fit",xaxis_name,s0,s1,s2))
+
+        # Keep track of overall max y
+        ymax = max(ymax,max(y_arr))
+        ymin = min(ymin,min(y_arr))
+
     # Set x and y ranges (just use default for y unless it's really tiny)
-    if (max(y_arr)-min(y_arr))<1e-6: ax.set_ylim([0.0,1.5])
+    if ((ymax-ymin)<1e-6): ax.set_ylim([0.0,1.5])
     ax.set_xlim(xaxis_range)
 
-    # Plot the points
-    ax.plot(x_arr,y_arr,label=get_fit_str("fit",xaxis_name,s0,s1,s2))
     #ax.plot(x_arr,y_arr,label="TEST")
     ax.legend()
 

--- a/topcoffea/modules/QuadFitTools.py
+++ b/topcoffea/modules/QuadFitTools.py
@@ -97,6 +97,19 @@ FIT_RANGES = {
 }
 
 
+########## General tools ##########
+
+# Construct a list of key strings (e.g. "ctG*ctp") for a quad fit dict for a given list of WCs
+def get_quad_keys(wc_lst):
+    quad_terms_lst = []
+    if "sm" not in wc_lst: wc_lst = ["sm"] + wc_lst
+    for i,wc_row in enumerate(wc_lst):
+        for j,wc_col in enumerate(wc_lst):
+            if j>i: continue
+            quad_terms_lst.append(wc_row+"*"+wc_col)
+    return quad_terms_lst
+
+
 ########## Plotting tools ##########
 
 # Takes two arrays and returnes a shifted differences

--- a/topcoffea/modules/YieldTools.py
+++ b/topcoffea/modules/YieldTools.py
@@ -5,7 +5,7 @@ import numpy as np
 import copy
 import coffea
 from coffea import hist
-#from topcoffea.modules.HistEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.GetValuesFromJsons import get_lumi
 
@@ -195,23 +195,26 @@ class YieldTools():
     # Takes a hist dictionary (i.e. from the pkl file that the processor makes) and an axis name, returns the list of categories for that axis. Defaults to 'njets' histogram if none given.
     def get_cat_lables(self,hin_dict,axis,h_name=None):
 
-        # If no hist specified, just choose the first one
-        if h_name is None:
-            all_hists = self.get_hist_list(hin_dict)
-            for h in all_hists:
-                if h != "SumOfEFTweights":
-                    h_name = h
-                    break
+        # If the hin is not a histo, then get one of the histos from inside of it
+        if not isinstance(hin_dict,HistEFT):
 
-            # If we failed to find a hist, raise exception
+            # If no hist specified, just choose the first one
             if h_name is None:
-                raise Exception("There are no hists in this hist dict")
+                all_hists = self.get_hist_list(hin_dict)
+                for h in all_hists:
+                    if h != "SumOfEFTweights":
+                        h_name = h
+                        break
 
-        # Chek if what we have is the output of the processsor, if so, get a specific hist from it
-        if isinstance(hin_dict,coffea.processor.accumulator.dict_accumulator):
-            hin_dict = hin_dict[h_name]
-        elif isinstance(hin_dict,dict):
-            hin_dict = hin_dict[h_name]
+                # If we failed to find a hist, raise exception
+                if h_name is None:
+                    raise Exception("There are no hists in this hist dict")
+
+            # Chek if what we have is the output of the processsor, if so, get a specific hist from it
+            if isinstance(hin_dict,coffea.processor.accumulator.dict_accumulator):
+                hin_dict = hin_dict[h_name]
+            elif isinstance(hin_dict,dict):
+                hin_dict = hin_dict[h_name]
 
         # Note: Use h.identifiers('axis') here, not axis.identifiers() (since according to Nick Smith "the axis may hold identifiers longer than the hist that uses it (hists can share axes)", but h.identifiers('axis') will get the ones actually contained in the histogram)
         cats_lst = []

--- a/topcoffea/modules/YieldTools.py
+++ b/topcoffea/modules/YieldTools.py
@@ -265,7 +265,7 @@ class YieldTools():
 
     # This should return true if the hist is split by lep flavor, definitely not a bullet proof check..
     def is_split_by_lepflav(self,hin_dict):
-        ch_names_lst = self.get_cat_lables(hin_dict,h_name="ht",axis="channel")
+        ch_names_lst = self.get_cat_lables(hin_dict,axis="channel")
         lep_flav_lst = ["ee","em","mm","eee","eem","emm","mmm"]
         for ch_name in ch_names_lst:
             for lep_flav_name in lep_flav_lst:


### PR DESCRIPTION
This PR adds some scripts related to looking at various aspects of the systematics. The branch ended up including a lot of different changes that are not entirely related to each other, but here is a summary of the main updates: 
* Unrelated to the main point of this script, this PR fixes a bug in the datacard maker that was affecting the case when we try to specify a single WC. 
* Various updates to the `make_cr_and_sr_plots.py` script to enable us to look at systematics more easily. A function was added (`make_all_sr_sys_plots()`) that is similar to the main function for plotting SR plots, but instead of overlaying processes or channels (as `make_all_sr_sys_plots()` does) this new function overlays the systematic variations. By default, it plots all up/down variations, and includes a ratio plot to compare the up/down to the nominal. 
* Adds a new script called `make_1d_quad_plots_from_template_histos.py` (admittedly, not a great name). This script is designed to reconstruct the quadratic parameterizations based on the decomposed terms in the template histograms. It expects to run on the output dictionary that `EFTFit`'s  new script `look_at_template.C`, reconstructs the quadratic parameterization, and plots the 1d quadratics for all of the WCs (for the nominal, up, and down parameterizations). This script is pretty basic and a bit hard coded (the path to the input dictionary as well as the path to where you want the plots to be saved to are both assumed to be hardcoded in the script) so it could certainly be improved in the future (e.g. adding command line options) but I wanted to push it now so that we will have a place to start from in the future if we want to build on it. 
* Also includes various minor updates to the `YieldTools` and `QuadFitTools` modules. 