### PR TITLE
Update private mc skim json files to include systematic weight info

### DIFF
--- a/topcoffea/json/signal_samples/private_UL/UL16APV_tHq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16APV_tHq_b1_NDSkim.json
@@ -37,5 +37,15 @@
   "nGenEvents": 15024000,
   "nSumOfWeights": 1047.8200353061318,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 1047.6633221890665,
+  "nSumOfWeights_ISRDown": 1047.7980882443821,
+  "nSumOfWeights_FSRUp": 1048.2891072495843,
+  "nSumOfWeights_FSRDown": 1047.7193594258194,
+  "nSumOfWeights_renormUp": 943.648854891888,
+  "nSumOfWeights_renormDown": 1179.8558701467277,
+  "nSumOfWeights_factUp": 973.4571851435986,
+  "nSumOfWeights_factDown": 1133.4534464223548,
+  "nSumOfWeights_renormfactUp": 876.9466158147894,
+  "nSumOfWeights_renormfactDown": 1276.7404114161852
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16APV_tllq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16APV_tllq_b1_NDSkim.json
@@ -64,5 +64,15 @@
   "nGenEvents": 15012000,
   "nSumOfWeights": 968.1314884591317,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 967.9384107826786,
+  "nSumOfWeights_ISRDown": 968.1640891611421,
+  "nSumOfWeights_FSRUp": 968.1176256196253,
+  "nSumOfWeights_FSRDown": 968.1242953985807,
+  "nSumOfWeights_renormUp": 867.7352055839159,
+  "nSumOfWeights_renormDown": 1096.2288463733787,
+  "nSumOfWeights_factUp": 901.9947784447556,
+  "nSumOfWeights_factDown": 1041.3950679990098,
+  "nSumOfWeights_renormfactUp": 808.3453014342165,
+  "nSumOfWeights_renormfactDown": 1178.9060386455237
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16APV_ttHJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16APV_ttHJet_b1_NDSkim.json
@@ -45,5 +45,15 @@
   "nGenEvents": 40553247,
   "nSumOfWeights": 19785.47263917102,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 18967.60249578278,
+  "nSumOfWeights_ISRDown": 20469.200852376005,
+  "nSumOfWeights_FSRUp": 19775.549871002506,
+  "nSumOfWeights_FSRDown": 19793.97759654991,
+  "nSumOfWeights_renormUp": 16850.634933713853,
+  "nSumOfWeights_renormDown": 23639.128432034326,
+  "nSumOfWeights_factUp": 18329.918618382108,
+  "nSumOfWeights_factDown": 21514.103332255178,
+  "nSumOfWeights_renormfactUp": 15619.637457044058,
+  "nSumOfWeights_renormfactDown": 25718.84618230294
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16APV_ttllJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16APV_ttllJet_b1_NDSkim.json
@@ -66,5 +66,15 @@
   "nGenEvents": 52859975,
   "nSumOfWeights": 10521.302784999827,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 10086.666872174726,
+  "nSumOfWeights_ISRDown": 10884.26135188675,
+  "nSumOfWeights_FSRUp": 10511.807755426518,
+  "nSumOfWeights_FSRDown": 10530.449515024604,
+  "nSumOfWeights_renormUp": 8931.18615993921,
+  "nSumOfWeights_renormDown": 12626.062239999339,
+  "nSumOfWeights_factUp": 9734.63028502166,
+  "nSumOfWeights_factDown": 11450.58126240444,
+  "nSumOfWeights_renormfactUp": 8271.70543676452,
+  "nSumOfWeights_renormfactDown": 13755.101250168987
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16APV_ttlnuJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16APV_ttlnuJet_b1_NDSkim.json
@@ -53,5 +53,15 @@
   "nGenEvents": 31921565,
   "nSumOfWeights": 5765.8911175108615,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 5584.252071186292,
+  "nSumOfWeights_ISRDown": 5912.492069513108,
+  "nSumOfWeights_FSRUp": 5758.844022539202,
+  "nSumOfWeights_FSRDown": 5772.858500106116,
+  "nSumOfWeights_renormUp": 5140.038589203759,
+  "nSumOfWeights_renormDown": 6614.031983178802,
+  "nSumOfWeights_factUp": 5504.33473485083,
+  "nSumOfWeights_factDown": 6053.38479878294,
+  "nSumOfWeights_renormfactUp": 4913.307801886767,
+  "nSumOfWeights_renormfactDown": 6956.174324136703
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16APV_tttt_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16APV_tttt_b1_NDSkim.json
@@ -58,5 +58,15 @@
   "nGenEvents": 15000000,
   "nSumOfWeights": 94.40149244006012,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16APV/Round1/Batch1/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0",
