### PR TITLE
Turn off systematics for data samples

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -121,8 +121,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         year               = self._samples[dataset]["year"]
         xsec               = self._samples[dataset]["xsec"]
         sow                = self._samples[dataset]["nSumOfWeights"]
-        
-        if not isData:
+
+        # Turn systematics off if this is a data sample, otherwise get up down weights from input dict
+        if isData:
+            self._do_systematics = False
+        else:
             sow_ISRUp          = self._samples[dataset]["nSumOfWeights_ISRUp"]
             sow_ISRDown        = self._samples[dataset]["nSumOfWeights_ISRDown"]
             sow_FSRUp          = self._samples[dataset]["nSumOfWeights_FSRUp"]
@@ -725,8 +728,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
               # Set up the list of syst wgt variations to loop over
               wgt_var_lst = ["nominal"]
-              if   (self._do_systematics and not isData and (syst_var == "nominal")): wgt_var_lst = wgt_var_lst + wgt_correction_syst_lst
-              elif (self._do_systematics and not isData and (syst_var != "nominal")): wgt_var_lst = [syst_var]
+              if   (self._do_systematics and (syst_var == "nominal")): wgt_var_lst = wgt_var_lst + wgt_correction_syst_lst
+              elif (self._do_systematics and (syst_var != "nominal")): wgt_var_lst = [syst_var]
 
               # Loop over the systematics
               for wgt_fluct in wgt_var_lst:

--- a/analysis/topEFT/work_queue_run.py
+++ b/analysis/topEFT/work_queue_run.py
@@ -45,7 +45,7 @@ parser.add_argument('--outname','-o'   , default='plotsTopEFT', help = 'Name of 
 parser.add_argument('--outpath','-p'   , default='histos', help = 'Name of the output directory')
 parser.add_argument('--treename'       , default='Events', help = 'Name of the tree inside the files')
 parser.add_argument('--do-errors'      , action='store_true', help = 'Save the w**2 coefficients')
-parser.add_argument('--do-systs', action='store_true', help = 'Run over systematic samples (takes longer)')
+parser.add_argument('--do-systs', action='store_true', help = 'Compute systematic variations (for any MC samples)')
 parser.add_argument('--split-lep-flavor', action='store_true', help = 'Split up categories by lepton flavor')
 parser.add_argument('--skip-sr', action='store_true', help = 'Skip all signal region categories')
 parser.add_argument('--skip-cr', action='store_true', help = 'Skip all control region categories')


### PR DESCRIPTION
This PR fixes a bug in the processor that was causing the data histograms to be filled multiple times when running with systematics turned on. Essentially, we'd been looping over `["nominal"] + obj_correction_syst_lst` [here](https://github.com/TopEFT/topcoffea/blob/c164b89c5c5c4f3e65153eb4804553e6acb3e3eb/analysis/topEFT/topeft.py#L247), when we should have just been looping over `nominal`. To fix this issue, I've added a check to turn off the systematics if the given samples is a data sample.

The way that this was noticed was that the fake contribution was much too large (by about a factor of 7) when running with systematics turned on (though this bug actually affected all data, and by extension both data based backgrounds i.e. both fakes and flips). The reason why we have not encountered it before is that it only happens when running with the systematics turned on when running over a set of samples that includes data samples. We don't usually run with the systematics on when e.g. making CR plots, so this is why the bug had gone unnoticed. Fortunately, this means it did not impact any of our previous studies, with the only exception being the limits shown at the April 1 group meeting [here](https://indico.cern.ch/event/1123569/contributions/4812674/attachments/2419955/4142017/Updates_April1_2022.pdf); in principle, I think the correct limits would be tighter than what is shown in those slides (since the the data based backgrounds were much too large in the runs used to generate those limits). 
 