### PR TITLE
Do not include up/down variations in nonprompt hists

### DIFF
--- a/topcoffea/modules/dataDrivenEstimation.py
+++ b/topcoffea/modules/dataDrivenEstimation.py
@@ -109,7 +109,15 @@ class DataDrivenProducer:
                         
                         # now we take all the stuff that is not data in the AR to make the prompt subtraction and assign them to nonprompt.
                         hPromptSub=hAR.group('sample', hist.Cat('sample','sample'), newNameDictNoData )
-                        
+
+                        # remove the up/down variations (if any) from the prompt subtraction histo
+                        syst_var_idet_rm_lst = []
+                        syst_var_idet_lst = hPromptSub.identifiers("systematic")
+                        for syst_var_idet in syst_var_idet_lst:
+                            if syst_var_idet.name != "nominal":
+                                syst_var_idet_rm_lst.append(syst_var_idet)
+                        hPromptSub = hPromptSub.remove(syst_var_idet_rm_lst,"systematic")
+
                         # now we actually make the subtraction
                         hPromptSub.scale(-1)
                         hFakes=hFakes+hPromptSub


### PR DESCRIPTION
This PR adds a check in `dataDrivenEstimation.py` that removes any up/down systematic variations from the `systematic` axis of the prompt subtraction histogram.

Currently (without this check), the nonprompt histograms will have up/down variations included whenever running a job with the systematics turned on. E.g.:
```
('nonpromptUL17', '2lss_CR', 'JERDown'): array([ 0.00000000e+00, -9.04329271e-05, -9.55624665e-05, -7.74992 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00, 0.00000000e+00,  0.00000000e+00])
```
It seems this was happening because of the prompt subtraction. I.e. when we do this:
```
hFakes=hFakes+hPromptSub
```
The up/down categories in `hPromptSub` were being included in `hFakes`. This PR removes all categories except `nominal` from `hPromptSub` prior to performing the subtraction. 

It seems this issue was not really causing a problem (as the datacard maker may have been ignoring these up/down variations anyway) but since they are unnecessary and unintentional, it seemed like we should remove them. 