### PR TITLE
Fix fakes in datacard maker

### DIFF
--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -403,11 +403,8 @@ class DatacardMaker():
             for syst in self.syst:
                 if channel in self.skip_process_channels and self.skip_process_channels[channel] in syst: continue
                 syst = syst+self.get_correlation_name(process, syst) # Tack on possible correlation name from self.syst_correlation
-                print('_'.join([process,syst]))
-                print(d_hists.keys())
                 if any([process+'_'+syst in d for d in d_hists]):
                     h_sys = getHist(d_hists, '_'.join([process,syst]))
-                    print(process,syst)
                     #if 'nonprompt' in process: process = process.replace('nonprompt', 'fakes')
                     h_sys.SetDirectory(fout)
 
@@ -460,11 +457,12 @@ class DatacardMaker():
                     syst = val
                 else:
                     raise NotImplementedError(f'Invalid value type {syst_special} {type(val)=}')
-                syst_cat = syst_special+self.get_correlation_name(process, syst_special)+'_flat_rate'
+                proc = process if 'nonprompt' not in process else 'fakes_sm'
+                syst_cat = syst_special+self.get_correlation_name(proc, syst_special)+'_flat_rate'
                 if syst_cat in systMap:
-                    systMap[syst_cat].update({process: syst})
+                    systMap[syst_cat].update({proc: syst})
                 else:
-                    systMap[syst_cat] = {process: syst}
+                    systMap[syst_cat] = {proc: syst}
                     
         print(f'Making the datacard for {channel}')
         if isinstance(charges, str): charge = charges
@@ -566,9 +564,7 @@ class DatacardMaker():
                         d_bkgs[name] = h_sm
                 return signalcount, bkgcount
             if True or h_sm.Integral() > self.tolerance or p not in self.signal:
-                print(name)
                 signalcount, bkgcount = addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout)
-                print(name)
                 '''
                 if p in self.signal:
                     if name in iproc:
@@ -593,9 +589,7 @@ class DatacardMaker():
                         bkgcount += 1
                         d_bkgs[name] = h_sm
                 '''
-                print(name)
                 if self.do_nuisance: processSyst(name, channel, systMap, d_hists, fout)
-                print(name)
                 h_sm.SetDirectory(fout)
                 h_sm.SetName(name)
                 h_sm.SetTitle(name)

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -475,8 +475,8 @@ class DatacardMaker():
                     h_sys.SetTitle(proc)
                     if h_sys.Integral() < 0:
                         print('Warning: {proc} normalization is {h_sys.Integral()}!')
-                    else:
-                        h_sys.Write()
+                        h_sys.Scale(0)
+                    h_sys.Write()
 
                     if 'Down' in syst: continue # The datacard only stores the systematic name, and combine tacks on Up/Down later
                     syst = syst.replace('Up', '') # Remove 'Up' to get just the systematic name

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -535,7 +535,7 @@ class DatacardMaker():
                 h_sm = getHist(d_hists, name)
             else:
                 h_sm = getHist(d_hists, proc+'_sm') # Special case for SM b/c background names overlap
-            #if 'nonprompt' in name: name = 'fakes_sm'
+            if True or h_sm.Integral() > self.tolerance or p not in self.signal:
             def addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout):
                 if 'nonprompt' in name: name = 'fakes_sm'
                 if p in self.signal:

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -547,7 +547,6 @@ class DatacardMaker():
             else:
                 h_sm = getHist(d_hists, proc+'_sm') # Special case for SM b/c background names overlap
             def addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout):
-                if 'nonprompt' in name: name = 'fakes_sm'
                 if p in self.signal:
                     if name in iproc:
                         allyields[name] += h_sm.Integral()
@@ -570,9 +569,9 @@ class DatacardMaker():
                         allyields[name] = h_sm.Integral()
                         bkgcount += 1
                         d_bkgs[name] = h_sm
-                return signalcount, bkgcount
+                return signalcount, bkgcount, h_sm
             if True or h_sm.Integral() > self.tolerance or p not in self.signal:
-                signalcount, bkgcount = addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout)
+                signalcount, bkgcount, h_sm = addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout)
                 if self.do_nuisance:
                     if any([sig in proc for sig in self.signal]):
                        processSyst(name, channel, systMap, d_hists, fout)

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -289,16 +289,16 @@ class DatacardMaker():
                 yproc = re.sub("UL\d\d(?:APV)?", "UL"+pyear, proc)
                 for syst in systs:
                     if pyear != re.findall("20\d\d(?:APV)?", syst)[0][2:]: continue
-                    nom = np.zeros_like(list(h._sumw.values())[0])
-                    mkey = None
+                    mkey = [key for key in h._sumw if yproc in str(key[0]) and syst in str(key[1])]
+                    if len(mkey) == 0: continue # Skip things like `nonprompt`
+                    mkey = mkey[0]
+                    nom = np.zeros_like(h._sumw[mkey])
                     for key in h._sumw:
-                        if yproc in str(key[0]) and syst in str(key[1]): mkey = key
                         if yproc.split('UL')[0] not in str(key[0]): continue
                         if yproc == str(key[0]) or 'nominal' not in str(key[1]): continue
                         kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
                         nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+pyear]
                     if mkey is None: continue
-                    if nom.shape != h._sumw[mkey].shape: continue
                     h._sumw[mkey] = h._sumw[mkey] + nom
         # Scale each plot to the SM
         processed = []

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -60,6 +60,9 @@ class DatacardMaker():
         print(f'Loading {self.fin}')
         with gzip.open(self.fin) as fin:
             self.hists = pickle.load(fin)
