### PR TITLE
Un pin uproot

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,3 @@ dependencies:
   - dill
   - xrootd
   - git
-  - uproot=4.2.3

--- a/topcoffea/modules/remote_environment.py
+++ b/topcoffea/modules/remote_environment.py
@@ -42,7 +42,6 @@ packages_json_template = string.Template('''
             "conda",
             "conda-pack",
             "dill",
-	    "uproot=4.2.3",
             "xrootd"
         ]
     },


### PR DESCRIPTION
Pinning uproot no longer necessary since the problematic change in uproot has been reverted. 