### PR TITLE
Fix for the HistEFT rebin method to preserve bin array shape

### DIFF
--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -643,12 +643,6 @@ class HistEFT(coffea.hist.Hist):
         anew[view_ax(inew)] += array[view_ax(iold)]
       return anew
 
-    # def dense_op(array):
-    #   anew = np.zeros(shape=(*out._dense_shape,out._ncoeffs), dtype=out._dtype)
-    #   for iold, inew in enumerate(binmap):
-    #     anew[view_ax(inew)] += array[view_ax(iold)]
-    #   return anew
-
     for key in self._sumw:
       out._sumw[key] = dense_op(self._sumw[key])
       if self._sumw2 is not None:

--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -633,10 +633,21 @@ class HistEFT(coffea.hist.Hist):
     binmap = [new_axis.index(i) for i in old_axis.identifiers(overflow='allnan')]
 
     def dense_op(array):
-      anew = np.zeros(shape=(*out._dense_shape,out._ncoeffs), dtype=out._dtype)
+      if array.shape != self._dense_shape:
+        newshape = (*out._dense_shape,out._ncoeffs)
+      else:
+        newshape = out._dense_shape
+
+      anew = np.zeros(shape=newshape, dtype=out._dtype)
       for iold, inew in enumerate(binmap):
         anew[view_ax(inew)] += array[view_ax(iold)]
       return anew
+
+    # def dense_op(array):
+    #   anew = np.zeros(shape=(*out._dense_shape,out._ncoeffs), dtype=out._dtype)
+    #   for iold, inew in enumerate(binmap):
+    #     anew[view_ax(inew)] += array[view_ax(iold)]
+    #   return anew
 
     for key in self._sumw:
       out._sumw[key] = dense_op(self._sumw[key])


### PR DESCRIPTION
Fixes a bug in `HistEFT` where if you call the `rebin()` method. Bins without an EFT parameterization were getting converted into a form as if they were meant to have an EFT parameterization. Basically 1D arrays were getting turned into 2D arrays. Below is a MRE that should better illustrate the point:
```python
from coffea.hist import StringBin, Cat, Bin
from topcoffea.modules.HistEFT import HistEFT

wcnames = ["ctG"]
h = HistEFT("Events",wcnames,Cat("sample","sample"),Bin("pt","pt",5,0,5))

coeffs = [
    [1,2,3],
]

h.fill(sample="EFT",pt=1.0,eft_coeff=coeffs)
h.fill(sample="EFT",pt=2.0,eft_coeff=coeffs)
h.fill(sample="EFT",pt=5.0,eft_coeff=coeffs)

h.fill(sample="SM",pt=1.0,eft_coeff=None)
h.fill(sample="SM",pt=2.0,eft_coeff=None)
h.fill(sample="SM",pt=5.0,eft_coeff=None)

new_edges = [0,3,5]
h_rebin = h.rebin("pt",Bin("pt","pt",new_edges))

print("-"*50)
print("- Before calling .rebin()")
print("-"*50)
for k,v in h._sumw.items():
    print(k); print(v);
print("")
print("-"*50)
print("- After calling .rebin()")
print("-"*50)
for k,v in h_rebin._sumw.items():
    print(k); print(v);
```
The fix was to make sure that shape of the dense axis is preserved during rebinning.