### PR TITLE
To Runner() interface

### DIFF
--- a/analysis/btagMCeff/run.py
+++ b/analysis/btagMCeff/run.py
@@ -64,9 +64,11 @@ if __name__ == '__main__':
 
   processor_instance = btagMCeff.AnalysisProcessor(samplesdict)
 
-  # Run the processor and get the output
+  executor = processor.FuturesExecutor(workers=nworkers, pre_workers=1)
+  runner = processor.Runner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+
   tstart = time.time()
-  output = processor.run_uproot_job(flist, treename=treename, processor_instance=processor_instance, executor=processor.futures_executor, executor_args={"schema": NanoAODSchema,'workers': nworkers, 'pre_workers': 1}, chunksize=chunksize, maxchunks=nchunks)
+  output = runner(flist, treename, processor_instance)
   dt = time.time() - tstart
 
   nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -86,8 +86,6 @@ if executor == "work_queue":
     executor_args = {
         'master_name': '{}-workqueue-coffea'.format(os.environ['USER']),
 
-        'xrootdtimeout': 180,
-
         # find a port to run work queue in this range:
         'port': [9123,9130],
 
@@ -97,9 +95,6 @@ if executor == "work_queue":
 
         'environment_file': remote_environment.get_environment(),
         'extra_input_files': extra_input_files_lst,
-
-        'schema': NanoAODSchema,
-        'skipbadfiles': False,
 
         # use mid-range compression for chunks results. 9 is the default for work
         # queue in coffea. Valid values are 0 (minimum compression, less memory
@@ -160,27 +155,14 @@ if executor == "work_queue":
 tstart = time.time()
 
 if executor == "futures":
-    output = processor.run_uproot_job(
-        flist,
-        treename=treename,
-        processor_instance=processor_instance,
-        executor=processor.futures_executor,
-        executor_args={"schema": NanoAODSchema,'workers': 8},
-        chunksize=chunksize,
-        maxchunks=nchunks,
-    )
-elif executor == "work_queue":
-    output = processor.run_uproot_job(
-        flist,
-        treename=treename,
-        processor_instance=processor_instance,
-        executor=processor.work_queue_executor,
-        executor_args=executor_args,
-        chunksize=chunksize,
-        maxchunks=nchunks,
-    )
+    exec_instance = processor.FuturesExecutor(workers=8)
+elif executor ==  "work_queue":
+    exec_instance = processor.WorkQueueExecutor(**executor_args)
 else:
-  raise Exception(f"Executor \"{executor}\" is not known.")
+    raise Exception(f"Executor \"{executor}\" is not known.")
+
+runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
+output = runner(flist, treename, processor_instance)
 
 dt = time.time() - tstart
 

--- a/analysis/topEFT/Genrun.py
+++ b/analysis/topEFT/Genrun.py
@@ -76,9 +76,12 @@ if __name__ == '__main__':
 
   processor_instance = Gentopeft.AnalysisProcessor(samplesdict,wc_lst,do_errors)
 
+  exec_instance = processor.IterativeExecutor(workers=nworkers, pre_workers=1)
+  runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+
   # Run the processor and get the output
   tstart = time.time()
-  output = processor.run_uproot_job(flist, treename=treename, processor_instance=processor_instance, executor=processor.iterative_executor, executor_args={"schema": NanoAODSchema,'workers': nworkers, 'pre_workers': 1}, chunksize=chunksize, maxchunks=nchunks)
+  output = runner(flist, treename, processor_instance)
   dt = time.time() - tstart
 
   nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))

--- a/analysis/topEFT/run.py
+++ b/analysis/topEFT/run.py
@@ -199,19 +199,22 @@ if __name__ == '__main__':
     print('Wilson Coefficients: {}.'.format(wc_print))
   else:
     print('No Wilson coefficients specified')
- 
+
   processor_instance = topeft.AnalysisProcessor(samplesdict,wc_lst,hist_lst,ecut_threshold,do_errors,do_systs,split_lep_flavor,skip_sr,skip_cr)
+
+  exec_instance = processor.FuturesExecutor(workers=nworkers)
+  runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
 
   # Run the processor and get the output
   tstart = time.time()
-  output = processor.run_uproot_job(flist, treename=treename, processor_instance=processor_instance, executor=processor.futures_executor, executor_args={"schema": NanoAODSchema,'workers': nworkers}, chunksize=chunksize, maxchunks=nchunks)
+  output = runner(flist, treename, processor_instance)
   dt = time.time() - tstart
 
   nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
   nfilled = sum(sum(np.sum(arr > 0) for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
   print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
   print("Processing time: %1.2f s with %i workers (%.2f s cpu overall)" % (dt, nworkers, dt*nworkers, ))
- 
+
   # Save the output
   if not os.path.isdir(outpath): os.system("mkdir -p %s"%outpath)
   out_pkl_file = os.path.join(outpath,outname+".pkl.gz")

--- a/analysis/topEFT/work_queue_run.py
+++ b/analysis/topEFT/work_queue_run.py
@@ -207,7 +207,6 @@ processor_instance = topeft.AnalysisProcessor(samplesdict,wc_lst,hist_lst,ecut_t
 
 executor_args = {
     'master_name': '{}-workqueue-coffea'.format(os.environ['USER']),
-    'xrootdtimeout': 180,
 
     # find a port to run work queue in this range:
     'port': port,
@@ -218,9 +217,6 @@ executor_args = {
 
     'environment_file': remote_environment.get_environment(),
     'extra_input_files': ["topeft.py"],
-
-    'schema': NanoAODSchema,
-    'skipbadfiles': False,
 
     'retries': 5,
 
@@ -281,7 +277,11 @@ executor_args = {
 
 # Run the processor and get the output
 tstart = time.time()
-output = processor.run_uproot_job(flist, treename=treename, processor_instance=processor_instance, executor=processor.work_queue_executor, executor_args=executor_args, chunksize=chunksize, maxchunks=nchunks)
+
+executor = processor.WorkQueueExecutor(**executor_args)
+runner = processor.Runner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
+output = runner(flist, treename, processor_instance)
+
 dt = time.time() - tstart
 
 print('Processed {} events in {} seconds ({:.2f} evts/sec).'.format(nevts_total,dt,nevts_total/dt))


### PR DESCRIPTION
For a while now the `run_uproot_job` function in coffea has been deprecated. This pr updates the calls to `run_uproot_job` to the new `Runner()` interface. Some of the advantages are that the arguments for the executor and the actual run are separated, and that that the arguments to the executor are now checked by python.