+  "nSumOfWeights_ISRUp": 94.39558463936109,
+  "nSumOfWeights_ISRDown": 94.40429651396407,
+  "nSumOfWeights_FSRUp": 94.60513379371767,
+  "nSumOfWeights_FSRDown": 94.3322387921118,
+  "nSumOfWeights_renormUp": 68.55497440512647,
+  "nSumOfWeights_renormDown": 134.48827259603422,
+  "nSumOfWeights_factUp": 81.82566606200842,
+  "nSumOfWeights_factDown": 110.30210561606927,
+  "nSumOfWeights_renormfactUp": 59.43166404700732,
+  "nSumOfWeights_renormfactDown": 157.1669224692717
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16_tHq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16_tHq_b1_NDSkim.json
@@ -37,5 +37,15 @@
   "nGenEvents": 15018000,
   "nSumOfWeights": 1046.8707148509804,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 1046.6601153056179,
+  "nSumOfWeights_ISRDown": 1046.8816392056444,
+  "nSumOfWeights_FSRUp": 1046.757891827457,
+  "nSumOfWeights_FSRDown": 1047.3014519111687,
+  "nSumOfWeights_renormUp": 942.8211060401992,
+  "nSumOfWeights_renormDown": 1178.7439293908233,
+  "nSumOfWeights_factUp": 972.6336972139882,
+  "nSumOfWeights_factDown": 1132.365693784019,
+  "nSumOfWeights_renormfactUp": 876.2312172630437,
+  "nSumOfWeights_renormfactDown": 1275.4710773820148
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16_tllq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16_tllq_b1_NDSkim.json
@@ -64,5 +64,15 @@
   "nGenEvents": 15024500,
   "nSumOfWeights": 967.7142460240699,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 967.527827093906,
+  "nSumOfWeights_ISRDown": 967.728783389464,
+  "nSumOfWeights_FSRUp": 967.8285617413841,
+  "nSumOfWeights_FSRDown": 967.8171324734537,
+  "nSumOfWeights_renormUp": 867.3533564270484,
+  "nSumOfWeights_renormDown": 1095.769902924701,
+  "nSumOfWeights_factUp": 901.5434529759759,
+  "nSumOfWeights_factDown": 1041.035632507851,
+  "nSumOfWeights_renormfactUp": 807.933868620323,
+  "nSumOfWeights_renormfactDown": 1178.5147980527047
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16_ttHJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16_ttHJet_b1_NDSkim.json
@@ -46,5 +46,15 @@
   "nGenEvents": 40221526,
   "nSumOfWeights": 19783.048406858354,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 18963.342261684415,
+  "nSumOfWeights_ISRDown": 20468.910896015524,
+  "nSumOfWeights_FSRUp": 19764.77698794392,
+  "nSumOfWeights_FSRDown": 19799.417778571238,
+  "nSumOfWeights_renormUp": 16850.79704136955,
+  "nSumOfWeights_renormDown": 23633.3546926989,
+  "nSumOfWeights_factUp": 18327.988010609915,
+  "nSumOfWeights_factDown": 21510.946530796067,
+  "nSumOfWeights_renormfactUp": 15620.223064347532,
+  "nSumOfWeights_renormfactDown": 25712.201174405553
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16_ttllJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16_ttllJet_b1_NDSkim.json
@@ -66,5 +66,15 @@
   "nGenEvents": 52728665,
   "nSumOfWeights": 10524.397853909957,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 10090.487374328715,
+  "nSumOfWeights_ISRDown": 10886.65032626385,
+  "nSumOfWeights_FSRUp": 10518.420743167351,
+  "nSumOfWeights_FSRDown": 10530.090901441572,
+  "nSumOfWeights_renormUp": 8933.928565867747,
+  "nSumOfWeights_renormDown": 12629.654247419629,
+  "nSumOfWeights_factUp": 9737.699834425915,
+  "nSumOfWeights_factDown": 11453.83415319607,
+  "nSumOfWeights_renormfactUp": 8274.428660574464,
+  "nSumOfWeights_renormfactDown": 13758.887484271378
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16_ttlnuJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16_ttlnuJet_b1_NDSkim.json
@@ -53,5 +53,15 @@
   "nGenEvents": 31796588,
   "nSumOfWeights": 5759.2672466085505,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 5577.467340933748,
