### PR TITLE
Split SR and CR bkg samples into their own cfgs

### DIFF
--- a/analysis/topEFT/fullR2_run.sh
+++ b/analysis/topEFT/fullR2_run.sh
@@ -3,12 +3,15 @@
 # Name the output
 OUT_NAME="example_name"
 
-# Build the run command
+# Build the run command for filling SR histos
 CFGS="../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_NDSkim.cfg,../../topcoffea/cfg/data_samples_NDSkim.cfg"
 OPTIONS="--hist-list ana --skip-cr --do-systs -s 50000 --do-np --do-renormfact-envelope -o $OUT_NAME" # For analysis
+
+# Build the run command for filling CR histos
+#CFGS="../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_cr_NDSkim.cfg,../../topcoffea/cfg/data_samples_NDSkim.cfg"
 #OPTIONS="--hist-list cr --skip-sr --do-systs --do-np --do-renormfact-envelope --wc-list ctG -o $OUT_NAME" # For CR plots
-RUN_COMMAND="time python work_queue_run.py $CFGS $OPTIONS"
 
 # Run the processor over all Run2 samples
+RUN_COMMAND="time python work_queue_run.py $CFGS $OPTIONS"
 printf "\nRunning the following command:\n$RUN_COMMAND\n\n"
 $RUN_COMMAND

--- a/topcoffea/cfg/mc_background_samples_NDSkim.cfg
+++ b/topcoffea/cfg/mc_background_samples_NDSkim.cfg
@@ -1,23 +1,10 @@
-# Central background samples
+# Central background samples (relevant for both SRs and CRs)
 
 # Central UL16APV background samples
 #root://ndcms.crc.nd.edu/
 root://deepthought.crc.nd.edu/
 ../../topcoffea/json/background_samples/central_UL/UL16APV_TTGamma_Dilept_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16APV_TTGamma_SingleLept_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL16APV_ZGToLLG_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_TTTo2L2Nu_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_TTToSemiLeptonic_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_DY10to50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_DY50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_ST_antitop_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_ST_top_s-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_ST_top_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_tbarW_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL16APV_TTGJets_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL16APV_TTJets_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_tW_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16APV_WJetsToLNu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16APV_WWTo2L2Nu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16APV_WWW_4F_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16APV_WWZ_4F_NDSkim.json
@@ -31,19 +18,6 @@ root://deepthought.crc.nd.edu/
 root://deepthought.crc.nd.edu/
 ../../topcoffea/json/background_samples/central_UL/UL16_TTGamma_Dilept_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16_TTGamma_SingleLept_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_TTTo2L2Nu_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_TTToSemiLeptonic_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_DY10to50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_DY50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_tbarW_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL16_TTGJets_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL16_TTJets_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_tW_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16_WWTo2L2Nu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16_WWW_4F_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL16_WWZ_4F_NDSkim.json
@@ -57,19 +31,6 @@ root://deepthought.crc.nd.edu/
 root://deepthought.crc.nd.edu/
 ../../topcoffea/json/background_samples/central_UL/UL17_TTGamma_Dilept_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL17_TTGamma_SingleLept_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_TTTo2L2Nu_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_TTToSemiLeptonic_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_DY10to50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_DY50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_tbarW_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL17_TTGJets_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL17_TTJets_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_tW_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL17_WWTo2L2Nu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL17_WWW_4F_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL17_WWZ_4F_NDSkim.json
@@ -83,19 +44,6 @@ root://deepthought.crc.nd.edu/
 root://deepthought.crc.nd.edu/
 ../../topcoffea/json/background_samples/central_UL/UL18_TTGamma_Dilept_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL18_TTGamma_SingleLept_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL18_ZGToLLG_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_TTTo2L2Nu_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_TTToSemiLeptonic_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_DY10to50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_DY50_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_ST_antitop_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_ST_top_s-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_ST_top_t-channel_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_tbarW_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL18_TTGJets_NDSkim.json
-#../../topcoffea/json/background_samples/central_UL/UL18_TTJets_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_tW_NDSkim.json
-../../topcoffea/json/background_samples/central_UL/UL18_WJetsToLNu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL18_WWTo2L2Nu_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL18_WWW_4F_NDSkim.json
 ../../topcoffea/json/background_samples/central_UL/UL18_WWZ_4F_NDSkim.json

--- a/topcoffea/cfg/mc_background_samples_cr_NDSkim.cfg
+++ b/topcoffea/cfg/mc_background_samples_cr_NDSkim.cfg
@@ -1,0 +1,63 @@
+# Central background samples (just relevant for CRs)
+
+# Central UL16APV background samples
+#root://ndcms.crc.nd.edu/
+root://deepthought.crc.nd.edu/
+../../topcoffea/json/background_samples/central_UL/UL16APV_ZGToLLG_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_TTTo2L2Nu_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_TTToSemiLeptonic_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_DY10to50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_DY50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_ST_antitop_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_ST_top_s-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_ST_top_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_tbarW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_tW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16APV_WJetsToLNu_NDSkim.json
+
+# Central UL16 background samples
+#root://ndcms.crc.nd.edu/
+root://deepthought.crc.nd.edu/
+../../topcoffea/json/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_TTTo2L2Nu_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_TTToSemiLeptonic_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_DY10to50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_DY50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_tbarW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_tW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
+
+# Central UL17 background samples
+#root://ndcms.crc.nd.edu/
+root://deepthought.crc.nd.edu/
+../../topcoffea/json/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_TTTo2L2Nu_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_TTToSemiLeptonic_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_DY10to50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_DY50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_tbarW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_tW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
+
+# Central UL18 background samples
+#root://ndcms.crc.nd.edu/
+root://deepthought.crc.nd.edu/
+../../topcoffea/json/background_samples/central_UL/UL18_ZGToLLG_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_TTTo2L2Nu_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_TTToSemiLeptonic_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_DY10to50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_DY50_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_ST_antitop_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_ST_top_s-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_ST_top_t-channel_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_tbarW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_tW_NDSkim.json
+../../topcoffea/json/background_samples/central_UL/UL18_WJetsToLNu_NDSkim.json
+
+


### PR DESCRIPTION
This PR splits the cfg file for skimmed background samples into two separate configs. One config is relevant for both SRs and CRs, and the other is relevant just for CRs. This PR should speed up the processing of our normal SR runs (slightly) since we will no longer have to process samples that are relevant only for the CRs. 