### PR TITLE
Fix json year names

### DIFF
--- a/analysis/topEFT/make_jsons.py
+++ b/analysis/topEFT/make_jsons.py
@@ -973,7 +973,7 @@ from collections import defaultdict
 # For more info on the datasets and eras for each year
 # See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVRun2LegacyAnalysis
 
-### 2016 ###
+### 2016APV ###
 year = 'Run2016'
 naod_version  = "MiniAODv2_NanoAODv9-v1"
 dataset_names = ["DoubleEG","DoubleMuon","SingleElectron","SingleMuon","MuonEG"]
@@ -984,9 +984,6 @@ dataset_eras = [# See: https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL20
     'D-HIPM_UL2016',
     'E-HIPM_UL2016',
     'F-HIPM_UL2016',
-    'F-UL2016',
-    'G-UL2016',
-    'H-UL2016',
 ]
 
 version_overwrite = {
@@ -1005,7 +1002,6 @@ version_overwrite = {
         'D-HIPM_UL2016': 'MiniAODv2_NanoAODv9-v2',
         'E-HIPM_UL2016': 'MiniAODv2_NanoAODv9-v2',
         'F-HIPM_UL2016': 'MiniAODv2_NanoAODv9-v2',
-        'G-UL2016': 'MiniAODv2_NanoAODv9-v2',
     },
     'MuonEG': {
         'B-ver1_HIPM_UL2016': 'MiniAODv2_NanoAODv9-v2',
@@ -1033,6 +1029,34 @@ version_overwrite = {
     },
 }
 
+data_2016APV_dict = defaultdict(lambda: {'path': '','histAxisName': 'dataUL16APV', 'xsecName': 'data'})
+for era in dataset_eras:
+    for ds_name in dataset_names:
+        key_name = "{name}_{era}".format(name=ds_name,era=era)
+        version = naod_version
+        if ds_name in version_overwrite:
+            if era in version_overwrite[ds_name]:
+                version = version_overwrite[ds_name][era]
+        ds_path = "/{ds}/{year}{era}_{ver}/NANOAOD".format(year=year,ds=ds_name,era=era,ver=version)
+        data_2016APV_dict[key_name]['path'] = ds_path
+
+
+### 2016 ###
+year = 'Run2016'
+naod_version  = "MiniAODv2_NanoAODv9-v1"
+dataset_names = ["DoubleEG","DoubleMuon","SingleElectron","SingleMuon","MuonEG"]
+dataset_eras = [# See: https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2016
+    'F-UL2016',
+    'G-UL2016',
+    'H-UL2016',
+]
+
+version_overwrite = {
+    'DoubleMuon': {# See: https://pdmv-pages.web.cern.ch/rereco_ul/?input_dataset=DoubleMuon%2FRun2016
+        'G-UL2016': 'MiniAODv2_NanoAODv9-v2',
+    },
+}
+
 data_2016_dict = defaultdict(lambda: {'path': '','histAxisName': 'dataUL16', 'xsecName': 'data'})
 for era in dataset_eras:
     for ds_name in dataset_names:
@@ -1043,6 +1067,7 @@ for era in dataset_eras:
                 version = version_overwrite[ds_name][era]
         ds_path = "/{ds}/{year}{era}_{ver}/NANOAOD".format(year=year,ds=ds_name,era=era,ver=version)
         data_2016_dict[key_name]['path'] = ds_path
+
 
 ### 2017 ###
 year = 'Run2017'
@@ -1278,9 +1303,10 @@ def main():
     make_jsons_for_dict_of_samples(central_UL16APV_bkg_dict,"/hadoop","2016APV",out_dir_central_bkg_UL,on_das=False) # Background samples are at ND now
 
     # Data samples
-    # make_jsons_for_dict_of_samples(data_2016_dict,"root://ndcms.crc.nd.edu/","2016",out_dir_data_2016,on_das=True)
-    # make_jsons_for_dict_of_samples(data_2017_dict,"root://ndcms.crc.nd.edu/","2017",out_dir_data_2017,on_das=True)
-    # make_jsons_for_dict_of_samples(data_2018_dict,"root://ndcms.crc.nd.edu/","2018",out_dir_data_2018,on_das=True)
+    #make_jsons_for_dict_of_samples(data_2016APV_dict,"root://ndcms.crc.nd.edu/","2016APV",out_dir_data_2016,on_das=True)
+    #make_jsons_for_dict_of_samples(data_2016_dict,"root://ndcms.crc.nd.edu/","2016",out_dir_data_2016,on_das=True)
+    #make_jsons_for_dict_of_samples(data_2017_dict,"root://ndcms.crc.nd.edu/","2017",out_dir_data_2017,on_das=True)
+    #make_jsons_for_dict_of_samples(data_2018_dict,"root://ndcms.crc.nd.edu/","2018",out_dir_data_2018,on_das=True)
 
     # Testing finding list of files with xrdfs ls
     #make_jsons_for_dict_of_samples(test_dict,"root://xrootd-local.unl.edu/","2017",".")

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver1_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_B-ver2_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_C-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_D-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_E-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleEG_F-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver1_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_B-ver2_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_C-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver1_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_B-ver2_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_C-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_D-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_E-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/MuonEG_F-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver1_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_B-ver2_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_C-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_D-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_E-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleElectron_F-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver1_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_B-ver2_HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_C-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_D-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_E-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [

--- a/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016_NDSkim.json
@@ -1,6 +1,6 @@
 {
   "xsec": 1.0,
-  "year": "2016",
+  "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "dataUL16",
   "options": "",

--- a/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/SingleMuon_F-HIPM_UL2016_NDSkim.json
@@ -2,7 +2,7 @@
   "xsec": 1.0,
   "year": "2016APV",
   "treeName": "Events",
-  "histAxisName": "dataUL16",
+  "histAxisName": "dataUL16APV",
   "options": "",
   "WCnames": [],
   "files": [


### PR DESCRIPTION
This PR updates the `year` key in the 2016 data jsons to be `2016APV` for the HIPM datasets. Similarly, it updates the `histAxisName` key to be `dataUL16APV` instead of just `dataUL16`. 

However, it does not change the actual `make_jsons.py` script, so if we were ever to remake the JSONs, we'd again end up with the wrong year names. Should we also update `make_jsons.py` as part of this PR? 