+  "nSumOfWeights_ISRDown": 5905.898205927548,
+  "nSumOfWeights_FSRUp": 5751.553697238853,
+  "nSumOfWeights_FSRDown": 5766.185008732279,
+  "nSumOfWeights_renormUp": 5133.933944464511,
+  "nSumOfWeights_renormDown": 6606.742495325739,
+  "nSumOfWeights_factUp": 5497.8727573847855,
+  "nSumOfWeights_factDown": 6046.634407644419,
+  "nSumOfWeights_renormfactUp": 4907.3579677341795,
+  "nSumOfWeights_renormfactDown": 6948.758993159174
 }

--- a/topcoffea/json/signal_samples/private_UL/UL16_tttt_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL16_tttt_b1_NDSkim.json
@@ -58,5 +58,15 @@
   "nGenEvents": 14995500,
   "nSumOfWeights": 94.36125901896325,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL16/Round1/Batch1/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0",
+  "nSumOfWeights_ISRUp": 94.37440487634439,
+  "nSumOfWeights_ISRDown": 94.34921875451916,
+  "nSumOfWeights_FSRUp": 94.38038098367981,
+  "nSumOfWeights_FSRDown": 94.33520842058621,
+  "nSumOfWeights_renormUp": 68.52603503751959,
+  "nSumOfWeights_renormDown": 134.42877437110965,
+  "nSumOfWeights_factUp": 81.7928153532927,
+  "nSumOfWeights_factDown": 110.25284079362395,
+  "nSumOfWeights_renormfactUp": 59.407717149845396,
+  "nSumOfWeights_renormfactDown": 157.0934402477121
 }

--- a/topcoffea/json/signal_samples/private_UL/UL17_tHq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL17_tHq_b1_NDSkim.json
@@ -40,5 +40,15 @@
   "nGenEvents": 29672500,
   "nSumOfWeights": 2069.1777662967534,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 2069.0841363858844,
+  "nSumOfWeights_ISRDown": 2068.9095102731817,
+  "nSumOfWeights_FSRUp": 2068.9418498573245,
+  "nSumOfWeights_FSRDown": 2069.228855063705,
+  "nSumOfWeights_renormUp": 1863.5046038079613,
+  "nSumOfWeights_renormDown": 2329.8537192212484,
+  "nSumOfWeights_factUp": 1922.4550399702996,
+  "nSumOfWeights_factDown": 2238.1420432891973,
+  "nSumOfWeights_renormfactUp": 1731.895063818121,
+  "nSumOfWeights_renormfactDown": 2521.0140929646313
 }

--- a/topcoffea/json/signal_samples/private_UL/UL17_tllq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL17_tllq_b1_NDSkim.json
@@ -94,5 +94,15 @@
   "nGenEvents": 29502500,
   "nSumOfWeights": 1902.2880295962273,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 1902.1745497585528,
+  "nSumOfWeights_ISRDown": 1902.0957299499153,
+  "nSumOfWeights_FSRUp": 1902.480456243322,
+  "nSumOfWeights_FSRDown": 1902.6657582754208,
+  "nSumOfWeights_renormUp": 1705.002707536776,
+  "nSumOfWeights_renormDown": 2154.014617774434,
+  "nSumOfWeights_factUp": 1772.3049295587746,
+  "nSumOfWeights_factDown": 2046.2992844474547,
+  "nSumOfWeights_renormfactUp": 1588.280397030305,
+  "nSumOfWeights_renormfactDown": 2316.5324643214894
 }

--- a/topcoffea/json/signal_samples/private_UL/UL17_ttHJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL17_ttHJet_b1_NDSkim.json
@@ -57,5 +57,15 @@
   "nGenEvents": 79248315,
   "nSumOfWeights": 39200.28688784468,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 37580.04048044768,
+  "nSumOfWeights_ISRDown": 40555.484165745846,
+  "nSumOfWeights_FSRUp": 39171.99082226539,
+  "nSumOfWeights_FSRDown": 39222.926792286074,
+  "nSumOfWeights_renormUp": 33384.00492421432,
+  "nSumOfWeights_renormDown": 46837.669170715904,
+  "nSumOfWeights_factUp": 36314.41149828148,
+  "nSumOfWeights_factDown": 42627.3502819377,
+  "nSumOfWeights_renormfactUp": 30943.407609879145,
+  "nSumOfWeights_renormfactDown": 50960.884292852155
 }

--- a/topcoffea/json/signal_samples/private_UL/UL17_ttllJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL17_ttllJet_b1_NDSkim.json
@@ -99,5 +99,15 @@
   "nGenEvents": 102921232,
   "nSumOfWeights": 20854.35035054562,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 19993.13270806095,
