### PR TITLE
Remove Rochester corrections systematic

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -211,7 +211,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         ################### Muon selection ####################
 
-        mu["pt"] = ApplyRochesterCorrections(year, mu, isData, var='nominal') # Need to apply corrections before doing muon selection
+        mu["pt"] = ApplyRochesterCorrections(year, mu, isData) # Need to apply corrections before doing muon selection
         mu["isPres"] = isPresMuon(mu.dxy, mu.dz, mu.sip3d, mu.eta, mu.pt, mu.miniPFRelIso_all)
         mu["isLooseM"] = isLooseMuon(mu.miniPFRelIso_all,mu.sip3d,mu.looseId)
         mu["isFO"] = isFOMuon(mu.pt, mu.conept, mu.btagDeepFlavB, mu.mvaTTHUL, mu.jetRelIso, year)

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -214,7 +214,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # Define the lists of systematics we include
         obj_correction_syst_lst = [
-            'MuonESUp','MuonESDown','JERUp','JERDown','JESUp','JESDown' # Systs that affect the kinematics of objects
+            'JERUp','JERDown','JESUp','JESDown' # Systs that affect the kinematics of objects
         ]
         wgt_correction_syst_lst = [
             "lepSF_muonUp","lepSF_muonDown","lepSF_elecUp","lepSF_elecDown",f"btagSFbc_{year}Up",f"btagSFbc_{year}Down","btagSFbc_corrUp","btagSFbc_corrDown",f"btagSFlight_{year}Up",f"btagSFlight_{year}Down","btagSFlight_corrUp","btagSFlight_corrDown","PUUp","PUDown","PreFiringUp","PreFiringDown","triggerSFUp","triggerSFDown", # Exp systs
@@ -273,9 +273,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             weights_obj_base_for_kinematic_syst = copy.deepcopy(weights_obj_base)
 
             # Rochester corrections
-            if syst_var == 'MuonESUp': mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='up')
-            elif syst_var == 'MuonESDown': mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='down')
-            else: mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='nominal')
+            mu["pt"]=ApplyRochesterCorrections(year, mu, isData, var='nominal')
 
             # Muon selection
             mu["isPres"] = isPresMuon(mu.dxy, mu.dz, mu.sip3d, mu.eta, mu.pt, mu.miniPFRelIso_all)

--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -502,7 +502,7 @@ def ApplyJetSystematics(cleanedJets,syst_var):
 # https://gitlab.cern.ch/akhukhun/roccor
 # https://github.com/CoffeaTeam/coffea/blob/master/coffea/lookup_tools/rochester_lookup.py
 
-def ApplyRochesterCorrections(year, mu, is_data, var='nominal'):
+def ApplyRochesterCorrections(year, mu, is_data):
     if year=='2016': rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2016bUL.txt"), loaduncs=True)
     elif year=='2016APV': rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2016aUL.txt"), loaduncs=True)
     elif year=='2017': rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2017UL.txt"), loaduncs=True)
@@ -522,10 +522,8 @@ def ApplyRochesterCorrections(year, mu, is_data, var='nominal'):
         corrections = ak.unflatten(corrections, ak.num(mu.pt, axis=1))
     else:
         corrections = rochester.kScaleDT(mu.charge, mu.pt, mu.eta, mu.phi)
-    if var == 'nominal': 
-        return(mu.pt * corrections) #nominal
-    else:
-        raise RuntimeError("Up/Down fluctuations removed for Rochester corrections!")
+
+    return (mu.pt * corrections)
 
 ###### Trigger SFs
 ################################################################

--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -513,25 +513,19 @@ def ApplyRochesterCorrections(year, mu, is_data, var='nominal'):
         mc_rand = np.random.rand(*ak.to_numpy(ak.flatten(mu.pt)).shape)
         mc_rand = ak.unflatten(mc_rand, ak.num(mu.pt, axis=1))
         corrections = np.array(ak.flatten(ak.ones_like(mu.pt)))
-        errors = np.array(ak.flatten(ak.ones_like(mu.pt)))
         
         mc_kspread = rochester.kSpreadMC(mu.charge[hasgen],mu.pt[hasgen],mu.eta[hasgen],mu.phi[hasgen],mu.matched_gen.pt[hasgen])
         mc_ksmear = rochester.kSmearMC(mu.charge[~hasgen],mu.pt[~hasgen],mu.eta[~hasgen],mu.phi[~hasgen],mu.nTrackerLayers[~hasgen],mc_rand[~hasgen])
-        errspread = rochester.kSpreadMCerror(mu.charge[hasgen],mu.pt[hasgen],mu.eta[hasgen],mu.phi[hasgen],mu.matched_gen.pt[hasgen])
-        errsmear = rochester.kSmearMCerror(mu.charge[~hasgen],mu.pt[~hasgen],mu.eta[~hasgen],mu.phi[~hasgen],mu.nTrackerLayers[~hasgen],mc_rand[~hasgen])
         hasgen_flat = np.array(ak.flatten(hasgen))
         corrections[hasgen_flat] = np.array(ak.flatten(mc_kspread))
         corrections[~hasgen_flat] = np.array(ak.flatten(mc_ksmear))
-        errors[hasgen_flat] = np.array(ak.flatten(errspread))
-        errors[~hasgen_flat] = np.array(ak.flatten(errsmear))
         corrections = ak.unflatten(corrections, ak.num(mu.pt, axis=1))
-        errors = ak.unflatten(errors, ak.num(mu.pt, axis=1))
     else:
         corrections = rochester.kScaleDT(mu.charge, mu.pt, mu.eta, mu.phi)
-        errors = rochester.kScaleDTerror(mu.charge, mu.pt, mu.eta, mu.phi)
-    if var=='nominal': return(mu.pt * corrections) #nominal
-    elif var=='up': return(mu.pt * corrections + mu.pt * errors) #up 
-    elif var=='down': return(mu.pt * corrections - mu.pt * errors) #down
+    if var == 'nominal': 
+        return(mu.pt * corrections) #nominal
+    else:
+        raise RuntimeError("Up/Down fluctuations removed for Rochester corrections!")
 
 ###### Trigger SFs
 ################################################################


### PR DESCRIPTION
As per issue #233, it was decided that we can drop the up/down fluctuations for the Rochester corrections. This PR removes the steps involved with calculating those fluctuations and also moves the muon/tau/loose/FO selections back outside of the `syst_var` loop as these objects no longer depend on anything from that loop and can just be calculated a single time, instead of once per systematic fluctuation.

I've also shuffled around where the Tau selection occurs to move it closer to where the Electron and Muon selection happens as I believe it only depends on the loose selection criteria and nothing else. However, I would like to make sure someone double checks that this is the case.