### PR TITLE
decrease max backoff of wq worker in test

### DIFF
--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -11,6 +11,8 @@ def test_topcoffea_wq():
     factory.min_workers=1
     factory.cores=2
 
+    factory.extra_options="--max-backoff 15"
+
     args = [
         "time",
         "python",


### PR DESCRIPTION
This should help eliminate the wq test timing-out, as the worker won't
wait for a long time between retries contacting the master.