### PR TITLE
Update wq run timeout to 400s

### DIFF
--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -32,6 +32,6 @@ def test_topcoffea_wq():
 
     # Run TopCoffea
     with factory:
-        subprocess.run(args, cwd="analysis/topEFT", timeout=300)
+        subprocess.run(args, cwd="analysis/topEFT", timeout=400)
 
     assert(exists('analysis/topEFT/histos/output_check_yields_wq.pkl.gz'))


### PR DESCRIPTION
As suggested by @btovar, this PR updates the WQ timeout (for the wq CI test) from 300s to 400s. 