### PR TITLE
Add datacard option to process a specific year

### DIFF
--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -111,6 +111,8 @@ def run_condor(dc,pkl_fpath,out_dir,var_lst,ch_lst,chunk_size):
         other_opts.append("--verbose")
     if dc.use_real_data:
         other_opts.append("--unblind")
+    if dc.year:
+        other_opts.extend(["--year",dc.year])
     other_opts = " ".join(other_opts)
 
     idx = 0
@@ -170,7 +172,7 @@ def main():
     rs_json    = args.rate_syst_json
     mp_file    = args.miss_parton_file
     out_dir    = args.out_dir
-    # year      = args.year     # NOT IMPLEMENTED YET
+    year       = args.year
     var_lst    = args.var_lst
     ch_lst     = args.ch_lst
     do_mc_stat = args.do_mc_stat
@@ -209,6 +211,7 @@ def main():
         "do_nuisance": do_nuis,
         "unblind": unblind,
         "verbose": verbose,
+        "single_year": year,
     }
 
     if out_dir != "." and not os.path.exists(out_dir):

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -297,6 +297,9 @@ class DatacardMaker():
         self.use_real_data   = kwargs.pop("unblind",False)
         self.verbose         = kwargs.pop("verbose",True)
 
+        if self.year and not self.year in self.YEARS:
+            raise ValueError(f"Invalid year choice '{self.year}', should be empty if running over all years or one of: {self.YEARS}")
+
         rate_syst_path = kwargs.pop("rate_systs_path","json/rate_systs.json")
         lumi_json_path = kwargs.pop("lumi_json_path","json/lumi.json")
         miss_part_path = kwargs.pop("missing_parton_path","data/missing_parton/missing_parton.root")
@@ -392,7 +395,15 @@ class DatacardMaker():
             for x in h.identifiers("sample"):
                 p = self.get_process(x.name)
                 if p in self.ignore:
+                    if self.verbose: print(f"Skipping (ignored): {x.name}")
                     to_remove.append(x.name)
+                    continue
+                if self.year:
+                    yr = self.get_year(x.name)
+                    if yr != self.year:
+                        if self.verbose: print(f"Skipping (year): {x.name}")
+                        to_remove.append(x.name)
+                        continue
             h = h.remove(to_remove,"sample")
 
             if not self.do_nuisance:


### PR DESCRIPTION
This PR implements the `--year` command line option that was previously available in the old dc maker, but didn't get implemented in the rewrite.

**Note:** A somewhat important difference between what arguments to use for the new dc maker vs. the old one is that the year string needs to be one of "UL16", "UL16APV", "UL17", "UL18" as opposed to simply "2017", which was the case I think for the old dc maker. This is b/c the year is determined from the category name from the "sample" histogram axis, which uses the "UL+YR" convention, which itself ultimately stems from the [`histAxisName`](https://github.com/TopEFT/topcoffea/blob/master/topcoffea/json/signal_samples/private_UL/UL17_ttllJet_b1.json#L5) specified in the json files. It should also be noted that the sample name is the only place to we're able to get the year information (which is a big reason correlating only a subset of years was so tricky)