+        for h in self.hists:
+            tri = {str(s).replace('_4F', ''):str(s) for s in self.hists[h].axis('sample').identifiers()}
+            self.hists[h] = self.hists[h].group('sample', hist.Cat('sample', 'sample'), tri) # Remove `4F` from triboson samples
 
         # Variables present in the pkl file
         self.all_var_lst = yt.get_hist_list(self.hists)

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -473,7 +473,10 @@ class DatacardMaker():
                         fout.Delete(proc+';1')
                     h_sys.SetName(proc)
                     h_sys.SetTitle(proc)
-                    h_sys.Write()
+                    if h_sys.Integral() < 0:
+                        print('Warning: {proc} normalization is {h_sys.Integral()}!')
+                    else:
+                        h_sys.Write()
 
                     if 'Down' in syst: continue # The datacard only stores the systematic name, and combine tacks on Up/Down later
                     syst = syst.replace('Up', '') # Remove 'Up' to get just the systematic name

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -288,7 +288,6 @@ class DatacardMaker():
                 pyear = year[2:]
                 yproc = re.sub("UL\d\d(?:APV)?", "UL"+pyear, proc)
                 mkey = [k for k in h._sumw if proc == str(k[0]) and 'nominal' in str(k[1])]
-                #if len(mkey) == 0: continue
                 mkey = mkey[0]
                 for syst in systs:
                     if pyear != re.findall("20\d\d(?:APV)?", syst)[0][2:]: continue
@@ -296,10 +295,9 @@ class DatacardMaker():
                     for key in h._sumw:
                         if yproc.split('UL')[0] not in str(key[0]): continue
                         if yproc == str(key[0]) or 'nominal' not in str(key[1]): continue
+                        if 'nominal' in str(mkey[1]) and 'nominal' in str(key[1]): continue
                         kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
-                        nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+pyear]
-                    if mkey is None: continue
-                    h._sumw[mkey] = h._sumw[mkey] + nom
+                        h._sumw[mkey] += h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+pyear]
         # Scale each plot to the SM
         processed = []
         for proc in self.samples:
@@ -319,19 +317,14 @@ class DatacardMaker():
             #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','').split('UL')[0] in k}
             #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k and proc.split('UL')[1] == k.split('UL')[1]}
             years = {year : self.lumi[year] for year in ul}
-            print(ul, years)
-            print('raw', h.values())
             if self.do_nuisance: fix_uncorrelated_systs(h, proc, years) # Before processed to handle all years
             # Integrate out processes
             h_base = h.group('sample', hist.Cat('year', 'year'), ul)
-            print('years', h_base.values())
             if h_base.values() == {}:
                 print(f'Issue with {proc}')
                 continue
             h_base.scale(years, axis='year')
-            print('scale', h_base.values())
             h_base = h_base.integrate('year')
-            print('integrated', h_base.values())
             if isinstance(self.analysis_bins[variable],dict):
                 lep_bin = channel.split('_')[0].split('l')[0] + 'l'
                 h_base = h_base.rebin(variable, hist.Bin(variable,  h.axis(variable).label, self.analysis_bins[variable][lep_bin]))
@@ -340,11 +333,9 @@ class DatacardMaker():
             # Save the SM plot
             h_bases = {syst: h_base.integrate('systematic', syst) for syst in self.syst}
             h_base = h_base.integrate('systematic', 'nominal')
-            print(pname, h_base.values()[()].sum())
             h_sm = h_bases
             for hists in h_sm.values():
                 hists.set_sm()
-            print('Writing', pname+'_sm', 'from', proc, p)
             if len(h_base.axes())>1:
                 fout[pname+'sm'] = export2d(h_bases)
             else:
@@ -543,7 +534,6 @@ class DatacardMaker():
 
         # Fold overflow bin in ROOT into last bin (combine does NOT use the overflow bin)
         d_hists = getOverflowMergedHists(d_hists_withoverflow)
-        print(d_hists.keys())
 
         # Create the ROOT file
         fname = f'histos/ttx_multileptons-{cat}.root'
@@ -586,8 +576,6 @@ class DatacardMaker():
             data_obs.Write()
             pname = self.rename[proc]+'_' if proc in self.rename else proc+'_'
             name = pname + 'sm'
-            print(name, proc, proc.split('UL')[0])
-            print(f"{proc.split('UL')[0] not in d_hists=}")
             if name not in d_hists and proc+'_sm' not in d_hists and proc.split('UL')[0]+'_sm' not in d_hists:
                 print(f'{name} not found in {channel}!')
                 continue
@@ -595,7 +583,6 @@ class DatacardMaker():
                 h_sm = getHist(d_hists, name)
             else:
                 h_sm = getHist(d_hists, proc+'_sm') # Special case for SM b/c background names overlap
-            print(name, h_sm.Integral())
             def addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout):
                 if p in self.signal:
                     if name in iproc:

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -25,7 +25,7 @@ class DatacardMaker():
         # PDF/QCD scale uncertainties take from TOP-19-001
         # Asymmetric errors are provided as k_down / k_up in combine
                                               # 30% flat uncertainty for charge flips
