### PR TITLE
Updates to SM yields table script

### DIFF
--- a/analysis/topEFT/get_datacard_yields.py
+++ b/analysis/topEFT/get_datacard_yields.py
@@ -24,6 +24,7 @@ PROC_ORDER = [
      "tttt_sm",
      "Sum_sig",
      "Sum_expected",
+     "Observation",
 ]
 CAT_ORDER = [
     "2lss_m_3b",
@@ -115,6 +116,7 @@ def get_rates(dc_lines_lst):
     # Get the rate and processes from the datacard
     dc_proc_line = None
     dc_rate_line = None
+    dc_observation_line = None
     for dc_line in dc_lines_lst:
         # The first line starting with "process" is the one we're after
         if dc_proc_line is None and dc_line.startswith("process"):
@@ -122,10 +124,14 @@ def get_rates(dc_lines_lst):
         # Also get the rate line (note there's only one of these)
         if dc_line.startswith("rate"):
             dc_rate_line = dc_line
+        # Get the observation line
+        if dc_line.startswith("observation"):
+            dc_observation_line = dc_line
 
     # Get lst from lines (drop the "process" and "rate" string first elements)
     proc_lst = dc_proc_line.split()[1:]
     rate_lst = dc_rate_line.split()[1:]
+    observation = dc_observation_line.split()[1] # This just has one number
 
     # Check length
     n_cats = len(proc_lst)
@@ -136,6 +142,7 @@ def get_rates(dc_lines_lst):
     rate_dict = {}
     for i in range(n_cats):
         rate_dict[proc_lst[i]] = float(rate_lst[i])
+    rate_dict["Observation"] = float(observation)
 
     return(rate_dict)
 
@@ -144,7 +151,7 @@ def get_rates(dc_lines_lst):
 def get_just_sm(rate_dict):
     sm_dict = {}
     for proc_name, rate in rate_dict.items():
-        if not proc_name.endswith("_sm"): continue
+        if not proc_name.endswith("_sm") and proc_name != "Observation": continue
         sm_dict[proc_name] = rate
     return sm_dict
 
@@ -258,6 +265,7 @@ def main():
     for dc_fname in dc_files:
         rate_dict_sm = get_sm_rates(os.path.join(args.datacards_dir_path,dc_fname))
         cat_name = get_cat_name_from_dc_name(dc_fname)
+        print("rate_dict_sm",rate_dict_sm)
         print(cat_name)
         printd(rate_dict_sm)
         all_rates_dict[cat_name] = rate_dict_sm

--- a/analysis/topEFT/get_datacard_yields.py
+++ b/analysis/topEFT/get_datacard_yields.py
@@ -211,7 +211,6 @@ def comb_dict(in_dict):
     cat_name_lst = in_dict.keys()
     for cat_name in in_dict.keys():
         cat_name_base = get_base_cat_name(cat_name)
-        print("cat name:",cat_name,cat_name_base)
         if cat_name_base not in out_dict:
             out_dict[cat_name_base] = in_dict[cat_name]
         else:
@@ -276,7 +275,16 @@ def main():
 
     # Dump to the screen text for a latex table
     all_rates_dict_none_errs = append_none_errs(all_rates_dict) # Get a dict that will work for the latex table (i.e. need None for errs)
-    mlt.print_latex_yield_table(all_rates_dict_none_errs,tag="SM yields",key_order=CAT_ORDER,subkey_order=PROC_ORDER,print_begin_info=True,print_end_info=True,column_variable="keys")
+    mlt.print_latex_yield_table(
+        all_rates_dict_none_errs,
+        tag="SM yields",
+        key_order=CAT_ORDER,
+        subkey_order=PROC_ORDER,
+        print_begin_info=True,
+        print_end_info=True,
+        column_variable="keys",
+        hz_line_lst=[4,5,11,12,13],
+    )
 
     # Save yields to a json
     out_json_name = args.json_name

--- a/topcoffea/modules/MakeLatexTable.py
+++ b/topcoffea/modules/MakeLatexTable.py
@@ -29,7 +29,7 @@ def print_end():
     print("\n")
 
 # Print the body of the latex table
-def print_table(vals_dict,key_order,subkey_order,caption_text,print_errs,columns):
+def print_table(vals_dict,key_order,subkey_order,caption_text,print_errs,columns,hz_line_lst):
     print("\\begin{table}[hbtp!]")
     print("\\setlength\\tabcolsep{5pt}")
     print(f"\\caption{{{caption_text}}}") # Need to escape the "{" with another "{"
@@ -40,7 +40,7 @@ def print_table(vals_dict,key_order,subkey_order,caption_text,print_errs,columns
         tabular_info = "c"*(len(subkey_order)+1)
         print(f"\\begin{{tabular}}{{{tabular_info}}}")
         print(format_header(subkey_order))
-        for key in key_order:
+        for i,key in enumerate(key_order):
             if key not in vals_dict.keys():
                 print("\\rule{0pt}{3ex} ","-",end=' ')
                 for subkey in subkey_order:
@@ -56,14 +56,16 @@ def print_table(vals_dict,key_order,subkey_order,caption_text,print_errs,columns
                         print("&",val,"$\pm$",err,end=' ')
                     else:
                         print("&",val,end=' ')
-            print("\\\ ")
+            if i not in hz_line_lst: endl_str = "\\\ "
+            else: endl_str = "\\\ \hline "
+            print(endl_str)
 
     # Print keys as columns
     elif columns == "keys":
         tabular_info = "c"*(len(key_order)+1)
         print(f"\\begin{{tabular}}{{{tabular_info}}}")
         print(format_header(key_order))
-        for subkey in subkey_order:
+        for i,subkey in enumerate(subkey_order):
             print("\\rule{0pt}{3ex} ",subkey.replace("_"," "),end=' ')
             for key in key_order:
                 if key not in vals_dict.keys():
@@ -76,7 +78,9 @@ def print_table(vals_dict,key_order,subkey_order,caption_text,print_errs,columns
                         print("&",val,"$\pm$",err,end=' ')
                     else:
                         print("&",val,end=' ')
-            print("\\\ ")
+            if i not in hz_line_lst: endl_str = "\\\ "
+            else: endl_str = "\\\ \hline "
+            print(endl_str)
 
     else:
         raise Exception(f"\nError: Unknown column type \"{columns}\". Exiting...\n")
@@ -86,7 +90,7 @@ def print_table(vals_dict,key_order,subkey_order,caption_text,print_errs,columns
     print("\\end{table}")
 
 # Wrapper function for printing a table
-def print_latex_yield_table(vals_dict,key_order=None,subkey_order=None,tag="",print_begin_info=False,print_end_info=False,print_errs=False,column_variable="subkeys"):
+def print_latex_yield_table(vals_dict,key_order=None,subkey_order=None,tag="",print_begin_info=False,print_end_info=False,print_errs=False,column_variable="subkeys",hz_line_lst=[None]):
 
     # If order for columns and rows not specified, just use the keys of the dict:
     if key_order is None:
@@ -98,6 +102,6 @@ def print_latex_yield_table(vals_dict,key_order=None,subkey_order=None,tag="",pr
 
     # Print the table
     if print_begin_info: print_begin()
-    print_table(vals_dict,key_order,subkey_order,tag,print_errs,columns=column_variable)
+    print_table(vals_dict,key_order,subkey_order,tag,print_errs,columns=column_variable,hz_line_lst=hz_line_lst)
     if print_end_info: print_end()
 


### PR DESCRIPTION
This PR updates the `get_datacard_yields.py` script to make a SM yield table from differential data cards (previously it assumed `njets` cards, which the new datacard maker can't make, so we need to be able to make yields tables from the differential cards). 