### PR TITLE
Make renormalization & factorization independent per-process systematics

### DIFF
--- a/analysis/topEFT/fullR2_run.sh
+++ b/analysis/topEFT/fullR2_run.sh
@@ -5,11 +5,11 @@ OUT_NAME="example_name"
 
 # Build the run command for filling SR histos
 CFGS="../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_NDSkim.cfg,../../topcoffea/cfg/data_samples_NDSkim.cfg"
-OPTIONS="--hist-list ana --skip-cr --do-systs -s 50000 --do-np --do-renormfact-envelope -o $OUT_NAME" # For analysis
+OPTIONS="--hist-list ana --skip-cr --do-systs -s 50000 --do-np -o $OUT_NAME" # For analysis
 
 # Build the run command for filling CR histos
 #CFGS="../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_cr_NDSkim.cfg,../../topcoffea/cfg/data_samples_NDSkim.cfg"
-#OPTIONS="--hist-list cr --skip-sr --do-systs --do-np --do-renormfact-envelope --wc-list ctG -o $OUT_NAME" # For CR plots
+#OPTIONS="--hist-list cr --skip-sr --do-systs --do-np --wc-list ctG -o $OUT_NAME" # For CR plots
 
 # Run the processor over all Run2 samples
 RUN_COMMAND="time python work_queue_run.py $CFGS $OPTIONS"

--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -113,6 +113,8 @@ def run_condor(dc,pkl_fpath,out_dir,var_lst,ch_lst,chunk_size):
         other_opts.append("--unblind")
     if dc.year_lst:
         other_opts.extend(["--year"," ".join(dc.year_lst)])
+    if dc.drop_syst:
+        other_opts.extend(["--drop-syst"," ".join(dc.drop_syst)])
     other_opts = " ".join(other_opts)
 
     idx = 0

--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -155,6 +155,7 @@ def main():
     parser.add_argument("--ch-lst","-c",default=[],action="extend",nargs="+",help="Specify a list of channels to process.")
     parser.add_argument("--do-mc-stat",action="store_true",help="Add bin-by-bin statistical uncertainties with the autoMCstats option (for background)")
     parser.add_argument("--ignore","-i",default=[],action="extend",nargs="+",help="Specify a list of processes to exclude, must match name from 'sample' axis modulo UL year")
+    parser.add_argument("--drop-syst",default=[],action="extend",nargs="+",help="Specify one or more template systematics to remove from the datacard")
     parser.add_argument("--POI",default=[],help="List of WCs (comma separated)")
     parser.add_argument("--year","-y",default=[],action="extend",nargs="+",help="Run over a subset of years")
     parser.add_argument("--do-nuisance",action="store_true",help="Include nuisance parameters")
@@ -180,6 +181,7 @@ def main():
     wcs        = args.POI
     ignore     = args.ignore
     do_nuis    = args.do_nuisance
+    drop_syst  = args.drop_syst
     unblind    = args.unblind
     verbose    = args.verbose
 
@@ -210,6 +212,7 @@ def main():
         "do_mc_stat": do_mc_stat,
         "ignore": ignore,
         "do_nuisance": do_nuis,