-        self.syst_special = {'charge_flips': {'charge_flips_sm': 0.3}, 'lumi': 0.016, 'pdf_scale' : {'ttH': 0.036, 'tllq': 0.04, 'ttlnu': 0.02, 'ttll': 0.03, 'tHq': 0.037, 'Diboson': 0.02, 'Triboson': 0.042, 'convs': 0.05}, 'qcd_scale' : {'ttH': '1.092/1.058', 'tllq': 0.01, 'ttlnu': '1.12/1.13', 'ttll': '1.12/1.10', 'tHq': '1.08/1.06', 'Diboson': 0.02, 'Triboson': 0.026, 'convs': 0.10}} # Strings b/c combine needs the `/` to process asymmetric errors
+        self.syst_special = {'charge_flips': {'charge_flips_sm': 0.3}, 'lumi': 0.016, 'pdf_scale' : {'ttH': 0.036, 'tllq': 0.04, 'ttlnu': 0.02, 'ttll': 0.03, 'tHq': 0.037, 'Diboson': 0.02, 'Triboson': 0.042, 'convs': 0.05}, 'qcd_scale' : {'ttH': '0.908/1.058', 'tllq': 0.01, 'ttlnu': '0.88/1.13', 'ttll': '0.88/1.10', 'tHq': '0.92/1.06', 'Diboson': 0.02, 'Triboson': 0.026, 'convs': 0.10}} # Strings b/c combine needs the `/` to process asymmetric errors
         # (Un)correlated systematics
         # {'proc': {'syst': name, 'type': name} will assign all procs a special name for the give systematics
         # e.g. {'ttH': {'pdf_scale': 'gg', 'qcd_scale': 'ttH'}} will add `_gg` to the ttH for the pdf scale and `_ttH` for the qcd scale (names correspond to `self.syst_correlated`)

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -907,7 +907,6 @@ if __name__ == '__main__':
     if len(var_lst) == 0:
         target_var_lst = yt.get_hist_list(pklfile)
     differential_lst = [var for var in yt.get_hist_list(pklfile,allow_empty=False) if var!='njets'] # List of differential variables, will use the first one
-    if len(differential_lst) == 0: raise Exception(f"No differential variables found in {pklfile}!\nAt least one is required to build the dictionaries of bins")
     # Variables we have defined a binning for
     known_var_lst = ['njets','ptbl','ht','ptz','o0pt','bl0pt','l0pt','lj0pt','ljptsum']
     for var_name in target_var_lst:
@@ -915,7 +914,8 @@ if __name__ == '__main__':
             include_var_lst.append(var_name)
     if len(include_var_lst) == 0: raise Exception("No variables specified")
 
-    card = DatacardMaker(pklfile, lumiJson, do_nuisance, wcs, year, do_sm, differential_lst[0])
+    build_var = differential_lst[0] if len(differential_lst)>0 else 'njets'
+    card = DatacardMaker(pklfile, lumiJson, do_nuisance, wcs, year, do_sm, build_var)
     card.read()
     card.buildWCString()
     jobs = []

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -202,6 +202,7 @@ class DatacardMaker():
                         fout[name+cat] = histo.to_hist()
                     elif self.do_nuisance and name not in self.syst_special:
                         if 'nonprompt' in name and 'FF' not in syst: continue # Only processes fake factor systs for fakes
+                        if 'fakes' in name and 'FF' not in syst: continue # Only processes fake factor systs for fakes
                         if 'nonprompt' not in name and 'FF' in syst: continue # Don't processes fake factor systs for others
                         # Special cass for systematics NOT correlated by year
                         if ulyear.search(name) and fullyear.search(syst):

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -797,7 +797,7 @@ class DatacardMaker():
         condorFile.write('error                 = condor/log/$(ClusterID)_$(ProcId).err\n')
         condorFile.write('log                   = condor/log/$(ClusterID).log\n')
         condorFile.write('Rank                  = Memory >= 64\n')
-        condorFile.write('Request_Memory        = 3 Gb\n')
+        condorFile.write('Request_Memory        = 4 Gb\n')
         condorFile.write('+JobFlavour           = "workday"\n')
         condorFile.write('getenv                = True\n')
         condorFile.write('Should_Transfer_Files = NO\n')

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -473,9 +473,6 @@ class DatacardMaker():
                         fout.Delete(proc+';1')
                     h_sys.SetName(proc)
                     h_sys.SetTitle(proc)
-                    if h_sys.Integral() < 0:
-                        print('Warning: {proc} normalization is {h_sys.Integral()}!')
-                        h_sys.Scale(0)
                     h_sys.Write()
 
                     if 'Down' in syst: continue # The datacard only stores the systematic name, and combine tacks on Up/Down later

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -313,7 +313,7 @@ class DatacardMaker():
             p = proc.split('_')[0]
             pname = self.rename[p] if p in self.rename else p
             pname.replace('_4F','').replace('_ext','')
-            ul = {'20'+k.split('UL')[1]:k for k in self.samples if pname in self.rename.get(k, k)}
+            ul = {'20'+k.split('UL')[1]:k for k in self.samples if pname in self.rename.get(k, k) and p.split('UL')[0] in k}
             pname = self.rename[p]+'_' if p in self.rename else p
             p = proc.split('_')[0].split('UL')[0]
             years = {year : self.lumi[year] for year in ul}

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -298,7 +298,8 @@ class DatacardMaker():
                         kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
                         nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+pyear]
                     if mkey is None: continue
