### PR TITLE
Rework Decorrelating Shape Systematics and Decorrelate ISR Systematic

### DIFF
--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -13,6 +13,7 @@ import time
 from coffea.hist import StringBin, Cat, Bin
 
 from topcoffea.modules.paths import topcoffea_path
+from topcoffea.modules.utils import regex_match
 import topcoffea.modules.eft_helper as efth
 
 PRECISION = 6   # Decimal point precision in the text datacard output
@@ -380,6 +381,44 @@ class DatacardMaker():
             # Note: This is not correct for the analysis, but just serves as an example
             # "FFcloseEl": {"2016": ["2016APV","2017","2018"], "2016APV": ["2016","2017","2018"], "2017": ["2016","2016APV","2018"], "2018": ["2016","2016APV","2017"]},
             # "FFcloseMu": {"2016": ["2016APV","2017","2018"], "2016APV": ["2016","2017","2018"], "2017": ["2016","2016APV","2018"], "2018": ["2016","2016APV","2017"]},
+        }
+
+        # Defines which systematics should be decorrelated in the self.analysis() step. Each key
+        #   should match (exactly) a particular systematic. The list for each systematic specifies
+        #   which processes should remain remain correlated or not.
+        # Note: A given process should appear AT MOST once in the "matches" list for a given systematic
+        #       grouping. If a process has an associated systematic, but doesn't match any of the
+        #       groups, then it will retain its original systematic name (i.e. all unmatched
+        #       processes will remain correlated).
+        # Note: For the special case where the group name is an empty string the systematic will
+        #       instead have the matched process' name appended to it, meaning that all matched
+        #       processes will be decorrelated!
+        # Note: Since the decorrelation happens during the self.analysis() step, the matched names
+        #       should correspond to the renamed/re-grouped processes, e.g. use "Diboson" instead of
+        #       "ZZ","WZ","WW".
+        self.syst_shape_decorrelate = {
+            "ISR": [
+                {
+                    "matches": ["ttH","ttll","tttt","convs"],
+                    "group": "gg",
+                },
+                {
+                    "matches": ["ttlnu","tllq","Diboson","Triboson"],
+                    "group": "qq",
+                },
+                {
+                    "matches": ["tHq"],
+                    "group": "qg"
+                }
+            ],
+            "renorm": [{
+                "matches": [".*"],
+                "group": "",
+            }],
+            "fact": [{
+                "matches": [".*"],
+                "group": "",
+            }]
         }
 
         if extra_ignore:
@@ -852,20 +891,36 @@ class DatacardMaker():
                             hist_name = f"{proc_name}_{syst}"
                             # Systematics in the text datacard don't have the Up/Down postfix
                             syst_base = syst.replace("Up","").replace("Down","")
-                            if syst_base in ["renorm","fact"]:  # Note: Requires exact matches
-                                # We want to split the renorm and fact systematics to be uncorrelated
-                                #   between processes, so we modify the systematic name to make combine
-                                #   treat them as separate systematics. Also, we use 'p' instead of
-                                #   'proc_name' for renaming since we want the decomposed EFT terms
-                                #   for a particular process to share the same nuisance parameter
-                                # TODO: We should move the hardcoded list in the if statement somewhere
-                                #   else to make it less buried in the weeds
-                                split_syst = f"{syst_base}_{p}"
+                            if syst_base in self.syst_shape_decorrelate:
+                                # We want to split this systematic to be uncorrelated between certain
+                                #   processes, so we modify the systematic name to make combine treat
+                                #   them as separate systematics. Also, we use 'p' instead of 'proc_name'
+                                #   for renaming since we want the decomposed EFT terms for a particular
+                                #   process to share the same nuisance parameter
+                                matched = []
+                                for r in self.syst_shape_decorrelate[syst_base]:
+                                    if regex_match([p],r["matches"]):
+                                        # The matched process should have this systematic put into a new group
+                                        matched.append(r["group"])
+                                if len(matched) == 0:
+                                    # No matches found, so keep the original systematic name
+                                    split_syst = syst_base
+                                elif len(matched) == 1:
+                                    # Found a match, so decorrelate the process from non-matched processes 
+                                    group = matched[0]
+                                    split_syst = f"{syst_base}_{group}"
+                                    if group == "":
+                                        # In the special case that the group is an empty string,
+                                        #   decorrelate ALL matched processes
+                                        split_syst = f"{syst_base}_{p}"
+                                else:
+                                    # We shouldn't have more than one match for a given systematic
+                                    raise RuntimeError(f"Unable to decorrelate shape systematic {syst_base} for {p}. Multiple group matches found: {matched}")
                                 hist_name = hist_name.replace(syst_base,split_syst)
                                 all_shapes.add(split_syst)
                                 text_card_info[proc_name]["shapes"].add(split_syst)
-                                if self.verbose:
-                                    print(f"\t {hist_name}: Splitting {syst_base} --> {split_syst}")
+                                if base == "sm" and self.verbose:
+                                    print(f"\tDecorrelate {p} for {syst_base} into {split_syst} ({syst.replace(syst_base,'')})")
                             else:
                                 all_shapes.add(syst_base)
                                 text_card_info[proc_name]["shapes"].add(syst_base)


### PR DESCRIPTION
This PR expands the way shape systematics are decorrelated as initial introduced in PR #327. The way decorrelations are specified is now done via a dictionary defined in the `__init__()` method, which takes the following form:
```python
self.syst_shape_decorrelate = {
    "SYST_1": [
        {
            "matches": ["PROC_1","PROC_2"],
            "group": "GROUP_1"
        },
        {
            "matches": ["PROC_3","PROC_4"],
            "group": "GROUP_2"
        },
        ...
    ],
    "SYST_2": [
        ...
    ]
}
```
Where `matches` defines a list of strings that will match certain processes, which are to stay correlated for the corresponding systematic. The `group` entry is a string that is appended to the end of the systematic name and introduced as a separate systematic in the datacard.

If a systematic has a process that isn't matched to any of the groupings, then that process (as well as any other processes that did not get matched) will remain correlated and use the original systematic name, but if no such process(-es) remain after the groupings, the original systematic will no longer show up in the datacard outputs.

The code includes an explicit check to make sure that for a given systematic each process is matched _at most_ once, i.e. a process should not appear in more than one correlated grouping, since this would mean that the systematic for that process would end up being double counted.

In the special case where the `group` string is `""` (the empty string), then the logic changes to instead split _all_ processes matched via the corresponding `matches` list into fully decorrelated systematics. This is accomplished by creating a new systematic with a name that has the process named appended to the end. For example, `renorm` could be split up into `renorm_ttll`, `renorm_tllq`, etc.

It should be noted that any new systematics specified in this way does not actually introduce additional template histograms into the workspace. Instead, it takes all the template histograms for the specified systematic and renames them such that only the specified groupings (which may only contain a single process) stay correlated, rather than having all processes correlated for that systematic. This does however introduce new nuisance parameters into the resulting workspace.

In addition to reworking/expanding how decorrelating shape systematics is done, this PR also decorrelates the `ISR` systematic, such that only processes with the same production mode (e.g. QCD-induced vs. EWK-induced) are correlated. The new groupings are as follows:
```
group: gg
processes: ttH, ttll, tttt, convs

group: gq
processes: tHq

group: qq
processes: ttlnu, tllq, Diboson, Triboson
```
The MC process `tWZ` is the only remaining process with an `ISR` systematic not included in the above groupings and so keeps the original systematic name. However, since `tWZ` is the only un-grouped process it is effectively decorrelated from all other processes for `ISR`.