### PR TITLE
Adding git to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - conda-pack
   - dill
   - xrootd
+  - git


### PR DESCRIPTION
This PR includes `git` in the dependencies we install with conda (which provides us with a much newer version of `git` than we had been getting with `cvmfs`). 