-                    h._sumw[mkey] = h._sumw[mkey] + deepcopy(nom)
+                    if nom.shape != h._sumw[mkey].shape: continue
+                    h._sumw[mkey] = h._sumw[mkey] + nom
         # Scale each plot to the SM
         processed = []
         for proc in self.samples:

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -151,6 +151,8 @@ class DatacardMaker():
         rename = {k: 'fakes' if bool(re.search('nonprompt', v)) else v for k,v in rename.items()}
         rename = {k: 'charge_flips' if bool(re.search('flips', v)) else v for k,v in rename.items()}
         self.rename = {**self.rename, **rename}
+        rename = {l.split('UL')[0]: re.split('(Jet)?_[a-zA-Z]*UL', l)[0] for l in self.samples}
+        self.rename = {**self.rename, **rename}
         rename = {k.split('_')[0].split('UL')[0]: v for k,v in self.rename.items()}
         self.rename = {**self.rename, **rename}
         self.has_nonprompt = not any(['appl' in str(a) for a in self.hists['njets'].axes()]) # Check for nonprompt samples by looking for 'appl' axis
@@ -309,13 +311,9 @@ class DatacardMaker():
             p = proc.split('_')[0]#.split('UL')[0]
             pname = self.rename[p] if p in self.rename else p
             pname.replace('_4F','').replace('_ext','')
-            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k}
             ul = {'20'+k.split('UL')[1]:k for k in self.samples if pname in self.rename.get(k, k)}
             pname = self.rename[p]+'_' if p in self.rename else p
             p = proc.split('UL')[0]
-            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k}
-            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','').split('UL')[0] in k}
-            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k and proc.split('UL')[1] == k.split('UL')[1]}
             years = {year : self.lumi[year] for year in ul}
             if self.do_nuisance: fix_uncorrelated_systs(h, proc, years) # Before processed to handle all years
             # Integrate out processes
@@ -548,7 +546,7 @@ class DatacardMaker():
         processed = []
         for proc in samples:
             simplified = proc.split('_central')[0].split('_private')[0].split('UL')[0].replace('_4F','').replace('_ext','')
-            if simplified in processed: continue # Only one process name per 3 years
+            #if simplified in processed: continue # Only one process name per 3 years
             processed.append(simplified)
             if proc in self.ignore or self.rename[proc] in self.ignore: continue # Skip any CR processes that might be in the pkl file
             if self.should_skip_process(proc, channel): continue

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -535,7 +535,6 @@ class DatacardMaker():
                 h_sm = getHist(d_hists, name)
             else:
                 h_sm = getHist(d_hists, proc+'_sm') # Special case for SM b/c background names overlap
-            if True or h_sm.Integral() > self.tolerance or p not in self.signal:
             def addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout):
                 if 'nonprompt' in name: name = 'fakes_sm'
                 if p in self.signal:

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -25,7 +25,7 @@ class DatacardMaker():
         # PDF/QCD scale uncertainties take from TOP-19-001
         # Asymmetric errors are provided as k_down / k_up in combine
                                               # 30% flat uncertainty for charge flips
-        self.syst_special = {'charge_flips': {'charge_flips_sm': 0.3}, 'lumi': 0.05, 'pdf_scale' : {'ttH': 0.036, 'tllq': 0.04, 'ttlnu': 0.02, 'ttll': 0.03, 'tHq': 0.037, 'Diboson': 0.02, 'Triboson': 0.042, 'convs': 0.05}, 'qcd_scale' : {'ttH': '1.092/1.058', 'tllq': 0.01, 'ttlnu': '1.12/1.13', 'ttll': '1.12/1.10', 'tHq': '1.08/1.06', 'Diboson': 0.02, 'Triboson': 0.026, 'convs': 0.10}} # Strings b/c combine needs the `/` to process asymmetric errors
+        self.syst_special = {'charge_flips': {'charge_flips_sm': 0.3}, 'lumi': 0.016, 'pdf_scale' : {'ttH': 0.036, 'tllq': 0.04, 'ttlnu': 0.02, 'ttll': 0.03, 'tHq': 0.037, 'Diboson': 0.02, 'Triboson': 0.042, 'convs': 0.05}, 'qcd_scale' : {'ttH': '1.092/1.058', 'tllq': 0.01, 'ttlnu': '1.12/1.13', 'ttll': '1.12/1.10', 'tHq': '1.08/1.06', 'Diboson': 0.02, 'Triboson': 0.026, 'convs': 0.10}} # Strings b/c combine needs the `/` to process asymmetric errors
         # (Un)correlated systematics
         # {'proc': {'syst': name, 'type': name} will assign all procs a special name for the give systematics
         # e.g. {'ttH': {'pdf_scale': 'gg', 'qcd_scale': 'ttH'}} will add `_gg` to the ttH for the pdf scale and `_ttH` for the qcd scale (names correspond to `self.syst_correlated`)

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -287,17 +287,21 @@ class DatacardMaker():
             for syst in systs:
                 print(syst)
                 year = re.findall("20\d\d(?:APV)?", syst)[0][2:]
-                print(year)
                 nom = np.zeros_like(list(h._sumw.values())[0])
                 mkey = None
                 for key in h._sumw:
                     if syst in str(key[1]): mkey = key
                     if year in str(key[0]): continue # Ignore process with same year as systematic
                     if 'nominal' in str(key[1]): # Get the nominal value for each other year
