### PR TITLE
Remove bad output files causing duplicated events

### DIFF
--- a/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_D-HIPM_UL2016_NDSkim.json
@@ -10,7 +10,6 @@
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_D_HIPM_UL2016/output_375.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_D_HIPM_UL2016/output_39.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_D_HIPM_UL2016/output_42.root",
-    "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_D_HIPM_UL2016/output_673.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_D_HIPM_UL2016/output_722.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_D_HIPM_UL2016/output_732.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_D_HIPM_UL2016/output_733.root",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_E-HIPM_UL2016_NDSkim.json
@@ -13,7 +13,6 @@
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_E_HIPM_UL2016/output_767.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_E_HIPM_UL2016/output_777.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_E_HIPM_UL2016/output_785.root",
-    "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_E_HIPM_UL2016/output_789.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_E_HIPM_UL2016/output_793.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_E_HIPM_UL2016/output_794.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_E_HIPM_UL2016/output_800.root",

--- a/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016_NDSkim.json
+++ b/topcoffea/json/data_samples/2016/DoubleMuon_F-HIPM_UL2016_NDSkim.json
@@ -8,7 +8,6 @@
   "files": [
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_F_HIPM_UL2016/output_128.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_F_HIPM_UL2016/output_334.root",
-    "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_F_HIPM_UL2016/output_555.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_F_HIPM_UL2016/output_642.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_F_HIPM_UL2016/output_644.root",
     "/store/user/awightma/skims/data/NAOD_ULv9_new-lepMVA-v2/2016APV/v1/DoubleMuon_F_HIPM_UL2016/output_779.root",


### PR DESCRIPTION
This PR updates the NDSkim jsons to remove output files that were marked as failed by the lobster skimming, but did not get cleaned up and subsequently included in PR #218.

The command used to re-create the jsons was
```
python make_skim_jsons.py --file ND_data_skim_locations.txt --json-dir ../../topcoffea/json/data_samples
```