+  "nSumOfWeights_ISRDown": 21573.88686294025,
+  "nSumOfWeights_FSRUp": 20839.665415968524,
+  "nSumOfWeights_FSRDown": 20867.735502635303,
+  "nSumOfWeights_renormUp": 17703.478807510288,
+  "nSumOfWeights_renormDown": 25025.072560888348,
+  "nSumOfWeights_factUp": 19295.70204910692,
+  "nSumOfWeights_factDown": 22695.88016335703,
+  "nSumOfWeights_renormfactUp": 16396.853794173698,
+  "nSumOfWeights_renormfactDown": 27262.490255699337
 }

--- a/topcoffea/json/signal_samples/private_UL/UL17_ttlnuJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL17_ttlnuJet_b1_NDSkim.json
@@ -73,5 +73,15 @@
   "nGenEvents": 54263805,
   "nSumOfWeights": 11430.198396718906,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch1/naodOnly_step/v4/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 11070.011751187623,
+  "nSumOfWeights_ISRDown": 11720.95606343879,
+  "nSumOfWeights_FSRUp": 11420.687093358476,
+  "nSumOfWeights_FSRDown": 11439.687658094977,
+  "nSumOfWeights_renormUp": 10188.752463123037,
+  "nSumOfWeights_renormDown": 13112.651245567944,
+  "nSumOfWeights_factUp": 10911.125356872888,
+  "nSumOfWeights_factDown": 12000.840468483206,
+  "nSumOfWeights_renormfactUp": 9738.806445118158,
+  "nSumOfWeights_renormfactDown": 13791.785474389553
 }

--- a/topcoffea/json/signal_samples/private_UL/UL17_tttt_b4_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL17_tttt_b4_NDSkim.json
@@ -78,5 +78,15 @@
   "nGenEvents": 29976500,
   "nSumOfWeights": 188.63581907019665,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch4/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL17/Round1/Batch4/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0",
+  "nSumOfWeights_ISRUp": 188.61251662942968,
+  "nSumOfWeights_ISRDown": 188.646745936205,
+  "nSumOfWeights_FSRUp": 188.63297815491666,
+  "nSumOfWeights_FSRDown": 188.65096892619727,
+  "nSumOfWeights_renormUp": 136.98549114648063,
+  "nSumOfWeights_renormDown": 268.74229606716176,
+  "nSumOfWeights_factUp": 163.5117836516959,
+  "nSumOfWeights_factDown": 220.40023906976026,
+  "nSumOfWeights_renormfactUp": 118.75870535244887,
+  "nSumOfWeights_renormfactDown": 314.04648277180036
 }

--- a/topcoffea/json/signal_samples/private_UL/UL18_tHq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL18_tHq_b1_NDSkim.json
@@ -40,5 +40,15 @@
   "nGenEvents": 30034000,
   "nSumOfWeights": 2090.4472420636366,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_tHq4f_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 2090.1059303626444,
+  "nSumOfWeights_ISRDown": 2090.3041396538088,
+  "nSumOfWeights_FSRUp": 2090.972740020504,
+  "nSumOfWeights_FSRDown": 2090.435838018317,
+  "nSumOfWeights_renormUp": 1882.6537702523412,
+  "nSumOfWeights_renormDown": 2353.811600440815,
+  "nSumOfWeights_factUp": 1942.1811433896198,
+  "nSumOfWeights_factDown": 2261.2210638518354,
+  "nSumOfWeights_renormfactUp": 1749.6606251713597,
+  "nSumOfWeights_renormfactDown": 2547.0225456300163
 }

--- a/topcoffea/json/signal_samples/private_UL/UL18_tllq_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL18_tllq_b1_NDSkim.json
@@ -95,5 +95,15 @@
   "nGenEvents": 30047500,
   "nSumOfWeights": 1933.3616499403668,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_tllq4fNoSchanWNoHiggs0p_all22WCsStartPtCheckV2dim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 1933.1291756652063,
+  "nSumOfWeights_ISRDown": 1933.3112989923661,
+  "nSumOfWeights_FSRUp": 1933.1828710039827,
+  "nSumOfWeights_FSRDown": 1933.4232422085354,
+  "nSumOfWeights_renormUp": 1732.8685756722157,
+  "nSumOfWeights_renormDown": 2189.1751092434506,
+  "nSumOfWeights_factUp": 1801.258423388485,
+  "nSumOfWeights_factDown": 2079.710993696646,
+  "nSumOfWeights_renormfactUp": 1614.2411843962898,
+  "nSumOfWeights_renormfactDown": 2354.3282063264833
 }