-                        print(key, h._sumw[key].sum())
-                        nom = nom + h._sumw[key]
+                        print(str(key[0]), str(key[1]), h._sumw[key].sum())
+                        kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
+                        print(kyear)
+                        print(year, self.lumi['20'+kyear]/self.lumi['20'+year])
+                        nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+year]
                 print(syst)
+                print(str(mkey[0]), str(mkey[1]), h._sumw[mkey].sum())
                 print(h._sumw[mkey].sum())
+                print('adding', nom.sum())
                 h._sumw[mkey] += nom
                 print(h._sumw[mkey].sum())
         fix_uncorrelated_systs(h)

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -274,7 +274,7 @@ class DatacardMaker():
                 cat = '_'.join([channel, maxb, variable])
         fname = f'histos/tmp_ttx_multileptons-{cat}.root'
         fout = uproot3.recreate(fname)
-        def fix_uncorrelated_systs(h):
+        def fix_uncorrelated_systs(h, proc):
             '''
             This function folds the nominal values for all other years into a specific year
             E.g., `ttH_sm_btagSFbc_2017Down` should be
@@ -284,33 +284,54 @@ class DatacardMaker():
                    +ttH_sm_btagSFbc_2018nominal`
             '''
             systs = (str(s) for s in h.axis('systematic').identifiers() if '20' in str(s))
+            year = re.findall("UL\d\d(?:APV)?", proc)[0][2:]
             for syst in systs:
-                print(syst)
-                year = re.findall("20\d\d(?:APV)?", syst)[0][2:]
+                print(year, re.findall("20\d\d(?:APV)?", syst)[0][2:])
+                if year != re.findall("20\d\d(?:APV)?", syst)[0][2:]: continue
                 nom = np.zeros_like(list(h._sumw.values())[0])
                 mkey = None
+                print('looking for NOT', year, 'to correct', proc, syst)
                 for key in h._sumw:
-                    if syst in str(key[1]): mkey = key
-                    if year in str(key[0]): continue # Ignore process with same year as systematic
+                    if proc in str(key[0]) and syst in str(key[1]): mkey = key
+                    if proc.split('UL')[0] not in str(key[0]): continue
+                    if proc == str(key[0]) or 'nominal' not in str(key[1]): continue
+                    print('\t correcting with', str(key[0]), str(key[1]))
+                    kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
+                    nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+year]
+                '''
+                nom = np.zeros_like(list(h._sumw.values())[0])
+                mkey = None
+                print('looking for NOT', year, 'to correct', syst)
+                for key in h._sumw:
+                    if proc not in str(key[0]): continue
+                    syear = re.findall("20\d\d(?:APV)?", syst)[0][2:]
+                    if year == syear and syst in str(key[1]):
+                        print('\t','found mkey', str(key[0]), str(key[1]))
+                        mkey = key
+                    if syear in str(key[0]) and 'nominal' in str(key[1]): # Get the nominal value for each other year
+                        print('\t','nominal is', str(key[0]), str(key[1]), h._sumw[key].sum(), '->', h._sumw[key].sum() * self.lumi['20'+year])
+                    if year == syear: continue # Ignore process with same year as systematic
+                    print(year, 'is NOT', syear)
                     if 'nominal' in str(key[1]): # Get the nominal value for each other year
-                        print(str(key[0]), str(key[1]), h._sumw[key].sum())
+                        print('\t','will correct with', str(key[0]), str(key[1]))
                         kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
-                        print(kyear)
-                        print(year, self.lumi['20'+kyear]/self.lumi['20'+year])
                         nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+year]
-                print(syst)
+                '''
+                if mkey is None: continue
+                if h.integrate('sample', proc).integrate('systematic', syst) != {}:
+                    print('uncorrected', proc, h.integrate('sample', proc).integrate('systematic', syst).values()[()].sum(), h.integrate('sample', proc).integrate('systematic', syst).values()[()].sum() * self.lumi['20'+year])
                 print(str(mkey[0]), str(mkey[1]), h._sumw[mkey].sum())
-                print(h._sumw[mkey].sum())
                 print('adding', nom.sum())
                 h._sumw[mkey] += nom
-                print(h._sumw[mkey].sum())
-        fix_uncorrelated_systs(h)
+                if h.integrate('sample', proc).integrate('systematic', syst) != {}:
+                    print('corrected', proc, h.integrate('sample', proc).integrate('systematic', syst).values()[()].sum(), h.integrate('sample', proc).integrate('systematic', syst).values()[()].sum() * self.lumi['20'+year])
         # Scale each plot to the SM
         processed = []
         for proc in self.samples:
             if proc in self.ignore or self.rename[proc] in self.ignore: continue # Skip any CR processes that might be in the pkl file
             if self.should_skip_process(proc, channel): continue
             simplified = proc.split('_central')[0].split('_private')[0].replace('_4F','').replace('_ext','')
+            fix_uncorrelated_systs(h, proc) # Before processed to handle all years
             if simplified in processed: continue # Only one process name per 3 years
             processed.append(simplified)
             p = proc.split('_')[0]

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -199,8 +199,8 @@ class DatacardMaker():
                     if syst == 'nominal':
                         fout[name+cat] = hist.export1d(histo)
                     elif self.do_nuisance and name not in self.syst_special:
-                        if 'nonprompt' in name and 'FF' not in syst: continue # Only processes fake factor systs for fakes
-                        if 'nonprompt' not in name and 'FF' in syst: continue # Don't processes fake factor systs for others
+                        if 'fakes' in name and 'FF' not in syst: continue # Only processes fake factor systs for fakes
+                        if 'fakes' not in name and 'FF' in syst: continue # Don't processes fake factor systs for others
                         # Special cass for systematics NOT correlated by year
                         if bool(re.search('UL\d\d', name)) and bool(re.search('20\d\d', syst)):
                             # Find systematic year
