### PR TITLE
Change DAS query to return correct event counts

### DIFF
--- a/topcoffea/modules/createJSON.py
+++ b/topcoffea/modules/createJSON.py
@@ -134,8 +134,8 @@ def main():
 
   # When getting data from DAS, we don't need to query every single file to get the number of events
   if isDAS and isData and nFiles is None:
-    dataset_part = "{name} | sum(file.nevents)".format(name=path)
-    output = RunDasGoClientCommand(dataset=dataset_part,mode='file,')
+    dataset_part = "{name} | grep dataset.nevents".format(name=path)
+    output = RunDasGoClientCommand(dataset=dataset_part,mode='')
     output = float(output.split(':')[-1].strip())
 
     # For data this this should all be the same


### PR DESCRIPTION
This PR is to fix a bug noticed by @kmohrman, where running the `make_jsons.py` script to regenerate the JSON files for the 2016/2017/2018 data samples would incorrectly set the `nEvents`, `nGenEvents`, and `nSumOfWeights` entries to 0. After making the change, I re-ran the script a confirmed it produces identical JSON files that are currently on master.