### PR TITLE
Fix for datacard column widths

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -684,7 +684,7 @@ class DatacardMaker():
         datacard.write('observation %%.%df\n' % 3 % allyields['data_obs'])
         #datacard.write('observation %%.%df\n' % np.abs(int(np.format_float_scientific(self.tolerance).split('e')[1])) % allyields['data_obs'])
         datacard.write('##----------------------------------\n')
-        klen = max([7, len(cat)]+[len(p[0]) for p in iproc.keys()])
+        klen = max([7, len(cat)]+[len(p) for p in iproc.keys()])
         kpatt = " %%%ds "  % klen
         fpatt = " %%%d.%df " % (klen,np.abs(3))
         #fpatt = " %%%d.%df " % (klen,np.abs(int(np.format_float_scientific(self.tolerance).split('e')[1])))#3)


### PR DESCRIPTION
This is a very simple update that fixes the calculation of the `klen` variable to correctly take into account the length of the process string lengths.

Without this change, any datacard which had a process name that was longer than the longest bin name would result in a misalignment of the datacard columns, making the card nearly impossible to read/inspect.