@@ -310,12 +310,12 @@ class DatacardMaker():
             simplified = proc.split('_central')[0].split('_private')[0].split('UL')[0].replace('_4F','').replace('_ext','')
             if simplified in processed: continue # Only one process name per 3 years
             processed.append(simplified)
-            p = proc.split('_')[0]#.split('UL')[0]
+            p = proc.split('_')[0]
             pname = self.rename[p] if p in self.rename else p
             pname.replace('_4F','').replace('_ext','')
             ul = {'20'+k.split('UL')[1]:k for k in self.samples if pname in self.rename.get(k, k)}
             pname = self.rename[p]+'_' if p in self.rename else p
-            p = proc.split('UL')[0]
+            p = proc.split('_')[0].split('UL')[0]
             years = {year : self.lumi[year] for year in ul}
             if self.do_nuisance: fix_uncorrelated_systs(h, proc, years) # Before processed to handle all years
             # Integrate out processes

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -148,7 +148,6 @@ class DatacardMaker():
         rename = {k: 'Triboson' if bool(re.search('[WZ]{3}', v)) else v for k,v in rename.items()}
         rename = {k: 'Diboson' if bool(re.search('[WZ]{2}', v)) else v for k,v in rename.items()}
         rename = {k: 'convs' if bool(re.search('TTG', v)) else v for k,v in rename.items()}
-        #rename = {k: 'fakes' if bool(re.search('nonprompt', v)) else v for k,v in rename.items()}
         rename = {k: 'charge_flips' if bool(re.search('flips', v)) else v for k,v in rename.items()}
         self.rename = {**self.rename, **rename}
         rename = {k.split('_')[0]: v for k,v in self.rename.items()}
@@ -405,7 +404,6 @@ class DatacardMaker():
                 syst = syst+self.get_correlation_name(process, syst) # Tack on possible correlation name from self.syst_correlation
                 if any([process+'_'+syst in d for d in d_hists]):
                     h_sys = getHist(d_hists, '_'.join([process,syst]))
-                    #if 'nonprompt' in process: process = process.replace('nonprompt', 'fakes')
                     h_sys.SetDirectory(fout)
 
                     # Need to handle quad term to get "Q"
@@ -565,30 +563,6 @@ class DatacardMaker():
                 return signalcount, bkgcount
             if True or h_sm.Integral() > self.tolerance or p not in self.signal:
                 signalcount, bkgcount = addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout)