--- a/topcoffea/json/signal_samples/private_UL/UL18_ttHJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL18_ttHJet_b1_NDSkim.json
@@ -57,5 +57,15 @@
   "nGenEvents": 78211928,
   "nSumOfWeights": 38564.22247337481,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_ttHJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 36968.471893332215,
+  "nSumOfWeights_ISRDown": 39898.50529562525,
+  "nSumOfWeights_FSRUp": 38548.73462800555,
+  "nSumOfWeights_FSRDown": 38585.606412412366,
+  "nSumOfWeights_renormUp": 32842.29279972028,
+  "nSumOfWeights_renormDown": 46077.617224616515,
+  "nSumOfWeights_factUp": 35725.24125827925,
+  "nSumOfWeights_factDown": 41935.638537166975,
+  "nSumOfWeights_renormfactUp": 30441.287337281698,
+  "nSumOfWeights_renormfactDown": 50133.76648268901
 }

--- a/topcoffea/json/signal_samples/private_UL/UL18_ttllJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL18_ttllJet_b1_NDSkim.json
@@ -98,5 +98,15 @@
   "nGenEvents": 105056039,
   "nSumOfWeights": 20993.713027504105,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_ttllNuNuJetNoHiggs_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 20126.55884494015,
+  "nSumOfWeights_ISRDown": 21718.10277550796,
+  "nSumOfWeights_FSRUp": 20963.7497664384,
+  "nSumOfWeights_FSRDown": 21011.4622027219,
+  "nSumOfWeights_renormUp": 17819.50565273288,
+  "nSumOfWeights_renormDown": 25195.331198320106,
+  "nSumOfWeights_factUp": 19423.64789171272,
+  "nSumOfWeights_factDown": 22848.452259291127,
+  "nSumOfWeights_renormfactUp": 16503.297376543465,
+  "nSumOfWeights_renormfactDown": 27448.774722693965
 }

--- a/topcoffea/json/signal_samples/private_UL/UL18_ttlnuJet_b1_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL18_ttlnuJet_b1_NDSkim.json
@@ -73,5 +73,15 @@
   "nGenEvents": 63615364,
   "nSumOfWeights": 11485.9609381048,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch1/naodOnly_step/v5/nAOD_step_ttlnuJet_all22WCsStartPtCheckdim6TopMay20GST_run0",
+  "nSumOfWeights_ISRUp": 11123.635350630642,
+  "nSumOfWeights_ISRDown": 11778.351910695808,
+  "nSumOfWeights_FSRUp": 11474.700337438586,
+  "nSumOfWeights_FSRDown": 11496.303714018704,
+  "nSumOfWeights_renormUp": 10237.916649734805,
+  "nSumOfWeights_renormDown": 13177.299423875676,
+  "nSumOfWeights_factUp": 10964.403952145316,
+  "nSumOfWeights_factDown": 12059.315306601691,
+  "nSumOfWeights_renormfactUp": 9785.819553963882,
+  "nSumOfWeights_renormfactDown": 13859.659399917118
 }

--- a/topcoffea/json/signal_samples/private_UL/UL18_tttt_b4_NDSkim.json
+++ b/topcoffea/json/signal_samples/private_UL/UL18_tttt_b4_NDSkim.json
@@ -78,5 +78,15 @@
   "nGenEvents": 29746500,
   "nSumOfWeights": 187.55443212752408,
   "isData": false,
-  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch4/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0"
+  "path": "/store/user/kmohrman/FullProduction/FullR2/UL18/Round1/Batch4/naodOnly_step/v2/nAOD_step_tttt_FourtopsMay3v1_run0",
+  "nSumOfWeights_ISRUp": 187.51909881491494,
+  "nSumOfWeights_ISRDown": 187.5751611865182,
+  "nSumOfWeights_FSRUp": 187.40019194317728,
+  "nSumOfWeights_FSRDown": 187.59834839007863,
+  "nSumOfWeights_renormUp": 136.20322322739733,
+  "nSumOfWeights_renormDown": 267.195593401901,
+  "nSumOfWeights_factUp": 162.57852057492957,
+  "nSumOfWeights_factDown": 219.13088556467326,
+  "nSumOfWeights_renormfactUp": 118.08325338805919,
+  "nSumOfWeights_renormfactDown": 312.23010486366394
 }


### PR DESCRIPTION
Propagates the updates made for the private MC JSONs, which includes the sum of various systematic weights, such has renormalization/factorization scale uncertainties.

The command used to (re-)generate the skim JSON files was:
```
python make_skim_jsons.py --json-dir ../../topcoffea/json/signal_samples/private_UL --file ND_private_mc_skim_locations.txt
```