### PR TITLE
Minor updates

### DIFF
--- a/analysis/topEFT/get_datacard_yields.py
+++ b/analysis/topEFT/get_datacard_yields.py
@@ -42,17 +42,17 @@ CAT_ORDER = [
 
 RENAME_CAT_MAP = {
     # name_in_card : name_we_want_want_in_the_table
-    "2lss_4t_m_2b" : "2lss_m_3b",
-    "2lss_4t_p_2b" : "2lss_p_3b",
-    "2lss_m_2b"    : "2lss_m_2b",
-    "2lss_p_2b"    : "2lss_p_2b",
+    "2lss_4t_m"    : "2lss_m_3b",
+    "2lss_4t_p"    : "2lss_p_3b",
+    "2lss_m"       : "2lss_m_2b",
+    "2lss_p"       : "2lss_p_2b",
     "3l_m_offZ_1b" : "3l_m_1b",
     "3l_m_offZ_2b" : "3l_m_2b",
     "3l_p_offZ_1b" : "3l_p_1b",
     "3l_p_offZ_2b" : "3l_p_2b",
     "3l_onZ_1b"    : "3l_onZ_1b",
     "3l_onZ_2b"    : "3l_onZ_2b",
-    "4l_2b"        : "4l_2b",
+    "4l"           : "4l_2b",
 }
 
 

--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -263,7 +263,7 @@ def main():
     # Check selected WCs against what's currently the list being assumed by the physcis model
     # Right now we're set to raise an exception if these files differ (warnings are easy to miss, and we really want the user to notice)
     # If you know what you're doing and expet them to differ, then just bypass this
-    if not args.skip_selected_wcs_check:
+    if not args.skip_selected_wcs_check and not use_selected:
         with open(args.selected_wcs_ref,"r") as selected_wcs_ref_f:
             selected_wcs_ref_data = selected_wcs_ref_f.read()
         selected_wcs_ref = json.loads(selected_wcs_ref_data)


### PR DESCRIPTION
This PR includes two minor, unrelated updates:
* Edit the logic in the datacard maker's selected WCs check so that the check is skipped in the case that we are providing the script with a set of WCs.
* Fix the names in the channel name map in the `get_datacard_yields.py` script to match the category names in the new datacard maker.   