-                '''
-                if p in self.signal:
-                    if name in iproc:
-                        allyields[name] += h_sm.Integral()
-                        d_sigs[name].Add(h_sm)
-                        fout.Delete(name+';1')
-                        h_sm = d_sigs[name]
-                    else:
-                        signalcount -= 1
-                        iproc[name] = signalcount
-                        allyields[name] = h_sm.Integral()
-                        d_sigs[name] = h_sm
-                else:
-                    if name in iproc:
-                        allyields[name] += h_sm.Integral()
-                        d_bkgs[name].Add(h_sm)
-                        fout.Delete(name+';1')
-                        h_sm = d_bkgs[name]
-                    else:
-                        iproc[name] = bkgcount
-                        allyields[name] = h_sm.Integral()
-                        bkgcount += 1
-                        d_bkgs[name] = h_sm
-                '''
                 if self.do_nuisance: processSyst(name, channel, systMap, d_hists, fout)
                 h_sm.SetDirectory(fout)
                 h_sm.SetName(name)

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -283,7 +283,6 @@ class DatacardMaker():
                    +ttH_sm_btagSFbc_2017Down
                    +ttH_sm_btagSFbc_2018nominal`
             '''
-            print(years)
             for year in years:
                 systs = (str(s) for s in h.axis('systematic').identifiers() if '20' in str(s))
                 pyear = year[2:]
@@ -291,19 +290,14 @@ class DatacardMaker():
                 mkey = [k for k in h._sumw if proc == str(k[0]) and 'nominal' in str(k[1])]
                 #if len(mkey) == 0: continue
                 mkey = mkey[0]
-                print(str(mkey[0]))
-                print(proc, 'nom', h._sumw[mkey].sum() * self.lumi['20'+pyear])
                 for syst in systs:
                     if pyear != re.findall("20\d\d(?:APV)?", syst)[0][2:]: continue
                     nom = np.zeros_like(h._sumw[mkey])
-                    #nom = np.zeros_like(list(h._sumw.values())[0])
-                    print('looking for', str(proc), str(syst))
                     for key in h._sumw:
                         if yproc.split('UL')[0] not in str(key[0]): continue
                         if yproc == str(key[0]) or 'nominal' not in str(key[1]): continue
                         if 'nominal' in str(mkey[1]) and 'nominal' in str(key[1]): continue
                         kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
-                        print('\tfound', str(key[0]), str(key[1]), kyear, pyear, self.lumi['20'+kyear]/self.lumi['20'+pyear])
                         nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+pyear]
                     if mkey is None: continue
                     if nom.shape != h._sumw[mkey].shape: continue
@@ -313,11 +307,8 @@ class DatacardMaker():
         for proc in self.samples:
             if proc in self.ignore or self.rename[proc] in self.ignore: continue # Skip any CR processes that might be in the pkl file
             if self.should_skip_process(proc, channel): continue
-            simplified = proc.split('_central')[0].split('_private')[0].replace('_4F','').replace('_ext','')
-            #simplified = proc.split('_central')[0].split('_private')[0].split('UL')[0].replace('_4F','').replace('_ext','')
-            print(simplified, processed)
+            simplified = proc.split('_central')[0].split('_private')[0].split('UL')[0].replace('_4F','').replace('_ext','')
             if simplified in processed: continue # Only one process name per 3 years
-            #if any(s == simplified for s in processed): continue # Only one process name per 3 years
             processed.append(simplified)
             p = proc.split('_')[0]#.split('UL')[0]
             pname = self.rename[p] if p in self.rename else p
@@ -325,20 +316,24 @@ class DatacardMaker():
             #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k}
             ul = {'20'+k.split('UL')[1]:k for k in self.samples if pname in self.rename.get(k, k)}
             pname = self.rename[p]+'_' if p in self.rename else p
-            print(pname)
+            p = proc.split('UL')[0]
             #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k}
             #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','').split('UL')[0] in k}
             #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k and proc.split('UL')[1] == k.split('UL')[1]}
             years = {year : self.lumi[year] for year in ul}
             print(ul, years)
+            print('raw', h.values())
             if self.do_nuisance: fix_uncorrelated_systs(h, proc, years) # Before processed to handle all years
             # Integrate out processes
             h_base = h.group('sample', hist.Cat('year', 'year'), ul)
+            print('years', h_base.values())
             if h_base.values() == {}:
                 print(f'Issue with {proc}')
                 continue
             h_base.scale(years, axis='year')
+            print('scale', h_base.values())
             h_base = h_base.integrate('year')
+            print('integrated', h_base.values())
             if isinstance(self.analysis_bins[variable],dict):
                 lep_bin = channel.split('_')[0].split('l')[0] + 'l'
                 h_base = h_base.rebin(variable, hist.Bin(variable,  h.axis(variable).label, self.analysis_bins[variable][lep_bin]))
@@ -347,9 +342,11 @@ class DatacardMaker():
             # Save the SM plot
             h_bases = {syst: h_base.integrate('systematic', syst) for syst in self.syst}
             h_base = h_base.integrate('systematic', 'nominal')
+            print(pname, h_base.values()[()].sum())
             h_sm = h_bases
             for hists in h_sm.values():
                 hists.set_sm()
+            print('Writing', pname+'_sm', 'from', proc, p)
             if len(h_base.axes())>1:
                 fout[pname+'sm'] = export2d(h_bases)
             else:
@@ -563,12 +560,11 @@ class DatacardMaker():
         processed = []
         for proc in samples:
             simplified = proc.split('_central')[0].split('_private')[0].split('UL')[0].replace('_4F','').replace('_ext','')
-            #if simplified in processed: continue # Only one process name per 3 years
+            if simplified in processed: continue # Only one process name per 3 years
             processed.append(simplified)
             if proc in self.ignore or self.rename[proc] in self.ignore: continue # Skip any CR processes that might be in the pkl file
             if self.should_skip_process(proc, channel): continue
             p = self.rename[proc] if proc in self.rename else proc
-            print(proc, p, self.rename)
             name = 'data_obs'
             if name not in d_hists:
                 print(f'{name} not found in {channel}!')
@@ -592,6 +588,8 @@ class DatacardMaker():
             data_obs.Write()
             pname = self.rename[proc]+'_' if proc in self.rename else proc+'_'
             name = pname + 'sm'
+            print(name, proc, proc.split('UL')[0])
+            print(f"{proc.split('UL')[0] not in d_hists=}")
             if name not in d_hists and proc+'_sm' not in d_hists and proc.split('UL')[0]+'_sm' not in d_hists:
                 print(f'{name} not found in {channel}!')
                 continue
@@ -599,6 +597,7 @@ class DatacardMaker():
                 h_sm = getHist(d_hists, name)
             else:
                 h_sm = getHist(d_hists, proc+'_sm') # Special case for SM b/c background names overlap
+            print(name, h_sm.Integral())
             def addYields(p, name, h_sm, allyields, iproc, signalcount, bkgcount, d_sigs, d_bkgs, fout):
                 if p in self.signal:
                     if name in iproc:

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -199,8 +199,8 @@ class DatacardMaker():
                     if syst == 'nominal':
                         fout[name+cat] = hist.export1d(histo)
                     elif self.do_nuisance and name not in self.syst_special:
-                        if 'fakes' in name and 'FF' not in syst: continue # Only processes fake factor systs for fakes
-                        if 'fakes' not in name and 'FF' in syst: continue # Don't processes fake factor systs for others
+                        if 'nonprompt' in name and 'FF' not in syst: continue # Only processes fake factor systs for fakes
+                        if 'nonprompt' not in name and 'FF' in syst: continue # Don't processes fake factor systs for others
                         # Special cass for systematics NOT correlated by year
                         if bool(re.search('UL\d\d', name)) and bool(re.search('20\d\d', syst)):
                             # Find systematic year

--- a/analysis/topEFT/datacard_maker.py
+++ b/analysis/topEFT/datacard_maker.py
@@ -151,8 +151,6 @@ class DatacardMaker():
         rename = {k: 'fakes' if bool(re.search('nonprompt', v)) else v for k,v in rename.items()}
         rename = {k: 'charge_flips' if bool(re.search('flips', v)) else v for k,v in rename.items()}
         self.rename = {**self.rename, **rename}
-        rename = {l.split('UL')[0]: re.split('(Jet)?_[a-zA-Z]*UL', l)[0] for l in self.samples}
-        self.rename = {**self.rename, **rename}
         rename = {k.split('_')[0].split('UL')[0]: v for k,v in self.rename.items()}
         self.rename = {**self.rename, **rename}
         self.has_nonprompt = not any(['appl' in str(a) for a in self.hists['njets'].axes()]) # Check for nonprompt samples by looking for 'appl' axis
@@ -285,36 +283,54 @@ class DatacardMaker():
                    +ttH_sm_btagSFbc_2017Down
                    +ttH_sm_btagSFbc_2018nominal`
             '''
+            print(years)
             for year in years:
                 systs = (str(s) for s in h.axis('systematic').identifiers() if '20' in str(s))
                 pyear = year[2:]
                 yproc = re.sub("UL\d\d(?:APV)?", "UL"+pyear, proc)
                 mkey = [k for k in h._sumw if proc == str(k[0]) and 'nominal' in str(k[1])]
+                #if len(mkey) == 0: continue
                 mkey = mkey[0]
+                print(str(mkey[0]))
+                print(proc, 'nom', h._sumw[mkey].sum() * self.lumi['20'+pyear])
                 for syst in systs:
                     if pyear != re.findall("20\d\d(?:APV)?", syst)[0][2:]: continue
                     nom = np.zeros_like(h._sumw[mkey])
+                    #nom = np.zeros_like(list(h._sumw.values())[0])
+                    print('looking for', str(proc), str(syst))
                     for key in h._sumw:
                         if yproc.split('UL')[0] not in str(key[0]): continue
                         if yproc == str(key[0]) or 'nominal' not in str(key[1]): continue
                         if 'nominal' in str(mkey[1]) and 'nominal' in str(key[1]): continue
                         kyear = re.findall("\d\d(?:APV)?", str(key[0]))[0]
-                        h._sumw[mkey] += h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+pyear]
+                        print('\tfound', str(key[0]), str(key[1]), kyear, pyear, self.lumi['20'+kyear]/self.lumi['20'+pyear])
+                        nom = nom + h._sumw[key] * self.lumi['20'+kyear]/self.lumi['20'+pyear]
+                    if mkey is None: continue
+                    if nom.shape != h._sumw[mkey].shape: continue
+                    h._sumw[mkey] = h._sumw[mkey] + nom
         # Scale each plot to the SM
         processed = []
         for proc in self.samples:
             if proc in self.ignore or self.rename[proc] in self.ignore: continue # Skip any CR processes that might be in the pkl file
             if self.should_skip_process(proc, channel): continue
-            simplified = proc.split('_central')[0].split('_private')[0].split('UL')[0].replace('_4F','').replace('_ext','')
+            simplified = proc.split('_central')[0].split('_private')[0].replace('_4F','').replace('_ext','')
+            #simplified = proc.split('_central')[0].split('_private')[0].split('UL')[0].replace('_4F','').replace('_ext','')
+            print(simplified, processed)
             if simplified in processed: continue # Only one process name per 3 years
+            #if any(s == simplified for s in processed): continue # Only one process name per 3 years
             processed.append(simplified)
             p = proc.split('_')[0]#.split('UL')[0]
             pname = self.rename[p] if p in self.rename else p
             pname.replace('_4F','').replace('_ext','')
+            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k}
             ul = {'20'+k.split('UL')[1]:k for k in self.samples if pname in self.rename.get(k, k)}
             pname = self.rename[p]+'_' if p in self.rename else p
-            p = proc.split('UL')[0]
+            print(pname)
+            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k}
+            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','').split('UL')[0] in k}
+            #ul = {'20'+k.split('UL')[1]:k for k in self.samples if p.replace('_4F','').replace('_ext','') in k and proc.split('UL')[1] == k.split('UL')[1]}
             years = {year : self.lumi[year] for year in ul}
+            print(ul, years)
             if self.do_nuisance: fix_uncorrelated_systs(h, proc, years) # Before processed to handle all years
             # Integrate out processes
             h_base = h.group('sample', hist.Cat('year', 'year'), ul)
@@ -532,6 +548,7 @@ class DatacardMaker():
 
         # Fold overflow bin in ROOT into last bin (combine does NOT use the overflow bin)
         d_hists = getOverflowMergedHists(d_hists_withoverflow)
+        print(d_hists.keys())
 
         # Create the ROOT file
         fname = f'histos/ttx_multileptons-{cat}.root'
@@ -551,6 +568,7 @@ class DatacardMaker():
             if proc in self.ignore or self.rename[proc] in self.ignore: continue # Skip any CR processes that might be in the pkl file
             if self.should_skip_process(proc, channel): continue
             p = self.rename[proc] if proc in self.rename else proc
+            print(proc, p, self.rename)
             name = 'data_obs'
             if name not in d_hists:
                 print(f'{name} not found in {channel}!')


### PR DESCRIPTION
This PR fixes the issue with the fakes. The recent updates was overwriting each year entry with the subsequent (e.g., if loading `nonpromptUL17` followed by `nonpromptUL18` _only_ `nonpromptUL18` would be written to the datacard). It's a bit of a hack, since it treats the fakes as special, but we can come back to this later if we need to generalize it.