### PR TITLE
Handle non eft cases in copy_sm()

### DIFF
--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -194,9 +194,9 @@ class HistEFT(coffea.hist.Hist):
     for sparse_key in self._sumw.keys():
       is_eft_bin = (self._sumw[sparse_key].shape != self._dense_shape)
       if is_eft_bin:
-        out._sumw[sparse_key]=self._sumw[sparse_key][:,0]
+        out._sumw[sparse_key] = np.copy(self._sumw[sparse_key][:,0])
       else:
-        out._sumw[sparse_key]=self._sumw[sparse_key]
+        out._sumw[sparse_key] = np.copy(self._sumw[sparse_key])
       out._sumw2[sparse_key]=np.zeros_like(out._sumw[sparse_key])
     return out
 

--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -192,7 +192,11 @@ class HistEFT(coffea.hist.Hist):
     out._sumw = {}
     out._sumw2 = {}
     for sparse_key in self._sumw.keys():
-      out._sumw[sparse_key]=self._sumw[sparse_key][:,0]
+      is_eft_bin = (self._sumw[sparse_key].shape != self._dense_shape)
+      if is_eft_bin:
+        out._sumw[sparse_key]=self._sumw[sparse_key][:,0]
+      else:
+        out._sumw[sparse_key]=self._sumw[sparse_key]
       out._sumw2[sparse_key]=np.zeros_like(out._sumw[sparse_key])
     return out
 


### PR DESCRIPTION
This PR adds a check so that non-EFT samples can be handled in the `copy_sm()` method. This does not come up in most of our use cases, but I did run into it a few weeks ago while running the non prompt estimation on a pkl file that had central signal samples. The error was this:
```
Traceback (most recent call last):
  File "/afs/crc.nd.edu/user/k/kmohrman/coffea_dir/check_PRs/kmohrman_histeft/topcoffea/analysis/topEFT/do_np.py", line 12, in <module>
    ddp = DataDrivenProducer(out_pkl_file,out_pkl_file_np)
  File "/afs/crc.nd.edu/user/k/kmohrman/coffea_dir/check_PRs/kmohrman_histeft/topcoffea/topcoffea/modules/dataDrivenEstimation.py", line 22, in __init__
    self.DDFakes()
  File "/afs/crc.nd.edu/user/k/kmohrman/coffea_dir/check_PRs/kmohrman_histeft/topcoffea/topcoffea/modules/dataDrivenEstimation.py", line 129, in DDFakes
    hPromptSub = hPromptSub.copy_sm()
  File "/afs/crc.nd.edu/user/k/kmohrman/coffea_dir/check_PRs/kmohrman_histeft/topcoffea/topcoffea/modules/HistEFT.py", line 195, in copy_sm
    out._sumw[sparse_key]=self._sumw[sparse_key][:,0]
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```
The updates in this PR works around the error. Probably I should have committed this somewhere a few weeks ago when I first ran into it, but I never did, and sort of forgot about the changes, but came across them recently while cleaning up my repository, so I figured it might be useful to commit them.

However, I'm certainly not an expert on HistEFT and have not modified it as much as e.g. @Andrew42, so @Andrew42 (and @bryates, and anyone else who might want to take a look), it would be great if you could check this PR for anything that looks suspicious or wrong. Thanks 