+        "drop_syst": drop_syst,
         "unblind": unblind,
         "verbose": verbose,
         "year_lst": years,

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -280,7 +280,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         ]
         wgt_correction_syst_lst = [
             "lepSF_muonUp","lepSF_muonDown","lepSF_elecUp","lepSF_elecDown",f"btagSFbc_{year}Up",f"btagSFbc_{year}Down","btagSFbc_corrUp","btagSFbc_corrDown",f"btagSFlight_{year}Up",f"btagSFlight_{year}Down","btagSFlight_corrUp","btagSFlight_corrDown","PUUp","PUDown","PreFiringUp","PreFiringDown",f"triggerSF_{year}Up",f"triggerSF_{year}Down", # Exp systs
-            "FSRUp","FSRDown","ISRUp","ISRDown","renormfactUp","renormfactDown", "renormUp","renormDown","factUp","factDown", # Theory systs
+            "FSRUp","FSRDown","ISRUp","ISRDown","renormUp","renormDown","factUp","factDown", # Theory systs
         ]
         data_syst_lst = [
             "FFUp","FFDown","FFptUp","FFptDown","FFetaUp","FFetaDown",f"FFcloseEl_{year}Up",f"FFcloseEl_{year}Down",f"FFcloseMu_{year}Up",f"FFcloseMu_{year}Down"
@@ -309,7 +309,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             weights_obj_base.add('ISR', events.nom, events.ISRUp*(sow/sow_ISRUp), events.ISRDown*(sow/sow_ISRDown))
             weights_obj_base.add('FSR', events.nom, events.FSRUp*(sow/sow_FSRUp), events.FSRDown*(sow/sow_FSRDown))
             # renorm/fact scale
-            weights_obj_base.add('renormfact', events.nom, events.renormfactUp*(sow/sow_renormfactUp), events.renormfactDown*(sow/sow_renormfactDown))
             weights_obj_base.add('renorm', events.nom, events.renormUp*(sow/sow_renormUp), events.renormDown*(sow/sow_renormDown))
             weights_obj_base.add('fact', events.nom, events.factUp*(sow/sow_factUp), events.factDown*(sow/sow_factDown))
             # Prefiring and PU (note prefire weights only available in nanoAODv9)

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -308,6 +308,7 @@ class DatacardMaker():
         self.year_lst        = kwargs.pop("year_lst",[])
         self.do_sm           = kwargs.pop("do_sm",False)
         self.do_nuisance     = kwargs.pop("do_nuisance",False)
+        self.drop_syst       = kwargs.pop("drop_syst",[])
         self.out_dir         = kwargs.pop("out_dir",".")
         self.var_lst         = kwargs.pop("var_lst",[])
         self.do_mc_stat      = kwargs.pop("do_mc_stat",False)
@@ -430,6 +431,18 @@ class DatacardMaker():
             if not self.do_nuisance:
                 # Remove all shape systematics
                 h = prune_axis(h,"systematic",["nominal"])
+
+            if self.drop_syst:
+                to_drop = set()
+                for syst in self.drop_syst:
+                    if syst.endswith("Up"):
+                        to_drop.add(syst)
+                    elif syst.endswith("Down"):
+                        to_drop.add(syst)
+                    else:
+                        to_drop.add(f"{syst}Up")
+                        to_drop.add(f"{syst}Down")
+                h = h.remove(list(to_drop),"systematic")
 
             if km_dist != "njets":
                 edge_arr = self.BINNING[km_dist] + [h.axis(km_dist).edges()[-1]]

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -864,7 +864,8 @@ class DatacardMaker():
                                 hist_name = hist_name.replace(syst_base,split_syst)
                                 all_shapes.add(split_syst)
                                 text_card_info[proc_name]["shapes"].add(split_syst)
-                                print(f"Splitting {syst_base} --> {split_syst}")
+                                if self.verbose:
+                                    print(f"\t {hist_name}: Splitting {syst_base} --> {split_syst}")
                             else:
                                 all_shapes.add(syst_base)
                                 text_card_info[proc_name]["shapes"].add(syst_base)

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -850,8 +850,19 @@ class DatacardMaker():
                             hist_name = f"{proc_name}_{syst}"
                             # Systematics in the text datacard don't have the Up/Down postfix
                             syst_base = syst.replace("Up","").replace("Down","")
-                            all_shapes.add(syst_base)
-                            text_card_info[proc_name]["shapes"].add(syst_base)
+                            if syst_base in ["renorm","fact"]:  # Note: Requires exact matches
+                                # We want to split the renorm and fact systematics to be uncorrelated
+                                #   between processes, so we modify the systematic name to make combine
+                                #   treat them as separate systematics
+                                # TODO: We should move the hardcoded list in the if statement somewhere
+                                #   else to make it less buried in the weeds
+                                split_syst = f"{syst_base}_{proc_name}"
+                                hist_name = hist_name.replace(syst_base,split_syst)
+                                all_shapes.add(split_syst)
+                                text_card_info[proc_name]["shapes"].add(split_syst)
+                            else:
+                                all_shapes.add(syst_base)
+                                text_card_info[proc_name]["shapes"].add(syst_base)
                             syst_width = max(len(syst),syst_width)
                         zero_out_sumw2 = p != "fakes" # Zero out sumw2 for all proc but fakes, so that we only do auto stats for fakes
                         f[hist_name] = to_hist(arr,hist_name,zero_wgts=zero_out_sumw2)

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -442,6 +442,8 @@ class DatacardMaker():
                     else:
                         to_drop.add(f"{syst}Up")
                         to_drop.add(f"{syst}Down")
+                for x in to_drop:
+                    print(f"Removing systematic: {x}")
                 h = h.remove(list(to_drop),"systematic")
 
             if km_dist != "njets":
@@ -853,13 +855,16 @@ class DatacardMaker():
                             if syst_base in ["renorm","fact"]:  # Note: Requires exact matches
                                 # We want to split the renorm and fact systematics to be uncorrelated
                                 #   between processes, so we modify the systematic name to make combine
-                                #   treat them as separate systematics
+                                #   treat them as separate systematics. Also, we use 'p' instead of
+                                #   'proc_name' for renaming since we want the decomposed EFT terms
+                                #   for a particular process to share the same nuisance parameter
                                 # TODO: We should move the hardcoded list in the if statement somewhere
                                 #   else to make it less buried in the weeds
-                                split_syst = f"{syst_base}_{proc_name}"
+                                split_syst = f"{syst_base}_{p}"
                                 hist_name = hist_name.replace(syst_base,split_syst)
                                 all_shapes.add(split_syst)
                                 text_card_info[proc_name]["shapes"].add(split_syst)
+                                print(f"Splitting {syst_base} --> {split_syst}")
                             else:
                                 all_shapes.add(syst_base)
                                 text_card_info[proc_name]["shapes"].add(syst_base)


### PR DESCRIPTION
This PR adds a hardcoded check for the systematics `renorm` and `fact` and when it finds them it modifies the systematic name from `renorm` to `renorm_PROCESS` and similarly for the corresponding template histogram name `PROCESS_renormUp` to `PROCESS_renorm_PROCESSUp`.

For the processes that are split by EFT contribution, all decomposed terms will share a single nuisance parameter. So for example `ttll` may be split into `ttll_sm`,`ttll_lin_cpt`, `ttll_quad_cpt`, etc. There will be only one nuisance correlated over each of them (e.g. `renorm_ttll` or `fact_ttll`).

This PR also adds a new command-line option `--drop-syst` which can be used to specify one (or more) systematics that should be dropped from the pkl file before proceeding. Systematics that are dropped this way should match exactly what name of the systematic, however, the "Up"/"Down" postfix isn't needed as the code will remove both, unless you explicitly specify "SYSTNAMEUp", which will only drop the "Up" version of SYSTNAME. You can specify multiple systematics to drop at once by separating each name with by a space after the `--drop-syst` option.