### PR TITLE
Un pin pip version

### DIFF
--- a/topcoffea/modules/remote_environment.py
+++ b/topcoffea/modules/remote_environment.py
@@ -38,7 +38,7 @@ packages_json_template = string.Template('''
         ],
         "packages": [
             "python=$py_version",
-            "pip=22.0.4",
+            "pip",
             "conda",
             "conda-pack",
             "dill",


### PR DESCRIPTION
As of @btovar's latest updates to cctools, it is no longer necessary to pin the pip version in topeft. This should also solve the timeout issue we were having with the wq test in the CI. 