### PR TITLE
Enforce consistent spacing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           exclude: "./topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py"
-          ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,F405,E501,E701,E714,F841,W391"
+          ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E271,E302,E303,E305,E402,F403,F405,E501,E701,E711,E714,E741,F841,W391,W605"
           # E116 unexpected indentation (comment)
           # E201 whitespace after '('
           # E202 whitespace before ')'
@@ -37,6 +37,7 @@ jobs:
           # E261 at least two spaces before inline comment
           # E265 block comment should start with '# '
           # E266 too many leading '#' for block comment
+          # E271 multiple spaces after keyword
           # E302 expected 2 blank lines, found 1
           # E303 too many blank lines (3)
           # E305 expected 2 blank lines after class or function definition, found 1
@@ -45,9 +46,12 @@ jobs:
           # F405 may be undefined, or defined from star imports
           # E501 line too long
           # E701 multiple statements on one line (colon)
+          # E711 comparison to None should be 'if cond is not None:'
           # E714 test for object identity should be 'is not'
+          # E741 ambiguous variable name
           # F841 local variable is assigned to but never used
           # W391 blank line at end of file
+          # W605 invalid escape sequence '\s'
 
   Full_Analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           exclude: "./topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py"
-          ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E271,E302,E303,E305,E402,F403,F405,E501,E701,E711,E714,E741,F841,W391,W605"
+          ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E262,E265,E266,E271,E302,E303,E305,E402,F403,F405,E501,E701,E702,E711,E713,E714,E741,F841,W391,W605"
           # E116 unexpected indentation (comment)
           # E201 whitespace after '('
           # E202 whitespace before ')'
@@ -35,6 +35,7 @@ jobs:
           # E241 multiple spaces after ','
           # E251 unexpected spaces around keyword / parameter equals
           # E261 at least two spaces before inline comment
+          # E262 inline comment should start with '# '
           # E265 block comment should start with '# '
           # E266 too many leading '#' for block comment
           # E271 multiple spaces after keyword
@@ -46,7 +47,9 @@ jobs:
           # F405 may be undefined, or defined from star imports
           # E501 line too long
           # E701 multiple statements on one line (colon)
+          # E702 multiple statements on one line
           # E711 comparison to None should be 'if cond is not None:'
+          # E713 test for membership should be 'not in'
           # E714 test for object identity should be 'is not'
           # E741 ambiguous variable name
           # F841 local variable is assigned to but never used

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,E501,E701,E714,F841"
+          ignore: "E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,F405,E501,E701,E714,F841,W391"
           # E201 whitespace after '('
           # E202 whitespace before ')'
           # E203 whitespace before ':'
@@ -40,10 +40,12 @@ jobs:
           # E305 expected 2 blank lines after class or function definition, found 1
           # E402 module level import not at top of file
           # F403 unable to detect undefined names
+          # F405 may be undefined, or defined from star imports
           # E501 line too long
           # E701 multiple statements on one line (colon)
           # E714 test for object identity should be 'is not'
           # F841 local variable is assigned to but never used
+          # W391 blank line at end of file
 
   Full_Analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,13 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          exclude: "./topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py"
-          ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E262,E265,E266,E271,E302,E303,E305,E402,F403,F405,E501,E701,E702,E711,E713,E714,E741,F841,W391,W605"
+          exclude: "./topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py,./topcoffea/modules/WCPoint.py"
+          ignore: "E116,E201,E202,E203,E211,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E262,E265,E266,E271,E301,E302,E303,E305,E402,F403,F405,E501,W504,E701,E702,E711,E713,E714,E741,F841,W391,W605"
           # E116 unexpected indentation (comment)
           # E201 whitespace after '('
           # E202 whitespace before ')'
           # E203 whitespace before ':'
+          # E211 whitespace before '['
           # E221 multiple spaces before operator
           # E222 multiple spaces after operator
           # E225 missing whitespace around operator
@@ -39,6 +40,7 @@ jobs:
           # E265 block comment should start with '# '
           # E266 too many leading '#' for block comment
           # E271 multiple spaces after keyword
+          # E301 expected 1 blank line, found 0
           # E302 expected 2 blank lines, found 1
           # E303 too many blank lines (3)
           # E305 expected 2 blank lines after class or function definition, found 1
@@ -46,6 +48,7 @@ jobs:
           # F403 unable to detect undefined names
           # F405 may be undefined, or defined from star imports
           # E501 line too long
+          # W504 line break after binary operator
           # E701 multiple statements on one line (colon)
           # E702 multiple statements on one line
           # E711 comparison to None should be 'if cond is not None:'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,8 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,F405,E501,E701,E714,F841,W391"
+          ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,F405,E501,E701,E714,F841,W391"
+          # E116 unexpected indentation (comment)
           # E201 whitespace after '('
           # E202 whitespace before ')'
           # E203 whitespace before ':'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          exclude: "/topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py"
+          exclude: "./topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py"
           ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,F405,E501,E701,E714,F841,W391"
           # E116 unexpected indentation (comment)
           # E201 whitespace after '('

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,38 @@ on:
     - cron: '0 1 * * *' # Test every day at 1AM
   
 jobs:
+
+  # Based on https://github.com/py-actions/flake8#quick-start
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v1
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2
+        with:
+          ignore: "E201,E202,E203,E221,E226,E225,E227,E228,E231,E241,E261,E265,E302,E303,E501,E701,E714"
+          # E201 whitespace after '('
+          # E202 whitespace before ')'
+          # E203 whitespace before ':'
+          # E221 multiple spaces before operator
+          # E225 missing whitespace around operator
+          # E226 missing whitespace around arithmetic operator
+          # E227 missing whitespace around bitwise or shift operator
+          # E228 missing whitespace around modulo operator
+          # E231 missing whitespace after ','
+          # E241 multiple spaces after ','
+          # E261 at least two spaces before inline comment
+          # E265 block comment should start with '# '
+          # E302 expected 2 blank lines, found 1
+          # E303 too many blank lines (3)
+          # E501 line too long
+          # E701 multiple statements on one line (colon)
+          # E714 test for object identity should be 'is not'
+
   Full_Analysis:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           exclude: "./topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py,./topcoffea/modules/WCPoint.py"
-          ignore: "E116,E201,E202,E203,E211,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E262,E265,E266,E271,E301,E302,E303,E305,E402,F403,F405,E501,W504,E701,E702,E711,E713,E714,E741,F841,W391,W605"
+          ignore: "E116,E201,E202,E203,E211,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E262,E265,E266,E271,E272,E301,E302,E303,E305,E402,F403,F405,E501,W504,E701,E702,E711,E713,E714,E731,E741,F841,W391,W605"
           # E116 unexpected indentation (comment)
           # E201 whitespace after '('
           # E202 whitespace before ')'
@@ -40,6 +40,7 @@ jobs:
           # E265 block comment should start with '# '
           # E266 too many leading '#' for block comment
           # E271 multiple spaces after keyword
+          # E272 multiple spaces before keyword
           # E301 expected 1 blank line, found 0
           # E302 expected 2 blank lines, found 1
           # E303 too many blank lines (3)
@@ -54,6 +55,7 @@ jobs:
           # E711 comparison to None should be 'if cond is not None:'
           # E713 test for membership should be 'not in'
           # E714 test for object identity should be 'is not'
+          # E731 do not assign a lambda expression, use a def
           # E741 ambiguous variable name
           # F841 local variable is assigned to but never used
           # W391 blank line at end of file

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,24 +19,31 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E201,E202,E203,E221,E226,E225,E227,E228,E231,E241,E261,E265,E302,E303,E501,E701,E714"
+          ignore: "E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,E501,E701,E714,F841"
           # E201 whitespace after '('
           # E202 whitespace before ')'
           # E203 whitespace before ':'
           # E221 multiple spaces before operator
+          # E222 multiple spaces after operator
           # E225 missing whitespace around operator
           # E226 missing whitespace around arithmetic operator
           # E227 missing whitespace around bitwise or shift operator
           # E228 missing whitespace around modulo operator
           # E231 missing whitespace after ','
           # E241 multiple spaces after ','
+          # E251 unexpected spaces around keyword / parameter equals
           # E261 at least two spaces before inline comment
           # E265 block comment should start with '# '
+          # E266 too many leading '#' for block comment
           # E302 expected 2 blank lines, found 1
           # E303 too many blank lines (3)
+          # E305 expected 2 blank lines after class or function definition, found 1
+          # E402 module level import not at top of file
+          # F403 unable to detect undefined names
           # E501 line too long
           # E701 multiple statements on one line (colon)
           # E714 test for object identity should be 'is not'
+          # F841 local variable is assigned to but never used
 
   Full_Analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
+          exclude: "/topcoffea/modules/fileReader.py,./topcoffea/modules/samples.py,./topcoffea/modules/createJSON.py,./topcoffea/modules/WCFit.py"
           ignore: "E116,E201,E202,E203,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,F403,F405,E501,E701,E714,F841,W391"
           # E116 unexpected indentation (comment)
           # E201 whitespace after '('

--- a/analysis/btagMCeff/btagMCeff.py
+++ b/analysis/btagMCeff/btagMCeff.py
@@ -111,7 +111,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         WP = {'all' : -999., 'loose': 0.0490, 'medium': 0.2783, 'tight': 0.7100}
         btagSelection = {}
         for wp, wpvals in WP.items():
-            btagSelection[wp] = (goodJets.btagDeepFlavB>wpvals) 
+            btagSelection[wp] = (goodJets.btagDeepFlavB>wpvals)
 
         for jetype in ['b', 'c', 'l']:
             for wp in WP.keys():

--- a/analysis/btagMCeff/btagMCeff.py
+++ b/analysis/btagMCeff/btagMCeff.py
@@ -1,22 +1,14 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import cloudpickle
-import json
-import pprint
 import coffea
 import numpy as np
 import awkward as ak
 np.seterr(divide='ignore', invalid='ignore', over='ignore')
 #from coffea.arrays import Initialize # Not used and gives error
 from coffea import hist, processor
-from coffea.util import load, save
-from optparse import OptionParser
-from coffea.analysis_tools import PackedSelection
+from coffea.util import load
 
 from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import SFevaluator, GetLeptonSF
 from topcoffea.modules.selection import *
-from topcoffea.modules.HistEFT import HistEFT
 
 #coffea.deprecations_as_errors = True
 
@@ -29,10 +21,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Create the histograms
         # In general, histograms depend on 'sample', 'channel' (final state) and 'cut' (level of selection)
         self._accumulator = processor.dict_accumulator({
-        'jetpt'  : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Cat("Flav", "Flav"), hist.Bin("pt",  "Jet p_{T} (GeV) ", 40, 0, 800)),
-        'jeteta' : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Cat("Flav", "Flav"), hist.Bin("eta", "Jet eta", 25, -2.5, 2.5)),
-        'jetpteta' : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Cat("Flav", "Flav"), hist.Bin("pt",  "Jet p_{T} (GeV) ", [20, 30, 60, 120]), hist.Bin("abseta", "Jet eta", [0, 1, 1.8, 2.4])),
-        'jetptetaflav' : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Bin("pt",  "Jet p_{T} (GeV) ", [20, 30, 60, 120]), hist.Bin("abseta", "Jet eta", [0, 1, 1.8, 2.4]), hist.Bin("flav", "Flavor", [0, 4, 5]) ),
+            'jetpt'  : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Cat("Flav", "Flav"), hist.Bin("pt",  "Jet p_{T} (GeV) ", 40, 0, 800)),
+            'jeteta' : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Cat("Flav", "Flav"), hist.Bin("eta", "Jet eta", 25, -2.5, 2.5)),
+            'jetpteta' : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Cat("Flav", "Flav"), hist.Bin("pt",  "Jet p_{T} (GeV) ", [20, 30, 60, 120]), hist.Bin("abseta", "Jet eta", [0, 1, 1.8, 2.4])),
+            'jetptetaflav' : hist.Hist("Events", hist.Cat("WP", "WP"), hist.Bin("pt",  "Jet p_{T} (GeV) ", [20, 30, 60, 120]), hist.Bin("abseta", "Jet eta", [0, 1, 1.8, 2.4]), hist.Bin("flav", "Flavor", [0, 4, 5]) ),
         })
 
     @property
@@ -52,8 +44,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         sow    = self._samples[dataset]['nSumOfWeights' ]
         isData = self._samples[dataset]['isData']
         datasets = ['SingleMuon', 'SingleElectron', 'EGamma', 'MuonEG', 'DoubleMuon', 'DoubleElectron']
-        for d in datasets: 
-          if d in dataset: dataset = dataset.split('_')[0] 
+        for d in datasets:
+            if d in dataset: dataset = dataset.split('_')[0]
 
         # Initialize objects
         met = events.MET
@@ -68,7 +60,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         leading_mu = mu[ak.argmax(mu.pt,axis=-1,keepdims=True)]
         leading_mu = leading_mu[leading_mu.isGood]
-        
+
         mu = mu[mu.isGood]
         mu_pres = mu[mu.isPres]
 
@@ -81,8 +73,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         leading_e = e[ak.argmax(e.pt,axis=-1,keepdims=True)]
         leading_e = leading_e[leading_e.isGood]
 
-        e  =  e[e .isGood]
-        e_pres = e[e .isPres & e .isClean]
+        e  =  e[e.isGood]
+        e_pres = e[e.isPres & e.isClean]
 
         nElec = ak.num(e)
         nMuon = ak.num(mu)
@@ -111,7 +103,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         eftweights = events['EFTfitCoefficients'] if hasattr(events, "EFTfitCoefficients") else []
 
         hout = self.accumulator.identity()
-        normweights = weights.weight().flatten() 
+        normweights = weights.weight().flatten()
         #hout['SumOfEFTweights'].fill(eftweights, sample=dataset, SumOfEFTweights=varnames['counts'], weight=normweights)
 
         flavSelection = {'b': (np.abs(goodJets.hadronFlavour) == 5), 'c': (np.abs(goodJets.hadronFlavour) == 4), 'l': (np.abs(goodJets.hadronFlavour) <= 3) }
@@ -119,22 +111,22 @@ class AnalysisProcessor(processor.ProcessorABC):
         WP = {'all' : -999., 'loose': 0.0490, 'medium': 0.2783, 'tight': 0.7100}
         btagSelection = {}
         for wp, wpvals in WP.items():
-          btagSelection[wp] = (goodJets.btagDeepFlavB>wpvals) 
+            btagSelection[wp] = (goodJets.btagDeepFlavB>wpvals) 
 
         for jetype in ['b', 'c', 'l']:
-          for wp in WP.keys():
-            mask = (flavSelection[jetype])&(btagSelection[wp])
-            selectjets = goodJets[mask]
-            pts     = ak.flatten(selectjets.pt)
-            etas    = ak.flatten(selectjets.eta)
-            absetas = ak.flatten(np.abs(selectjets.eta))
-            flavarray = np.zeros_like(pts) if jetype == 'l' else (np.ones_like(pts)*(4 if jetype=='c' else 5))
-            weights =  np.ones_like(pts)
-            hout['jetpt'].fill(WP=wp, Flav=jetype,  pt=pts, weight=weights)
-            hout['jeteta'].fill(WP=wp, Flav=jetype,  eta=etas, weight=weights)
-            hout['jetpteta'].fill(WP=wp, Flav=jetype,  pt=pts, abseta=absetas, weight=weights)
-            hout['jetptetaflav'].fill(WP=wp, pt=pts, abseta=absetas, flav=flavarray, weight=weights)
-    
+            for wp in WP.keys():
+                mask = (flavSelection[jetype])&(btagSelection[wp])
+                selectjets = goodJets[mask]
+                pts     = ak.flatten(selectjets.pt)
+                etas    = ak.flatten(selectjets.eta)
+                absetas = ak.flatten(np.abs(selectjets.eta))
+                flavarray = np.zeros_like(pts) if jetype == 'l' else (np.ones_like(pts)*(4 if jetype=='c' else 5))
+                weights =  np.ones_like(pts)
+                hout['jetpt'].fill(WP=wp, Flav=jetype,  pt=pts, weight=weights)
+                hout['jeteta'].fill(WP=wp, Flav=jetype,  eta=etas, weight=weights)
+                hout['jetpteta'].fill(WP=wp, Flav=jetype,  pt=pts, abseta=absetas, weight=weights)
+                hout['jetptetaflav'].fill(WP=wp, pt=pts, abseta=absetas, flav=flavarray, weight=weights)
+
         return hout
 
 

--- a/analysis/btagMCeff/run.py
+++ b/analysis/btagMCeff/run.py
@@ -50,7 +50,10 @@ if __name__ == '__main__':
         print('Execute as [path]/run.py [path]/samples.cfg')
         exit()
 
-    flist = {}; xsec = {}; sow = {}; isData = {}
+    flist = {}
+    xsec = {}
+    sow = {}
+    isData = {}
     for k in samplesdict.keys():
         flist[k] = samplesdict[k]['files']
         xsec[k]  = samplesdict[k]['xsec']

--- a/analysis/btagMCeff/run.py
+++ b/analysis/btagMCeff/run.py
@@ -1,90 +1,85 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import pickle
-import json
 import time
 import cloudpickle
 import gzip
 import os
-from optparse import OptionParser
 
-import uproot
 import numpy as np
 from coffea import hist, processor
-from coffea.util import load, save
+from coffea.util import load
 from coffea.nanoevents import NanoAODSchema
 
 import btagMCeff
 from topcoffea.modules import samples
 
 if __name__ == '__main__':
-  import argparse
-  parser = argparse.ArgumentParser(description='You can customize your run')
-  parser.add_argument('cfgfile'           , nargs='?', default=''           , help = 'Config file with dataset names')
-  parser.add_argument('--test','-t'       , action='store_true'  , help = 'To perform a test, run over a few events in a couple of chunks')
-  parser.add_argument('--nworkers','-n'   , default=8  , help = 'Number of workers')
-  parser.add_argument('--chunksize','-s'   , default=500000  , help = 'Number of events per chunk')
-  parser.add_argument('--nchunks','-c'   , default=None  , help = 'You can choose to run only a number of chunks')
-  parser.add_argument('--outname','-o'   , default='btagMCeff', help = 'Name of the output file with histograms')
-  parser.add_argument('--outpath','-p'   , default='histos', help = 'Name of the output directory')
-  parser.add_argument('--treename'   , default='Events', help = 'Name of the tree inside the files')
+    import argparse
+    parser = argparse.ArgumentParser(description='You can customize your run')
+    parser.add_argument('cfgfile'           , nargs='?', default=''           , help = 'Config file with dataset names')
+    parser.add_argument('--test','-t'       , action='store_true'  , help = 'To perform a test, run over a few events in a couple of chunks')
+    parser.add_argument('--nworkers','-n'   , default=8  , help = 'Number of workers')
+    parser.add_argument('--chunksize','-s'   , default=500000  , help = 'Number of events per chunk')
+    parser.add_argument('--nchunks','-c'   , default=None  , help = 'You can choose to run only a number of chunks')
+    parser.add_argument('--outname','-o'   , default='btagMCeff', help = 'Name of the output file with histograms')
+    parser.add_argument('--outpath','-p'   , default='histos', help = 'Name of the output directory')
+    parser.add_argument('--treename'   , default='Events', help = 'Name of the tree inside the files')
 
-  args = parser.parse_args()
-  cfgfile    = args.cfgfile
-  dotest     = args.test
-  nworkers   = int(args.nworkers)
-  chunksize  = int(args.chunksize)
-  nchunks    = int(args.nchunks) if not args.nchunks is None else args.nchunks
-  outname    = args.outname
-  outpath    = args.outpath
-  treename   = args.treename
+    args = parser.parse_args()
+    cfgfile    = args.cfgfile
+    dotest     = args.test
+    nworkers   = int(args.nworkers)
+    chunksize  = int(args.chunksize)
+    nchunks    = int(args.nchunks) if not args.nchunks is None else args.nchunks
+    outname    = args.outname
+    outpath    = args.outpath
+    treename   = args.treename
 
-  if dotest:
-    nchunks = 2
-    chunksize = 10000
-    nworkers = 1
-    print('Running a fast test with %i workers, %i chunks of %i events'%(nworkers, nchunks, chunksize))
+    if dotest:
+        nchunks = 2
+        chunksize = 10000
+        nworkers = 1
+        print('Running a fast test with %i workers, %i chunks of %i events'%(nworkers, nchunks, chunksize))
 
-  ### Load samples
-  if cfgfile != '':
-    samplesdict = samples.main()
-  elif os.path.isfile('.samples.coffea'):
-    print('Using samples form .samples.coffea')
-    samplesdict = load('.samples.coffea')
-  else:
-    print('Execute as [path]/run.py [path]/samples.cfg')
-    exit()
+    ### Load samples
+    if cfgfile != '':
+        samplesdict = samples.main()
+    elif os.path.isfile('.samples.coffea'):
+        print('Using samples form .samples.coffea')
+        samplesdict = load('.samples.coffea')
+    else:
+        print('Execute as [path]/run.py [path]/samples.cfg')
+        exit()
 
-  flist = {}; xsec = {}; sow = {}; isData = {}
-  for k in samplesdict.keys():
-    flist[k] = samplesdict[k]['files']
-    xsec[k]  = samplesdict[k]['xsec']
-    sow[k]   = samplesdict[k]['nSumOfWeights']
-    isData[k]= samplesdict[k]['isData']
+    flist = {}; xsec = {}; sow = {}; isData = {}
+    for k in samplesdict.keys():
+        flist[k] = samplesdict[k]['files']
+        xsec[k]  = samplesdict[k]['xsec']
+        sow[k]   = samplesdict[k]['nSumOfWeights']
+        isData[k]= samplesdict[k]['isData']
 
-  processor_instance = btagMCeff.AnalysisProcessor(samplesdict)
+    processor_instance = btagMCeff.AnalysisProcessor(samplesdict)
 
-  executor = processor.FuturesExecutor(workers=nworkers, pre_workers=1)
-  runner = processor.Runner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+    executor = processor.FuturesExecutor(workers=nworkers, pre_workers=1)
+    runner = processor.Runner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
 
-  tstart = time.time()
-  output = runner(flist, treename, processor_instance)
-  dt = time.time() - tstart
+    tstart = time.time()
+    output = runner(flist, treename, processor_instance)
+    dt = time.time() - tstart
 
-  nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
-  nfilled = sum(sum(np.sum(arr > 0) for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
-  print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
-  print("Processing time: %1.2f s with %i workers (%.2f s cpu overall)" % (dt, nworkers, dt*nworkers, ))
+    nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
+    nfilled = sum(sum(np.sum(arr > 0) for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
+    print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
+    print("Processing time: %1.2f s with %i workers (%.2f s cpu overall)" % (dt, nworkers, dt*nworkers, ))
 
-  # This is taken from the DM photon analysis...
-  # Pickle is not very fast or memory efficient, will be replaced by something better soon
-  #    with lz4f.open("pods/"+options.year+"/"+dataset+".pkl.gz", mode="xb", compression_level=5) as fout:
-  if not outpath.endswith('/'): outpath += '/'
-  if not os.path.isdir(outpath): os.system("mkdir -p %s"%outpath)
-  print('Saving output in %s...'%(outpath + outname + ".pkl.gz"))
-  with gzip.open(outpath + outname + ".pkl.gz", "wb") as fout:
-    cloudpickle.dump(output, fout)
-  print('Done!')
+    # This is taken from the DM photon analysis...
+    # Pickle is not very fast or memory efficient, will be replaced by something better soon
+    #    with lz4f.open("pods/"+options.year+"/"+dataset+".pkl.gz", mode="xb", compression_level=5) as fout:
+    if not outpath.endswith('/'): outpath += '/'
+    if not os.path.isdir(outpath): os.system("mkdir -p %s"%outpath)
+    print('Saving output in %s...'%(outpath + outname + ".pkl.gz"))
+    with gzip.open(outpath + outname + ".pkl.gz", "wb") as fout:
+        cloudpickle.dump(output, fout)
+    print('Done!')
 
 
 

--- a/analysis/extreme_events_study/extreme_events.py
+++ b/analysis/extreme_events_study/extreme_events.py
@@ -10,7 +10,7 @@ from coffea.processor import AccumulatorABC
 
 from topcoffea.modules.GetValuesFromJsons import get_param
 from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, ApplyRochesterCorrections 
+from topcoffea.modules.corrections import AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, ApplyRochesterCorrections
 from topcoffea.modules.selection import *
 from topcoffea.modules.paths import topcoffea_path
 
@@ -32,7 +32,7 @@ class dataframe_accumulator(AccumulatorABC):
             self._value = pd.concat([self._value, other])
         else:
             self._value = pd.concat([self._value, other._value])
-    
+
     # The cutoff values are set manually
     # First sort the dataframe to get a sufficient amount of top events (e.g. get_ST)
     # Then determine what values to focus on
@@ -85,14 +85,14 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # Create an accumulator of multiple dataframes
         self._accumulator = processor.dict_accumulator({
-                "nleps": dataframe_accumulator(pd.DataFrame()),
-                "njets": dataframe_accumulator(pd.DataFrame()),
-                "ST": dataframe_accumulator(pd.DataFrame()),
-                "HT": dataframe_accumulator(pd.DataFrame()),
-                "invMass": dataframe_accumulator(pd.DataFrame()),
-                "pt_l": dataframe_accumulator(pd.DataFrame()),
-                "pt_j": dataframe_accumulator(pd.DataFrame())
-            })
+            "nleps": dataframe_accumulator(pd.DataFrame()),
+            "njets": dataframe_accumulator(pd.DataFrame()),
+            "ST": dataframe_accumulator(pd.DataFrame()),
+            "HT": dataframe_accumulator(pd.DataFrame()),
+            "invMass": dataframe_accumulator(pd.DataFrame()),
+            "pt_l": dataframe_accumulator(pd.DataFrame()),
+            "pt_j": dataframe_accumulator(pd.DataFrame())
+        })
 
     @property
     def accumulator(self):

--- a/analysis/extreme_events_study/get_histo_yield.py
+++ b/analysis/extreme_events_study/get_histo_yield.py
@@ -34,35 +34,35 @@ def print_yields():
 
     # Specify the values of the WCs
     wc_ranges_differential = {
-            'cQQ1' : 4.0,
-            'cQei' : 4.0,
-            'cQl3i': 5.5,
-            'cQlMi': 4.0,
-            'cQq11': 0.7,
-            'cQq13': 0.35,
-            'cQq81': 1.5,
-            'cQq83': 0.6,
-            'cQt1' : 4.0,
-            'cQt8' : 8.0,
-            'cbW'  : 3.0,
-            'cpQ3' : 4.0,
-            'cpQM' : 17.0,
-            'cpt'  : 15.0,
-            'cptb' : 9.0,
-            'ctG'  : 0.8,
-            'ctW'  : 1.5,
-            'ctZ'  : 2.0,
-            'ctei' : 4.0,
-            'ctlSi': 5.0,
-            'ctlTi': 0.9,
-            'ctli' : 4.0,
-            'ctp'  : 35.0,
-            'ctq1' : 0.6,
-            'ctq8' : 1.4,
-            'ctt1' : 2.1,
-        }
+        'cQQ1' : 4.0,
+        'cQei' : 4.0,
+        'cQl3i': 5.5,
+        'cQlMi': 4.0,
+        'cQq11': 0.7,
+        'cQq13': 0.35,
+        'cQq81': 1.5,
+        'cQq83': 0.6,
+        'cQt1' : 4.0,
+        'cQt8' : 8.0,
+        'cbW'  : 3.0,
+        'cpQ3' : 4.0,
+        'cpQM' : 17.0,
+        'cpt'  : 15.0,
+        'cptb' : 9.0,
+        'ctG'  : 0.8,
+        'ctW'  : 1.5,
+        'ctZ'  : 2.0,
+        'ctei' : 4.0,
+        'ctlSi': 5.0,
+        'ctlTi': 0.9,
+        'ctli' : 4.0,
+        'ctp'  : 35.0,
+        'ctq1' : 0.6,
+        'ctq8' : 1.4,
+        'ctt1' : 2.1,
+    }
 
-    # Initialize the output to print    
+    # Initialize the output to print
     sum_dict = {}
 
     # Calculate the SM prediction

--- a/analysis/extreme_events_study/run_extreme_events.py
+++ b/analysis/extreme_events_study/run_extreme_events.py
@@ -5,7 +5,6 @@ import gzip
 import os
 import argparse
 
-import numpy as np
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
 import topcoffea.modules.remote_environment as remote_environment
@@ -42,7 +41,8 @@ for fn in inputFiles:
     if fn.endswith('.json'):
         sample = os.path.basename(fn).replace('.json','')
         jsn = load_sample_json_file(fn)
-        samples_to_process = update_cfg(jsn,
+        samples_to_process = update_cfg(
+            jsn,
             name=sample,
             cfg=samples_to_process,
             max_files=max_files,

--- a/analysis/extreme_events_study/visualization/find_file.py
+++ b/analysis/extreme_events_study/visualization/find_file.py
@@ -31,7 +31,7 @@ class dataframe_accumulator(AccumulatorABC):
             df = other._value.merge(self._base, on=["run", "luminosityBlock", "event"])
             df = df.loc[:,~df.columns.duplicated()]
             self._value = pd.concat([self._value, df])
-    
+
 
 class AnalysisProcessor(processor.ProcessorABC):
 
@@ -46,7 +46,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         ############# Specify events to track #############
 
-        # Put event information of selected events from SKIM files into one dataframe 
+        # Put event information of selected events from SKIM files into one dataframe
         df_pt_j = output["pt_j"].value[["run", "luminosityBlock", "event"]][:1]
         df_njets = output["njets"].value[["run", "luminosityBlock", "event"]][:1]
         df_nleps = output["nleps"].value.sort_values(by="pt_l_0", ascending=False)
@@ -54,8 +54,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         df_SKIM = pd.concat([df_pt_j, df_njets, df_nleps], ignore_index=True)
 
         self._accumulator = processor.dict_accumulator({
-                                "nonSKIM": dataframe_accumulator(df_SKIM)
-                            })
+            "nonSKIM": dataframe_accumulator(df_SKIM)
+        })
 
     @property
     def accumulator(self):

--- a/analysis/extreme_events_study/visualization/find_file.py
+++ b/analysis/extreme_events_study/visualization/find_file.py
@@ -1,29 +1,9 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import cloudpickle
-import json
-import pprint
-import copy
-import coffea
 import numpy as np
-import awkward as ak
 import pandas as pd
 np.seterr(divide='ignore', invalid='ignore', over='ignore')
-from coffea import hist, processor
-from coffea.util import load, save
-from optparse import OptionParser
-from coffea.analysis_tools import PackedSelection
-from coffea.lumi_tools import LumiMask
+from coffea import processor
 from coffea.processor import AccumulatorABC
-
-from topcoffea.modules.GetValuesFromJsons import get_param
-from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import SFevaluator, GetBTagSF, ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, GetPUSF, ApplyRochesterCorrections, ApplyJetSystematics, AttachPSWeights, AttachPdfWeights, AttachScaleWeights, GetTriggerSF
-from topcoffea.modules.selection import *
-from topcoffea.modules.HistEFT import HistEFT
-from topcoffea.modules.paths import topcoffea_path
-import topcoffea.modules.eft_helper as efth
-import topcoffea.modules.GetValuesFromJsons as getj
 
 import pickle
 import gzip

--- a/analysis/flip_measurement/dense_lookup_example.py
+++ b/analysis/flip_measurement/dense_lookup_example.py
@@ -1,6 +1,6 @@
 import gzip
 import pickle
-from coffea import lookup_tools
+#from coffea import lookup_tools
 
 # The committed pkl files
 pkl_lst_committed = [

--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -1,12 +1,11 @@
-# Notes on this script: 
-#   - This script runs on the output of flip_ar_processor.py 
+# Notes on this script:
+#   - This script runs on the output of flip_ar_processor.py
 #   - It opens the pkl file and plots the SS data and the prediction
 #   - The prediction was calculated in the processor by applying flip probabilities to the OS data
 
 import os
 import copy
 import matplotlib.pyplot as plt
-import uproot3
 from coffea import hist
 
 from topcoffea.modules.YieldTools import YieldTools

--- a/analysis/flip_measurement/flip_ar_processor.py
+++ b/analysis/flip_measurement/flip_ar_processor.py
@@ -1,26 +1,16 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import cloudpickle
-import json
-import pprint
-import copy
 import coffea
 import numpy as np
 import awkward as ak
 np.seterr(divide='ignore', invalid='ignore', over='ignore')
 from coffea import hist, processor
-from coffea.util import load, save
-from optparse import OptionParser
 from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
 
-from topcoffea.modules.GetValuesFromJsons import get_param
 from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import SFevaluator, GetBTagSF, ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, GetPUSF, ApplyRochesterCorrections, ApplyJetSystematics, AttachPSWeights, AttachPdfWeights, AttachScaleWeights, GetTriggerSF
+from topcoffea.modules.corrections import AttachMuonSF, AttachElectronSF, AttachPerLeptonFR
 from topcoffea.modules.selection import *
-from topcoffea.modules.HistEFT import HistEFT
 from topcoffea.modules.paths import topcoffea_path
-import topcoffea.modules.eft_helper as efth
 
 # Check if the values in an array are within a given range
 def in_range_mask(in_var,lo_lim=None,hi_lim=None):

--- a/analysis/flip_measurement/flip_ar_processor.py
+++ b/analysis/flip_measurement/flip_ar_processor.py
@@ -72,8 +72,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         sow                = self._samples[dataset]["nSumOfWeights"]
 
         datasets = ["SingleMuon", "SingleElectron", "EGamma", "MuonEG", "DoubleMuon", "DoubleElectron", "DoubleEG"]
-        for d in datasets: 
-            if d in dataset: dataset = dataset.split('_')[0] 
+        for d in datasets:
+            if d in dataset: dataset = dataset.split('_')[0]
 
         # Set the sampleType (used for MC matching requirement)
         # Does not really matter for this processor, but still need to pass it to the selection function anyway
@@ -82,7 +82,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         sampleType = 'prompt'
         if isData:
             sampleType = 'data'
-        elif dataset in conversionDatasets: 
+        elif dataset in conversionDatasets:
             sampleType = 'conversions'
         elif dataset in nonpromptDatasets:
             sampleType = 'nonprompt'
@@ -106,7 +106,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             mu["gen_parent_pdgId"] = mu.matched_gen.distinctParent.pdgId
             e["gen_gparent_pdgId"] = e.matched_gen.distinctParent.distinctParent.pdgId
             mu["gen_gparent_pdgId"] = mu.matched_gen.distinctParent.distinctParent.pdgId
-        
+
         # Get the lumi mask for data
         if year == "2016" or year == "2016APV":
             golden_json_path = topcoffea_path("data/goldenJsons/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt")
@@ -118,7 +118,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             raise ValueError(f"Error: Unknown year \"{year}\".")
         lumi_mask = LumiMask(golden_json_path)(events.run,events.luminosityBlock)
 
-        
+
         ################### Object selection ####################
 
         # Electron selection
@@ -151,8 +151,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Attach per lepton fake rates
         AttachPerLeptonFR(e_fo, flavor = "Elec", year=year)
         AttachPerLeptonFR(m_fo, flavor = "Muon", year=year)
-        m_fo['convVeto'] = ak.ones_like(m_fo.charge); 
-        m_fo['lostHits'] = ak.zeros_like(m_fo.charge); 
+        m_fo['convVeto'] = ak.ones_like(m_fo.charge)
+        m_fo['lostHits'] = ak.zeros_like(m_fo.charge)
         l_fo = ak.with_name(ak.concatenate([e_fo, m_fo], axis=1), 'PtEtaPhiMCandidate')
         l_fo_conept_sorted = l_fo[ak.argsort(l_fo.conept, axis=-1,ascending=False)]
         events["l_fo_conept_sorted"] = l_fo_conept_sorted

--- a/analysis/flip_measurement/flip_mr_plotter.py
+++ b/analysis/flip_measurement/flip_mr_plotter.py
@@ -1,15 +1,12 @@
 # Notes on this script:
 #   - This script runs on the output of flip_mr_processor.py
 #   - It opens the pkl file, extracts the flip and no flip histos, calculates the flip prob, and saves that to a histo (also saves the 2d hists to png for reference)
-#   - The output histo is then placed in topcoffea/data so that corrections.py can read in the values using dense lookup 
+#   - The output histo is then placed in topcoffea/data so that corrections.py can read in the values using dense lookup
 
-import os
 import copy
-import json
 import matplotlib.pyplot as plt
 import cloudpickle
 import gzip
-import uproot3
 from coffea import hist
 
 from topcoffea.modules.YieldTools import YieldTools

--- a/analysis/flip_measurement/flip_mr_processor.py
+++ b/analysis/flip_measurement/flip_mr_processor.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 import numpy as np
-import lz4.frame as lz4f
-import cloudpickle
 import awkward as ak
-import coffea
 from coffea import hist, processor
 
 import topcoffea.modules.objects as obj
@@ -20,7 +17,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             "ptabseta" : hist.Hist(
                 "Counts",
                 hist.Cat("sample", "sample"),
-                hist.Cat("flipstatus", "flipstatus"), 
+                hist.Cat("flipstatus", "flipstatus"),
                 hist.Bin("pt", "pt", [0, 30.0, 45.0, 60.0, 100.0, 200.0]),
                 hist.Bin("abseta", "abseta", [0, 0.4, 0.8, 1.1, 1.4, 1.6, 1.9, 2.2, 2.5]),
             ),

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -45,7 +45,8 @@ for fn in inputFiles:
     if fn.endswith('.json'):
         sample = os.path.basename(fn).replace('.json','')
         jsn = load_sample_json_file(fn)
-        samples_to_process = update_cfg(jsn,
+        samples_to_process = update_cfg(
+            jsn,
             name=sample,
             cfg=samples_to_process,
             max_files=max_files,

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -5,7 +5,6 @@ import gzip
 import os
 import argparse
 
-import numpy as np
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
 import topcoffea.modules.remote_environment as remote_environment

--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -2,25 +2,17 @@
 #   - Should be run on the output of the mc_validation_gen_processor.py processor
 #   - Was used during the June 2022 MC validation studies (for TOP-22-006 pre approval checks)
 
-import numpy as np
 import os
-import copy
 import datetime
 import argparse
-import matplotlib.pyplot as plt
-from cycler import cycler
 import gzip
 import cloudpickle
 
-import uproot
 from coffea import hist
 
-from topcoffea.modules.HistEFT import HistEFT
-from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.YieldTools import YieldTools
 from topcoffea.scripts.make_html import make_html
 
-import topcoffea.modules.GetValuesFromJsons as getj
 
 # Probably I should move the utility functions out of this script and put them in modules
 # Anyway, not good practice to just import it here as if it were a library, but I'm doing it anyway (for now)
@@ -37,7 +29,7 @@ def save_pkl_for_arr(sf_arr,tag):
     save_pkl_str = "ht_rwgt_sf_" + tag + ".pkl.gz"
     with gzip.open(save_pkl_str, "wb") as fout:
         cloudpickle.dump(sf_histo, fout)
-    
+
 
 # Main wrapper script for making the private vs central comparison plots
 def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
@@ -48,22 +40,22 @@ def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
 
     comp_proc_dict = {
         "ttH" : {
-            "central_nonUL" : f"ttH_central2017",
+            "central_nonUL" : "ttH_central2017",
             "central" : f"ttH_central{year}",
             "private": f"ttHJet_private{year}",
         },
         "ttlnu" : {
-            "central_nonUL" : f"ttW_central2017",
+            "central_nonUL" : "ttW_central2017",
             "central" : f"ttW_central{year}",
             "private": f"ttlnuJet_private{year}",
         },
         "ttll" : {
-            "central_nonUL" : f"ttZ_central2017",
+            "central_nonUL" : "ttZ_central2017",
             "central" : f"ttZ_central{year}",
             "private": f"ttllJet_private{year}",
         },
         "tllq" : {
-            "central_nonUL" : f"tZq_central2017",
+            "central_nonUL" : "tZq_central2017",
             "central" : f"tZq_central{year}",
             "private": f"tllq_private{year}",
         },

--- a/analysis/mc_validation/mc_validation_gen_processor.py
+++ b/analysis/mc_validation/mc_validation_gen_processor.py
@@ -1,25 +1,14 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import cloudpickle
-import json
-import pprint
-import copy
-import coffea
 import numpy as np
 import awkward as ak
 np.seterr(divide='ignore', invalid='ignore', over='ignore')
 from coffea import hist, processor
-from coffea.util import load, save
-from optparse import OptionParser
-from coffea.analysis_tools import PackedSelection
-from coffea.lumi_tools import LumiMask
 
 from topcoffea.modules.GetValuesFromJsons import get_lumi
 from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import SFevaluator, GetBTagSF, ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, GetPUSF, ApplyRochesterCorrections, ApplyJetSystematics, AttachPSWeights, AttachPdfWeights, AttachScaleWeights, GetTriggerSF, get_ht_sf
+#from topcoffea.modules.corrections import get_ht_sf
 from topcoffea.modules.selection import *
 from topcoffea.modules.HistEFT import HistEFT
-from topcoffea.modules.paths import topcoffea_path
 import topcoffea.modules.eft_helper as efth
 
 
@@ -164,7 +153,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         lumi = get_lumi(year)*1000.0
         event_weight = lumi*xsec*genw/sow
 
-        # Example of reweighting based on Ht 
+        # Example of reweighting based on Ht
         #if "private" in histAxisName:
         #    ht_sf = get_ht_sf(ht,histAxisName)
         #    event_weight = event_weight*ht_sf

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -4,16 +4,11 @@
 
 import numpy as np
 import os
-import copy
 import datetime
 import argparse
-import matplotlib.pyplot as plt
-from cycler import cycler
 
 import uproot
-from coffea import hist
 
-from topcoffea.modules.HistEFT import HistEFT
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.YieldTools import YieldTools
 from topcoffea.scripts.make_html import make_html

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -13,7 +13,6 @@ from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.YieldTools import YieldTools
 from topcoffea.scripts.make_html import make_html
 
-import topcoffea.modules.GetValuesFromJsons as getj
 
 # This script should maybe just be a part of make_cr_and_sr_plots, though that script is getting really long
 # Probably I should move the utility functions out of that script and put them in modules

--- a/analysis/topEFT/get_datacard_yields.py
+++ b/analysis/topEFT/get_datacard_yields.py
@@ -3,7 +3,6 @@ import copy
 import datetime
 import argparse
 import json
-import numpy as np
 
 import topcoffea.modules.MakeLatexTable as mlt
 
@@ -11,23 +10,23 @@ BKG_PROC_LST = ["tWZ_sm", "convs_sm","Diboson_sm","Triboson_sm","charge_flips_sm
 SIG_PROC_LST = ["ttH_sm", "ttlnu_sm", "ttll_sm", "tllq_sm", "tHq_sm", "tttt_sm"]
 
 PROC_ORDER = [
-     "tWZ_sm",
-     "Diboson_sm",
-     "Triboson_sm",
-     "charge_flips_sm",
-     "fakes_sm",
-     "convs_sm",
-     "Sum_bkg",
-     "ttlnu_sm",
-     "ttll_sm",
-     "ttH_sm",
-     "tllq_sm",
-     "tHq_sm",
-     "tttt_sm",
-     "Sum_sig",
-     "Sum_expected",
-     "Observation",
-     "Pdiff",
+    "tWZ_sm",
+    "Diboson_sm",
+    "Triboson_sm",
+    "charge_flips_sm",
+    "fakes_sm",
+    "convs_sm",
+    "Sum_bkg",
+    "ttlnu_sm",
+    "ttll_sm",
+    "ttH_sm",
+    "tllq_sm",
+    "tHq_sm",
+    "tttt_sm",
+    "Sum_sig",
+    "Sum_expected",
+    "Observation",
+    "Pdiff",
 ]
 CAT_ORDER = [
     "2lss_m_3b",
@@ -105,7 +104,7 @@ def get_dc_file_names(flst,ext=".txt"):
     for fname in flst:
         if fname.startswith("ttx") and fname.endswith(ext):
             dclst.append(fname)
-    return(dclst)
+    return (dclst)
 
 # Take the name of a datacard and extract the process name
 def get_cat_name_from_dc_name(dc_name,ext=".txt"):
@@ -147,7 +146,7 @@ def get_rates(dc_lines_lst):
         rate_dict[proc_lst[i]] = float(rate_lst[i])
     rate_dict["Observation"] = float(observation)
 
-    return(rate_dict)
+    return (rate_dict)
 
 
 # Takes a rate dict (as returned by get_rates) and returns just the sm terms
@@ -272,7 +271,7 @@ def get_sm_rates(dc_fullpath):
     rate_dict_sm = get_just_sm(rate_dict)
     rate_dict_sm_with_sums = add_proc_sums(rate_dict_sm)
     return rate_dict_sm_with_sums
-    
+
 
 ########################################
 # Main function

--- a/analysis/topEFT/get_yield_json.py
+++ b/analysis/topEFT/get_yield_json.py
@@ -50,6 +50,6 @@ def main():
     with open(out_json_name+".json", "w") as out_file:
         json.dump(yld_dict, out_file, indent=4)
     print(f"Saved json file: {out_json_name}.json\n")
-    
+
 if __name__ == "__main__":
     main()

--- a/analysis/topEFT/make_1d_quad_plots.py
+++ b/analysis/topEFT/make_1d_quad_plots.py
@@ -1,7 +1,6 @@
 import os
 import argparse
 import datetime
-import matplotlib.pyplot as plt
 from coffea.nanoevents import NanoEventsFactory
 
 import topcoffea.modules.fileReader as fr

--- a/analysis/topEFT/make_1d_quad_plots.py
+++ b/analysis/topEFT/make_1d_quad_plots.py
@@ -1,7 +1,6 @@
 import os
 import argparse
 import datetime
-import numpy as np
 import matplotlib.pyplot as plt
 from coffea.nanoevents import NanoEventsFactory
 
@@ -9,7 +8,7 @@ import topcoffea.modules.fileReader as fr
 import topcoffea.modules.QuadFitTools as qft
 from topcoffea.scripts.make_html import make_html
 
-# This is more or less a placeholder script 
+# This is more or less a placeholder script
 #   - It shows  an example of how we might want to access the quadratic fit information using topcoffea.modules.QuadFitTools
 #   - Currently the script doesn't do much (just processes a single ttH file, prints where fits cross a threshold, and makes 1d quadratic plots)
 #   - So this is probably not all that useful right now, but might give us a place to build from in the future

--- a/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topEFT/make_1d_quad_plots_from_template_histos.py
@@ -1,16 +1,16 @@
 # About this script:
 #     - This script takes as input the information from the template histograms
 #     - The goal is to reconstruct the quadratic parameterizations from the templates
-#     - The script extracts the full 26-dimensional quadratic, but currently just plots the 1d quadratics 
+#     - The script extracts the full 26-dimensional quadratic, but currently just plots the 1d quadratics
 # About the input to this script:
-#     - The relevant templates are the ones produced by topcoffea's datacard_maker.py, which should be passed 
+#     - The relevant templates are the ones produced by topcoffea's datacard_maker.py, which should be passed
 #       to EFTFit's look_at_templates.C (which opens the templates, optionally extrapolates the up/down beyond +-1sigma,
 #       and dumps the info into a python dictionary), so it is the output of look_at_templates.C that this script runs on
-#     - It would probably be better for look_at_templates.C to dump the info into e.g. a json, but right now it just prints 
-#       the info to the screen in the form of a python dictionary, so this script assumes that dictionary has been pasted 
+#     - It would probably be better for look_at_templates.C to dump the info into e.g. a json, but right now it just prints
+#       the info to the screen in the form of a python dictionary, so this script assumes that dictionary has been pasted
 #       into a .py file and we can just directly import the dictionary
 #     - That dictionary that we import is a global variable called IN_DICT in the script
-#     - Note that so far this script assumes the templates are just njets (i.e. none of the naming and conventions etc. are 
+#     - Note that so far this script assumes the templates are just njets (i.e. none of the naming and conventions etc. are
 #       currently set up to work with e.g. bins in lj0pt)
 
 # Some notes on the naming conventions for the decomposed and reconstructed quadratic parameterization
@@ -23,7 +23,7 @@
 # Thus, to reconstruct the quadratic parameterization, we need the following combinations of decomposed terms:
 #     S    = sm
 #     Qi   = quad_i
-#     Li   = lin_i - S - Qi 
+#     Li   = lin_i - S - Qi
 #          = lin_i - sm - quad_i
 #     2Mij = mixed_ij - S - Qi - Qj - Li - Lj
 #          = mixed_ij - sm - quad_i - quad_j - (lin_i - sm - Qi) - (lin_j - sm - quad_j)
@@ -31,11 +31,10 @@
 # To run this script:
 #     - The script is currently very basic and hard coded
 #     - The inputs dictionary is hardcoded, also where to save the output plots is hard coded
-#     - So to run it is just: 
+#     - So to run it is just:
 #       python make_1d_quad_plots_from_template_histos.py
 
 
-import numpy as np
 import os
 import topcoffea.modules.QuadFitTools as qft
 from topcoffea.scripts.make_html import make_html
@@ -96,7 +95,7 @@ def get_decomp_term_sm(decomp_lst):
         if "sm" in decomp_term_name:
             ret = decomp_term_name
     if ret is None:
-        print(f"\nError: Can't find term for wc \"{wc}\" in this list of terms: {decomp_lst}")
+        print("\nError: Can't find term for sm in this list of terms: {decomp_lst}")
         raise Exception("Error, no sm term found")
     else: return ret
 
@@ -132,7 +131,7 @@ def get_decomp_term_mix(decomp_lst,wc0,wc1):
         if ("mix" in decomp_term_name) and (wc0 in substr_lst) and (wc1 in substr_lst):
             ret = decomp_term_name
     if ret is None:
-        print(f"\nError: Can't find term for wc \"{wc}\" in this list of terms: {decomp_lst}")
+        print(f"\nError: Can't find term for WCs \"{wc0}\" and \"{wc1}\" in this list of terms: {decomp_lst}")
         raise Exception("Error, no mixed term found")
     else: return ret
 

--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -94,7 +94,7 @@ def run_condor(dc,pkl_fpath,out_dir,var_lst,ch_lst,chunk_size):
     if not os.path.samefile(home,out_dir):
         condor_exe_fname = os.path.join(out_dir,"condor.sh")
 
-    print(f"Generating condor executable script")
+    print("Generating condor executable script")
     with open(condor_exe_fname,"w") as f:
         f.write(sh_fragment)
 
@@ -260,7 +260,7 @@ def main():
                 for wc in wcs:
                     if not wc in selected_wcs[p]:
                         selected_wcs[p].append(wc)
-        with open(os.path.join(out_dir,f"selectedWCs.txt"),"w") as f:
+        with open(os.path.join(out_dir,"selectedWCs.txt"),"w") as f:
             selected_wcs_for_json = {}
             for p,v in selected_wcs.items():
                 if not dc.is_signal(p):

--- a/analysis/topEFT/make_cr_and_sr_plots.py
+++ b/analysis/topEFT/make_cr_and_sr_plots.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 from cycler import cycler
 
 from coffea import hist
-from topcoffea.modules.HistEFT import HistEFT
+#from topcoffea.modules.HistEFT import HistEFT
 
 from topcoffea.modules.YieldTools import YieldTools
 import topcoffea.modules.GetValuesFromJsons as getj
@@ -17,7 +17,7 @@ import topcoffea.modules.utils as utils
 # This script takes an input pkl file that should have both data and background MC included.
 # Use the -y option to specify a year, if no year is specified, all years will be included.
 # There are various other options available from the command line.
-# For example, to make unit normalized plots for 2018, with the timestamp appended to the directory name, you would run:    
+# For example, to make unit normalized plots for 2018, with the timestamp appended to the directory name, you would run:
 #     python make_cr_plots.py -f histos/your.pkl.gz -o ~/www/somewhere/in/your/web/dir -n some_dir_name -y 2018 -t -u
 
 # Some options for plotting the data and MC
@@ -165,7 +165,7 @@ def get_dict_with_stripped_bin_names(in_chan_dict,type_of_info_to_strip):
                 raise Exception(f"Error: Unknown type of string to remove \"{type_of_info_to_strip}\".")
             if bin_name_no_njet not in out_chan_dict[cat]:
                 out_chan_dict[cat].append(bin_name_no_njet)
-    return(out_chan_dict)
+    return (out_chan_dict)
 
 
 # Figures out which year a sample is from, retruns the lumi for that year
@@ -180,7 +180,7 @@ def get_lumi_for_sample(sample_name):
         # Should not be here unless "UL16APV" not in sample_name
         lumi = 1000.0*getj.get_lumi("2016")
     else:
-        raise Exception(f"Error: Unknown year \"{year}\".")
+        raise Exception(f"Error: Unknown year for \"{sample_name}\".")
     return lumi
 
 # Group bins in a hist, returns a new hist
@@ -366,7 +366,7 @@ def get_shape_syst_arrs(base_histo):
 # Special case for renorm and fact, as these are decorrelated across processes
 # Sorry to anyone who tries to read this in the future, this function is very ad hoc and messy and hard to follow
 # Just used in get_shape_syst_arrs()
-# Here are a few notes: 
+# Here are a few notes:
 #   - This is complicated, so I just symmetrized the errors
 #   - The processes are generally correlated across groups (e.g. WZ and ZZ) since this is what's done in the datacard maker for the SR
 #   - So the grouping generally follows what's in the CR group map, except in the case of signal
@@ -374,7 +374,7 @@ def get_shape_syst_arrs(base_histo):
 #       - Note there are caveats to this:
 #           * In the SR, TTZToLL_M1to10 and TTToSemiLeptonic and TTTo2L2Nu are all grouped into ttll
 #           * Here in the CR TTZToLL_M1to10 is part of signal group, but TTToSemiLeptonic and TTTo2L2Nu are in their own ttbar group
-#           * So there are two differences with respect to how these processes are grouped in the SR: 
+#           * So there are two differences with respect to how these processes are grouped in the SR:
 #               1) Here TTToSemiLeptonic and TTTo2L2Nu are correlated with each other, but not with ttll
 #               2) Here TTZToLL_M1to10 is grouped as part of signal (as in SR) but here _all_ signal processes are uncorrleated so here TTZToLL_M1to10 is uncorrelated with ttll while in SR they would be correlated
 def get_decorrelated_uncty(syst_name,grp_map,relevant_samples_lst,base_histo,template_zeros_arr):
@@ -744,6 +744,7 @@ def make_simple_plots(dict_of_hists,year,save_dir_path):
             continue
 
             # Make a sub dir for this category
+            save_tag = "placeholder" # Flake8 pointed out that save_tag is not defined, should figure out why at some point if this function is ever used again
             save_dir_path_tmp = os.path.join(save_dir_path,save_tag)
             if not os.path.exists(save_dir_path_tmp):
                 os.mkdir(save_dir_path_tmp)
@@ -956,7 +957,7 @@ def make_all_sr_plots(dict_of_hists,year,unit_norm_bool,save_dir_path,split_by_c
 
         # Make plots for each SR category
         if split_by_chan:
-            for hist_cat in SR_CHAN_DICT.keys(): 
+            for hist_cat in SR_CHAN_DICT.keys():
                 if ((var_name == "ptz") and ("3l" not in hist_cat)): continue
 
                 # Make a sub dir for this category

--- a/analysis/topEFT/make_jsons.py
+++ b/analysis/topEFT/make_jsons.py
@@ -7,8 +7,8 @@ import subprocess
 import os
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.samples import loadxsecdic
-from topcoffea.modules.combine_json_ext  import combine_json_ext
-from topcoffea.modules.combine_json_batch  import combine_json_batch
+from topcoffea.modules.combine_json_ext import combine_json_ext
+from topcoffea.modules.combine_json_batch import combine_json_batch
 import re
 
 ########### The XSs from xsec.cfg ###########
@@ -612,12 +612,12 @@ central_UL17_bkg_dict = {
         "xsecName": "ST_top_s-channel",
     },
     "UL17_ST_top_t-channel" : {
-        "path" : "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM", 
+        "path" : "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",
         "histAxisName": "ST_top_t-channel_centralUL17",
         "xsecName": "ST_top_t-channel",
     },
     "UL17_ST_antitop_t-channel" : {
-        "path" : "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM", 
+        "path" : "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",
         "histAxisName": "ST_antitop_t-channel_centralUL17",
         "xsecName": "ST_antitop_t-channel",
     },
@@ -699,7 +699,7 @@ central_UL17_bkg_dict = {
     },
     "UL17_WZTo3LNu" : {
         "path" : "/WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",
-        "path_local" : "/store/mc/RunIISummer20UL17NanoAODv9/WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_mc2017_realistic_v9-v2", 
+        "path_local" : "/store/mc/RunIISummer20UL17NanoAODv9/WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_mc2017_realistic_v9-v2",
         "histAxisName": "WZTo3LNu_centralUL17",
         "xsecName": "WZTo3LNu",
     },
@@ -828,12 +828,12 @@ central_UL18_bkg_dict = {
         "xsecName": "ST_top_s-channel",
     },
     "UL18_ST_top_t-channel" : {
-        "path" : "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM", 
+        "path" : "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM",
         "histAxisName": "ST_top_t-channel_centralUL18",
         "xsecName": "ST_top_t-channel",
     },
     "UL18_ST_antitop_t-channel" : {
-        "path" : "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM", 
+        "path" : "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM",
         "histAxisName": "ST_antitop_t-channel_centralUL18",
         "xsecName": "ST_antitop_t-channel",
     },
@@ -1046,7 +1046,7 @@ central_UL16_bkg_dict = {
         "xsecName": "DYJetsToLL_M_10to50_MLM",
     },
     "UL16_DY50" : {
-        "path" : "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16NanoAODv9-106X_mcRun2_asymptotic_v17-v1/NANOAODSIM", 
+        "path" : "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16NanoAODv9-106X_mcRun2_asymptotic_v17-v1/NANOAODSIM",
         "histAxisName": "DY50_centralUL16",
         "xsecName": "DYJetsToLL_M_50_MLM",
     },
@@ -1258,7 +1258,7 @@ central_UL16APV_bkg_dict = {
     },
     "UL16APV_DY10to50" : {
         "path" : "/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",
-        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1", 
+        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1",
         "histAxisName": "DY10to50_centralUL16APV",
         "xsecName": "DYJetsToLL_M_10to50_MLM",
     },
@@ -1273,12 +1273,12 @@ central_UL16APV_bkg_dict = {
         "xsecName": "ST_top_s-channel",
     },
     "UL16APV_ST_top_t-channel" : {
-        "path" : "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM", 
+        "path" : "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",
         "histAxisName": "ST_top_t-channel_centralUL16APV",
         "xsecName": "ST_top_t-channel",
     },
     "UL16APV_ST_antitop_t-channel" : {
-        "path" : "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM", 
+        "path" : "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",
         "histAxisName": "ST_antitop_t-channel_centralUL16APV",
         "xsecName": "ST_antitop_t-channel",
     },
@@ -1293,7 +1293,7 @@ central_UL16APV_bkg_dict = {
         "xsecName": "ST_tW_top_5f_inclusiveDecays",
     },
     "UL16APV_TTGJets" : {
-        "path" : "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM", 
+        "path" : "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",
         "histAxisName": "TTGJets_centralUL16APV",
         "xsecName": "TTGJets",
     },
@@ -1311,7 +1311,7 @@ central_UL16APV_bkg_dict = {
     },
     "UL16APV_TTJets" : {
         "path" : "/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",
-        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1", 
+        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1",
         "histAxisName": "TTJets_centralUL16APV",
         "xsecName": "TT",
     },
@@ -1334,7 +1334,7 @@ central_UL16APV_bkg_dict = {
     },
     "UL16APV_WJetsToLNu" : {
         "path" : "/WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",
-        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2", 
+        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
         "histAxisName": "WJetsToLNu_centralUL16APV",
         "xsecName": "WJetsToLNu",
     },
@@ -1360,7 +1360,7 @@ central_UL16APV_bkg_dict = {
     },
     "UL16APV_WZTo3LNu" : {
         "path" : "/WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",
-        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1", 
+        "path_local" : "/store/mc/RunIISummer20UL16NanoAODAPVv9/WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1",
         "histAxisName": "WZTo3LNu_centralUL16APV",
         "xsecName": "WZTo3LNu",
     },
@@ -1634,7 +1634,7 @@ for era in dataset_eras:
         ds_path = "/{ds}/{year}{era}_{ver}/NANOAOD".format(year=year,ds=ds_name,era=era,ver=version)
         data_2018_dict[key_name]['path'] = ds_path
 
-########### TESTING ########### 
+########### TESTING ###########
 
 test_dict = {
     "test_dy_sample" : {
@@ -1651,7 +1651,7 @@ def replace_val_in_json(path_to_json_file,key,new_val,verbose=True):
 
     # Replace value if it's different than what's in the JSON
     with open(path_to_json_file) as json_file:
-       json_dict = json.load(json_file)
+        json_dict = json.load(json_file)
     if new_val == json_dict[key]:
         if verbose:
             print(f"\tValues already agree, both are {new_val}")
@@ -1730,16 +1730,16 @@ def make_jsons_for_dict_of_samples(samples_dict,prefix,year,out_dir,on_das=False
         if not os.path.exists(out_name):
             failed.append(sample_name)
 
-        subprocess.run(["mv",out_name,out_dir]) 
+        subprocess.run(["mv",out_name,out_dir])
         if '_ext' in out_name:
-          combine_json_ext(out_dir+'/'+out_name) # Merge with non-ext version
-          os.remove(out_dir+'/'+out_name) # Remove (now) outdated ext version
+            combine_json_ext(out_dir+'/'+out_name) # Merge with non-ext version
+            os.remove(out_dir+'/'+out_name) # Remove (now) outdated ext version
         # Only run if more than one file exists (differentiates between `*_b2.json` and `*_b2_atPSI.json`
         r = re.compile(re.sub(r'_b[1-9]', '_b[1-9]', out_name))
         matches = [b for b in str(subprocess.check_output(["ls",'.'], shell=True)).split('\\n') if bool(r.match(b))]
         if re.search('_b[2-9]', out_name) and len(matches)>1:
-          combine_json_batch(out_dir+'/'+out_name) # Merge batches
-          os.remove(out_dir+'/'+out_name) # Remove (now) outdated batch version
+            combine_json_batch(out_dir+'/'+out_name) # Merge batches
+            os.remove(out_dir+'/'+out_name) # Remove (now) outdated batch version
 
         print("sample name:",sample_name)
         print("\tpath:",path,"\n\thistAxisName:",hist_axis_name,"\n\txsecName",xsec_name,"\n\tout name:",out_name,"\n\tout dir:",out_dir)

--- a/analysis/topEFT/make_skim_jsons.py
+++ b/analysis/topEFT/make_skim_jsons.py
@@ -1,10 +1,9 @@
 import os
 import argparse
-import json
 
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.update_json import update_json
-from topcoffea.modules.utils import regex_match, load_sample_json_file, get_files
+from topcoffea.modules.utils import get_files
 
 pjoin = os.path.join
 
@@ -73,7 +72,8 @@ def main():
     ignore_files.extend(['lumi.json','params.json'])
     # These are json files for already produced skims, so skip them as well
     ignore_files.extend([".*_atPSI\\.json",".*_NDSkim\\.json"])
-    template_json_fpaths = get_files(json_dir,
+    template_json_fpaths = get_files(
+        json_dir,
         ignore_dirs  = ignore_dirs,
         match_files  = match_files,
         ignore_files = ignore_files,
@@ -114,14 +114,14 @@ def main():
         template_json_fpaths.remove(matched_json_fp)
     # These are lobster skims for which we couldn't find a matching json template
     if missing_templates:
-        print(f"Skims with no matching json template found:")
+        print("Skims with no matching json template found:")
         for x in missing_templates:
             print(f"\t{x}")
     else:
         print(f"Skims with no matching json template found: {missing_templates}")
     # These are json templates for which we couldn't find a lobster skim
     if template_json_fpaths:
-        print(f"Json templates with no matching skim found:")
+        print("Json templates with no matching skim found:")
         for x in template_json_fpaths:
             print(f"\t{x}")
     else:

--- a/analysis/topEFT/missing_parton.py
+++ b/analysis/topEFT/missing_parton.py
@@ -1,6 +1,6 @@
 '''
 This script computes the msising parton rate
-It requires the central (tZq) and private (tllq) samples exist in 
+It requires the central (tZq) and private (tllq) samples exist in
 `histos/central_sm/` and `histos/private_sm/` respectively
 To create these, run the datacard maker (tllq `with` systematics, tZq without)
 '''
@@ -11,7 +11,7 @@ import mplhep as hep
 import math
 import json
 from topcoffea.modules.comp_datacard import strip
-from coffea import hist
+#from coffea import hist
 import re
 
 files = ['2lss_m_2b',  '2lss_p_2b',  '2lss_4t_m_2b', '2lss_4t_p_2b', '3l1b_m',  '3l1b_p',  '3l2b_m',  '3l2b_p',  '3l_sfz_1b',  '3l_sfz_2b',  '4l_2b']
@@ -22,13 +22,13 @@ def get_hists(fname, path, process):
     fin = uproot.open('histos/'+path+'/ttx_multileptons-'+fname+'.root')
     card = strip('histos/'+path+'/ttx_multileptons-'+fname+'.txt')
     sm = [k.split(';')[0] for k in fin.keys() if 'sm' in k]
-  
+
     nom = {}; up = {}; down = {}
-        
+
     nom = {proc.strip(';1'): fin[proc].values() for proc in fin if 'sm;' in proc and (process in proc or process.replace('ll','Z') in proc)}
     for val in nom.values():
         val = [x if not math.isinf(x) else 0 for x in val]
-   
+
     up = {proc.strip('Up;1'): fin[proc].to_numpy()[0] for proc in fin if 'sm' in proc and ('Up;' in proc or 'flat' in proc) and 'fakes' not in proc}
     down = {proc.strip('Down;1'): fin[proc].to_numpy()[0] for proc in fin if 'sm' in proc and ('Down;' in proc or 'flat' in proc) and 'fakes' not in proc}
     total = np.array([v for v in nom.values()])[0]
@@ -67,7 +67,7 @@ def get_hists(fname, path, process):
                 s[1] = float(val) - 1
             err[0] = np.sqrt(np.square(err[0]) + np.square(total*s[0]))
             err[1] = np.sqrt(np.square(err[1]) + np.square(total*s[1]))
-  
+
     bins = fin[process+'_sm'].axis().edges()
     return total, nom, err, bins, [proc.split('_sm')[0]for proc in fin if 'sm;' in proc]
 

--- a/analysis/topEFT/parse_datacard_templtes.py
+++ b/analysis/topEFT/parse_datacard_templtes.py
@@ -14,7 +14,7 @@ import get_datacard_yields as dy # Note the functions we're using from this scri
 
 # Get the list of histo names from a root file
 def get_histo_names(in_file,only_sm=True,only_nom=False):
-    histo_name_lst = [] 
+    histo_name_lst = []
     in_file_keys = in_file.GetListOfKeys()
     for key_object in in_file_keys:
         hname = key_object.GetName()
@@ -72,9 +72,9 @@ def draw_nom_up_do_overlay(h_n,h_u,h_d,save_path):
     h_n.Draw("E SAME")
 
     # Set the colors
-    h_u.SetLineColor(3);
-    h_n.SetLineColor(1);
-    h_d.SetLineColor(4);
+    h_u.SetLineColor(3)
+    h_n.SetLineColor(1)
+    h_d.SetLineColor(4)
 
     # Set y range
     max_u = h_u.GetMaximum()

--- a/analysis/topEFT/run.py
+++ b/analysis/topEFT/run.py
@@ -1,22 +1,15 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import pickle
 import json
 import time
 import cloudpickle
 import gzip
 import os
-from optparse import OptionParser
 
-import uproot
 import numpy as np
 from coffea import hist, processor
-from coffea.util import load, save
 from coffea.nanoevents import NanoAODSchema
 
 import topeft
-from topcoffea.modules import samples
-from topcoffea.modules import fileReader
 from topcoffea.modules.utils import dump_to_pkl, get_hist_from_pkl
 from topcoffea.modules.dataDrivenEstimation import DataDrivenProducer
 from topcoffea.modules.get_renormfact_envelope import get_renormfact_envelope

--- a/analysis/topEFT/run.py
+++ b/analysis/topEFT/run.py
@@ -36,217 +36,218 @@ WGT_VAR_LST = [
 
 if __name__ == '__main__':
 
-  import argparse
-  parser = argparse.ArgumentParser(description='You can customize your run')
-  parser.add_argument('jsonFiles'           , nargs='?', default=''           , help = 'Json file(s) containing files and metadata')
-  parser.add_argument('--prefix', '-r'     , nargs='?', default=''           , help = 'Prefix or redirector to look for the files')
-  parser.add_argument('--test','-t'       , action='store_true'  , help = 'To perform a test, run over a few events in a couple of chunks')
-  parser.add_argument('--pretend'        , action='store_true'  , help = 'Read json files but, not execute the analysis')
-  parser.add_argument('--nworkers','-n'   , default=8  , help = 'Number of workers')
-  parser.add_argument('--chunksize','-s'   , default=100000  , help = 'Number of events per chunk')
-  parser.add_argument('--nchunks','-c'   , default=None  , help = 'You can choose to run only a number of chunks')
-  parser.add_argument('--outname','-o'   , default='plotsTopEFT', help = 'Name of the output file with histograms')
-  parser.add_argument('--outpath','-p'   , default='histos', help = 'Name of the output directory')
-  parser.add_argument('--treename'   , default='Events', help = 'Name of the tree inside the files')
-  parser.add_argument('--do-errors', action='store_true', help = 'Save the w**2 coefficients')
-  parser.add_argument('--do-systs', action='store_true', help = 'Run over systematic samples (takes longer)')
-  parser.add_argument('--split-lep-flavor', action='store_true', help = 'Split up categories by lepton flavor')
-  parser.add_argument('--skip-sr', action='store_true', help = 'Skip all signal region categories')
-  parser.add_argument('--skip-cr', action='store_true', help = 'Skip all control region categories')
-  parser.add_argument('--do-np', action='store_true', help = 'Perform nonprompt estimation on the output hist, and save a new hist with the np contribution included. Note that signal, background and data samples should all be processed together in order for this option to make sense.')
-  parser.add_argument('--do-renormfact-envelope', action='store_true', help = 'Perform renorm/fact envelope calculation on the output hist (saves the modified with the the same name as the original.')
-  parser.add_argument('--wc-list', action='extend', nargs='+', help = 'Specify a list of Wilson coefficients to use in filling histograms.')
-  parser.add_argument('--hist-list', action='extend', nargs='+', help = 'Specify a list of histograms to fill.')
-  parser.add_argument('--ecut', default=None  , help = 'Energy cut threshold i.e. throw out events above this (GeV)')
+    import argparse
+    parser = argparse.ArgumentParser(description='You can customize your run')
+    parser.add_argument('jsonFiles'           , nargs='?', default=''           , help = 'Json file(s) containing files and metadata')
+    parser.add_argument('--prefix', '-r'     , nargs='?', default=''           , help = 'Prefix or redirector to look for the files')
+    parser.add_argument('--test','-t'       , action='store_true'  , help = 'To perform a test, run over a few events in a couple of chunks')
+    parser.add_argument('--pretend'        , action='store_true'  , help = 'Read json files but, not execute the analysis')
+    parser.add_argument('--nworkers','-n'   , default=8  , help = 'Number of workers')
+    parser.add_argument('--chunksize','-s'   , default=100000  , help = 'Number of events per chunk')
+    parser.add_argument('--nchunks','-c'   , default=None  , help = 'You can choose to run only a number of chunks')
+    parser.add_argument('--outname','-o'   , default='plotsTopEFT', help = 'Name of the output file with histograms')
+    parser.add_argument('--outpath','-p'   , default='histos', help = 'Name of the output directory')
+    parser.add_argument('--treename'   , default='Events', help = 'Name of the tree inside the files')
+    parser.add_argument('--do-errors', action='store_true', help = 'Save the w**2 coefficients')
+    parser.add_argument('--do-systs', action='store_true', help = 'Run over systematic samples (takes longer)')
+    parser.add_argument('--split-lep-flavor', action='store_true', help = 'Split up categories by lepton flavor')
+    parser.add_argument('--skip-sr', action='store_true', help = 'Skip all signal region categories')
+    parser.add_argument('--skip-cr', action='store_true', help = 'Skip all control region categories')
+    parser.add_argument('--do-np', action='store_true', help = 'Perform nonprompt estimation on the output hist, and save a new hist with the np contribution included. Note that signal, background and data samples should all be processed together in order for this option to make sense.')
+    parser.add_argument('--do-renormfact-envelope', action='store_true', help = 'Perform renorm/fact envelope calculation on the output hist (saves the modified with the the same name as the original.')
+    parser.add_argument('--wc-list', action='extend', nargs='+', help = 'Specify a list of Wilson coefficients to use in filling histograms.')
+    parser.add_argument('--hist-list', action='extend', nargs='+', help = 'Specify a list of histograms to fill.')
+    parser.add_argument('--ecut', default=None  , help = 'Energy cut threshold i.e. throw out events above this (GeV)')
 
-  args = parser.parse_args()
-  jsonFiles        = args.jsonFiles
-  prefix           = args.prefix
-  dotest           = args.test
-  nworkers         = int(args.nworkers)
-  chunksize        = int(args.chunksize)
-  nchunks          = int(args.nchunks) if not args.nchunks is None else args.nchunks
-  outname          = args.outname
-  outpath          = args.outpath
-  pretend          = args.pretend
-  treename         = args.treename
-  do_errors        = args.do_errors
-  do_systs         = args.do_systs
-  split_lep_flavor = args.split_lep_flavor
-  skip_sr          = args.skip_sr
-  skip_cr          = args.skip_cr
-  do_np            = args.do_np
-  do_renormfact_envelope= args.do_renormfact_envelope
-  wc_lst = args.wc_list if args.wc_list is not None else []
+    args = parser.parse_args()
+    jsonFiles        = args.jsonFiles
+    prefix           = args.prefix
+    dotest           = args.test
+    nworkers         = int(args.nworkers)
+    chunksize        = int(args.chunksize)
+    nchunks          = int(args.nchunks) if not args.nchunks is None else args.nchunks
+    outname          = args.outname
+    outpath          = args.outpath
+    pretend          = args.pretend
+    treename         = args.treename
+    do_errors        = args.do_errors
+    do_systs         = args.do_systs
+    split_lep_flavor = args.split_lep_flavor
+    skip_sr          = args.skip_sr
+    skip_cr          = args.skip_cr
+    do_np            = args.do_np
+    do_renormfact_envelope= args.do_renormfact_envelope
+    wc_lst = args.wc_list if args.wc_list is not None else []
 
-  # Check if we have valid options
-  if do_renormfact_envelope:
-      if not do_systs:
-          raise Exception("Error: Cannot specify do_renormfact_envelope if we are not including systematics.")
-      if not do_np:
-          raise Exception("Error: Cannot specify do_renormfact_envelope if we have not already done the integration across the appl axis that occurs in the data driven estimator step.")
-
-  # Set the threshold for the ecut (if not applying a cut, should be None)
-  ecut_threshold = args.ecut
-  if ecut_threshold is not None: ecut_threshold = float(args.ecut)
-
-  # Figure out which hists to include
-  if args.hist_list == ["ana"]:
-    # Here we hardcode a list of hists used for the analysis
-    hist_lst = ["njets","lj0pt","ptz"]
-  elif args.hist_list == ["cr"]:
-    # Here we hardcode a list of hists used for the CRs
-    hist_lst = ["lj0pt", "ptz", "met", "ljptsum", "l0pt", "l0eta", "l1pt", "l1eta", "j0pt", "j0eta", "njets", "nbtagsl", "invmass"]
-  else:
-    # We want to specify a custom list
-    # If we don't specify this argument, it will be None, and the processor will fill all hists 
-    hist_lst = args.hist_list
-
-  if dotest:
-    nchunks = 2
-    chunksize = 10000
-    nworkers = 1
-    print('Running a fast test with %i workers, %i chunks of %i events'%(nworkers, nchunks, chunksize))
-
-  ### Load samples from json
-  samplesdict = {}
-  allInputFiles = []
-
-  def LoadJsonToSampleName(jsonFile, prefix):
-    sampleName = jsonFile if not '/' in jsonFile else jsonFile[jsonFile.rfind('/')+1:]
-    if sampleName.endswith('.json'): sampleName = sampleName[:-5]
-    with open(jsonFile) as jf:
-      samplesdict[sampleName] = json.load(jf)
-      samplesdict[sampleName]['redirector'] = prefix
-
-  if   isinstance(jsonFiles, str) and ',' in jsonFiles: jsonFiles = jsonFiles.replace(' ', '').split(',')
-  elif isinstance(jsonFiles, str)                     : jsonFiles = [jsonFiles]
-  for jsonFile in jsonFiles:
-    if os.path.isdir(jsonFile):
-      if not jsonFile.endswith('/'): jsonFile+='/'
-      for f in os.path.listdir(jsonFile):
-        if f.endswith('.json'): allInputFiles.append(jsonFile+f)
-    else:
-      allInputFiles.append(jsonFile)
-
-  # Read from cfg files
-  for f in allInputFiles:
-    if not os.path.isfile(f):
-      raise Exception(f'[ERROR] Input file {f} not found!')
-    # This input file is a json file, not a cfg
-    if f.endswith('.json'): 
-      LoadJsonToSampleName(f, prefix)
-    # Open cfg files
-    else:
-      with open(f) as fin:
-        print(' >> Reading json from cfg file...')
-        lines = fin.readlines()
-        for l in lines:
-          if '#' in l: l=l[:l.find('#')]
-          l = l.replace(' ', '').replace('\n', '')
-          if l == '': continue
-          if ',' in l:
-            l = l.split(',')
-            for nl in l:
-              if not os.path.isfile(l): prefix = nl
-              else: LoadJsonToSampleName(nl, prefix)
-          else:
-            if not os.path.isfile(l): prefix = l
-            else: LoadJsonToSampleName(l, prefix)
-
-  flist = {};
-  for sname in samplesdict.keys():
-    redirector = samplesdict[sname]['redirector']
-    flist[sname] = [(redirector+f) for f in samplesdict[sname]['files']]
-    samplesdict[sname]['year'] = samplesdict[sname]['year']
-    samplesdict[sname]['xsec'] = float(samplesdict[sname]['xsec'])
-    samplesdict[sname]['nEvents'] = int(samplesdict[sname]['nEvents'])
-    samplesdict[sname]['nGenEvents'] = int(samplesdict[sname]['nGenEvents'])
-    samplesdict[sname]['nSumOfWeights'] = float(samplesdict[sname]['nSumOfWeights'])
-    if not samplesdict[sname]["isData"]:
-      for wgt_var in WGT_VAR_LST:
-          # Check that MC samples have all needed weight sums (only needed if doing systs)
-          if do_systs:
-              if (wgt_var not in samplesdict[sname]):
-                  raise Exception(f"Missing weight variation \"{wgt_var}\".")
-              else:
-                  samplesdict[sname][wgt_var] = float(samplesdict[sname][wgt_var])
-
-    # Print file info
-    print('>> '+sname)
-    print('   - isData?      : %s'   %('YES' if samplesdict[sname]['isData'] else 'NO'))
-    print('   - year         : %s'   %samplesdict[sname]['year'])
-    print('   - xsec         : %f'   %samplesdict[sname]['xsec'])
-    print('   - histAxisName : %s'   %samplesdict[sname]['histAxisName'])
-    print('   - options      : %s'   %samplesdict[sname]['options'])
-    print('   - tree         : %s'   %samplesdict[sname]['treeName'])
-    print('   - nEvents      : %i'   %samplesdict[sname]['nEvents'])
-    print('   - nGenEvents   : %i'   %samplesdict[sname]['nGenEvents'])
-    print('   - SumWeights   : %f'   %samplesdict[sname]['nSumOfWeights'])
-    if not samplesdict[sname]["isData"]:
-      for wgt_var in WGT_VAR_LST:
-        if wgt_var in samplesdict[sname]:
-            print(f'   - {wgt_var}: {samplesdict[sname][wgt_var]}')
-    print('   - Prefix       : %s'   %samplesdict[sname]['redirector'])
-    print('   - nFiles       : %i'   %len(samplesdict[sname]['files']))
-    for fname in samplesdict[sname]['files']: print('     %s'%fname)
-
-  if pretend: 
-    print('pretending...')
-    exit() 
-
-  # Extract the list of all WCs, as long as we haven't already specified one.
-  if len(wc_lst) == 0:
-    for k in samplesdict.keys():
-      for wc in samplesdict[k]['WCnames']:
-        if wc not in wc_lst:
-          wc_lst.append(wc)
-
-  if len(wc_lst) > 0:
-    # Yes, why not have the output be in correct English?
-    if len(wc_lst) == 1:
-      wc_print = wc_lst[0]
-    elif len(wc_lst) == 2:
-      wc_print = wc_lst[0] + ' and ' + wc_lst[1]
-    else:
-      wc_print = ', '.join(wc_lst[:-1]) + ', and ' + wc_lst[-1]
-    print('Wilson Coefficients: {}.'.format(wc_print))
-  else:
-    print('No Wilson coefficients specified')
-
-  processor_instance = topeft.AnalysisProcessor(samplesdict,wc_lst,hist_lst,ecut_threshold,do_errors,do_systs,split_lep_flavor,skip_sr,skip_cr)
-
-  exec_instance = processor.FuturesExecutor(workers=nworkers)
-  runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
-
-  # Run the processor and get the output
-  tstart = time.time()
-  output = runner(flist, treename, processor_instance)
-  dt = time.time() - tstart
-
-  nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
-  nfilled = sum(sum(np.sum(arr > 0) for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
-  print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
-  print("Processing time: %1.2f s with %i workers (%.2f s cpu overall)" % (dt, nworkers, dt*nworkers, ))
-
-  # Save the output
-  if not os.path.isdir(outpath): os.system("mkdir -p %s"%outpath)
-  out_pkl_file = os.path.join(outpath,outname+".pkl.gz")
-  print(f"\nSaving output in {out_pkl_file}...")
-  with gzip.open(out_pkl_file, "wb") as fout:
-    cloudpickle.dump(output, fout)
-  print("Done!")
-
-  # Run the data driven estimation, save the output
-  if do_np:
-    print("\nDoing the nonprompt estimation...")
-    out_pkl_file_name_np = os.path.join(outpath,outname+"_np.pkl.gz")
-    ddp = DataDrivenProducer(out_pkl_file,out_pkl_file_name_np)
-    print(f"Saving output in {out_pkl_file_name_np}...")
-    ddp.dumpToPickle()
-    print("Done!")
+    # Check if we have valid options
     if do_renormfact_envelope:
-      print("\nDoing the renorm. fact. envelope calculation...")
-      dict_of_histos = get_hist_from_pkl(out_pkl_file_name_np,allow_empty=False)
-      dict_of_histos_after_applying_envelope = get_renormfact_envelope(dict_of_histos)
-      dump_to_pkl(out_pkl_file_name_np,dict_of_histos_after_applying_envelope)
+        if not do_systs:
+            raise Exception("Error: Cannot specify do_renormfact_envelope if we are not including systematics.")
+        if not do_np:
+            raise Exception("Error: Cannot specify do_renormfact_envelope if we have not already done the integration across the appl axis that occurs in the data driven estimator step.")
+
+    # Set the threshold for the ecut (if not applying a cut, should be None)
+    ecut_threshold = args.ecut
+    if ecut_threshold is not None: ecut_threshold = float(args.ecut)
+
+    # Figure out which hists to include
+    if args.hist_list == ["ana"]:
+        # Here we hardcode a list of hists used for the analysis
+        hist_lst = ["njets","lj0pt","ptz"]
+    elif args.hist_list == ["cr"]:
+        # Here we hardcode a list of hists used for the CRs
+        hist_lst = ["lj0pt", "ptz", "met", "ljptsum", "l0pt", "l0eta", "l1pt", "l1eta", "j0pt", "j0eta", "njets", "nbtagsl", "invmass"]
+    else:
+        # We want to specify a custom list
+        # If we don't specify this argument, it will be None, and the processor will fill all hists 
+        hist_lst = args.hist_list
+
+    if dotest:
+        nchunks = 2
+        chunksize = 10000
+        nworkers = 1
+        print('Running a fast test with %i workers, %i chunks of %i events'%(nworkers, nchunks, chunksize))
+
+    ### Load samples from json
+    samplesdict = {}
+    allInputFiles = []
+
+    def LoadJsonToSampleName(jsonFile, prefix):
+        sampleName = jsonFile if not '/' in jsonFile else jsonFile[jsonFile.rfind('/')+1:]
+        if sampleName.endswith('.json'): sampleName = sampleName[:-5]
+        with open(jsonFile) as jf:
+            samplesdict[sampleName] = json.load(jf)
+            samplesdict[sampleName]['redirector'] = prefix
+
+    if isinstance(jsonFiles, str) and ',' in jsonFiles:
+        jsonFiles = jsonFiles.replace(' ', '').split(',')
+    elif isinstance(jsonFiles, str):
+        jsonFiles = [jsonFiles]
+    for jsonFile in jsonFiles:
+        if os.path.isdir(jsonFile):
+            if not jsonFile.endswith('/'): jsonFile+='/'
+            for f in os.path.listdir(jsonFile):
+                if f.endswith('.json'): allInputFiles.append(jsonFile+f)
+        else:
+            allInputFiles.append(jsonFile)
+
+    # Read from cfg files
+    for f in allInputFiles:
+        if not os.path.isfile(f):
+            raise Exception(f'[ERROR] Input file {f} not found!')
+        # This input file is a json file, not a cfg
+        if f.endswith('.json'): 
+            LoadJsonToSampleName(f, prefix)
+        # Open cfg files
+        else:
+            with open(f) as fin:
+                print(' >> Reading json from cfg file...')
+                lines = fin.readlines()
+                for l in lines:
+                    if '#' in l: l=l[:l.find('#')]
+                    l = l.replace(' ', '').replace('\n', '')
+                    if l == '': continue
+                    if ',' in l:
+                        l = l.split(',')
+                        for nl in l:
+                            if not os.path.isfile(l): prefix = nl
+                            else: LoadJsonToSampleName(nl, prefix)
+                    else:
+                        if not os.path.isfile(l): prefix = l
+                        else: LoadJsonToSampleName(l, prefix)
+
+    flist = {};
+    for sname in samplesdict.keys():
+        redirector = samplesdict[sname]['redirector']
+        flist[sname] = [(redirector+f) for f in samplesdict[sname]['files']]
+        samplesdict[sname]['year'] = samplesdict[sname]['year']
+        samplesdict[sname]['xsec'] = float(samplesdict[sname]['xsec'])
+        samplesdict[sname]['nEvents'] = int(samplesdict[sname]['nEvents'])
+        samplesdict[sname]['nGenEvents'] = int(samplesdict[sname]['nGenEvents'])
+        samplesdict[sname]['nSumOfWeights'] = float(samplesdict[sname]['nSumOfWeights'])
+        if not samplesdict[sname]["isData"]:
+            for wgt_var in WGT_VAR_LST:
+                # Check that MC samples have all needed weight sums (only needed if doing systs)
+                if do_systs:
+                    if (wgt_var not in samplesdict[sname]):
+                        raise Exception(f"Missing weight variation \"{wgt_var}\".")
+                    else:
+                        samplesdict[sname][wgt_var] = float(samplesdict[sname][wgt_var])
+        # Print file info
+        print('>> '+sname)
+        print('   - isData?      : %s'   %('YES' if samplesdict[sname]['isData'] else 'NO'))
+        print('   - year         : %s'   %samplesdict[sname]['year'])
+        print('   - xsec         : %f'   %samplesdict[sname]['xsec'])
+        print('   - histAxisName : %s'   %samplesdict[sname]['histAxisName'])
+        print('   - options      : %s'   %samplesdict[sname]['options'])
+        print('   - tree         : %s'   %samplesdict[sname]['treeName'])
+        print('   - nEvents      : %i'   %samplesdict[sname]['nEvents'])
+        print('   - nGenEvents   : %i'   %samplesdict[sname]['nGenEvents'])
+        print('   - SumWeights   : %f'   %samplesdict[sname]['nSumOfWeights'])
+        if not samplesdict[sname]["isData"]:
+            for wgt_var in WGT_VAR_LST:
+                if wgt_var in samplesdict[sname]:
+                    print(f'   - {wgt_var}: {samplesdict[sname][wgt_var]}')
+        print('   - Prefix       : %s'   %samplesdict[sname]['redirector'])
+        print('   - nFiles       : %i'   %len(samplesdict[sname]['files']))
+        for fname in samplesdict[sname]['files']: print('     %s'%fname)
+
+    if pretend: 
+        print('pretending...')
+        exit() 
+
+    # Extract the list of all WCs, as long as we haven't already specified one.
+    if len(wc_lst) == 0:
+        for k in samplesdict.keys():
+            for wc in samplesdict[k]['WCnames']:
+                if wc not in wc_lst:
+                    wc_lst.append(wc)
+
+    if len(wc_lst) > 0:
+        # Yes, why not have the output be in correct English?
+        if len(wc_lst) == 1:
+            wc_print = wc_lst[0]
+        elif len(wc_lst) == 2:
+            wc_print = wc_lst[0] + ' and ' + wc_lst[1]
+        else:
+            wc_print = ', '.join(wc_lst[:-1]) + ', and ' + wc_lst[-1]
+        print('Wilson Coefficients: {}.'.format(wc_print))
+    else:
+        print('No Wilson coefficients specified')
+
+    processor_instance = topeft.AnalysisProcessor(samplesdict,wc_lst,hist_lst,ecut_threshold,do_errors,do_systs,split_lep_flavor,skip_sr,skip_cr)
+
+    exec_instance = processor.FuturesExecutor(workers=nworkers)
+    runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+
+    # Run the processor and get the output
+    tstart = time.time()
+    output = runner(flist, treename, processor_instance)
+    dt = time.time() - tstart
+
+    nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
+    nfilled = sum(sum(np.sum(arr > 0) for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
+    print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
+    print("Processing time: %1.2f s with %i workers (%.2f s cpu overall)" % (dt, nworkers, dt*nworkers, ))
+
+    # Save the output
+    if not os.path.isdir(outpath): os.system("mkdir -p %s"%outpath)
+    out_pkl_file = os.path.join(outpath,outname+".pkl.gz")
+    print(f"\nSaving output in {out_pkl_file}...")
+    with gzip.open(out_pkl_file, "wb") as fout:
+        cloudpickle.dump(output, fout)
+    print("Done!")
+
+    # Run the data driven estimation, save the output
+    if do_np:
+        print("\nDoing the nonprompt estimation...")
+        out_pkl_file_name_np = os.path.join(outpath,outname+"_np.pkl.gz")
+        ddp = DataDrivenProducer(out_pkl_file,out_pkl_file_name_np)
+        print(f"Saving output in {out_pkl_file_name_np}...")
+        ddp.dumpToPickle()
+        print("Done!")
+        if do_renormfact_envelope:
+            print("\nDoing the renorm. fact. envelope calculation...")
+            dict_of_histos = get_hist_from_pkl(out_pkl_file_name_np,allow_empty=False)
+            dict_of_histos_after_applying_envelope = get_renormfact_envelope(dict_of_histos)
+            dump_to_pkl(out_pkl_file_name_np,dict_of_histos_after_applying_envelope)

--- a/analysis/topEFT/run.py
+++ b/analysis/topEFT/run.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
         hist_lst = ["lj0pt", "ptz", "met", "ljptsum", "l0pt", "l0eta", "l1pt", "l1eta", "j0pt", "j0eta", "njets", "nbtagsl", "invmass"]
     else:
         # We want to specify a custom list
-        # If we don't specify this argument, it will be None, and the processor will fill all hists 
+        # If we don't specify this argument, it will be None, and the processor will fill all hists
         hist_lst = args.hist_list
 
     if dotest:
@@ -136,7 +136,7 @@ if __name__ == '__main__':
         if not os.path.isfile(f):
             raise Exception(f'[ERROR] Input file {f} not found!')
         # This input file is a json file, not a cfg
-        if f.endswith('.json'): 
+        if f.endswith('.json'):
             LoadJsonToSampleName(f, prefix)
         # Open cfg files
         else:
@@ -156,7 +156,7 @@ if __name__ == '__main__':
                         if not os.path.isfile(l): prefix = l
                         else: LoadJsonToSampleName(l, prefix)
 
-    flist = {};
+    flist = {}
     for sname in samplesdict.keys():
         redirector = samplesdict[sname]['redirector']
         flist[sname] = [(redirector+f) for f in samplesdict[sname]['files']]
@@ -192,9 +192,9 @@ if __name__ == '__main__':
         print('   - nFiles       : %i'   %len(samplesdict[sname]['files']))
         for fname in samplesdict[sname]['files']: print('     %s'%fname)
 
-    if pretend: 
+    if pretend:
         print('pretending...')
-        exit() 
+        exit()
 
     # Extract the list of all WCs, as long as we haven't already specified one.
     if len(wc_lst) == 0:

--- a/analysis/topEFT/run_sow.py
+++ b/analysis/topEFT/run_sow.py
@@ -44,7 +44,8 @@ for fn in inputFiles:
     if fn.endswith('.json'):
         sample = os.path.basename(fn).replace('.json','')
         jsn = load_sample_json_file(fn)
-        samples_to_process = update_cfg(jsn,
+        samples_to_process = update_cfg(
+            jsn,
             name=sample,
             cfg=samples_to_process,
             max_files=max_files,

--- a/analysis/topEFT/run_sow.py
+++ b/analysis/topEFT/run_sow.py
@@ -6,7 +6,6 @@ import os
 import argparse
 
 # import uproot
-import numpy as np
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
 import topcoffea.modules.remote_environment as remote_environment

--- a/analysis/topEFT/simple_processor.py
+++ b/analysis/topEFT/simple_processor.py
@@ -28,7 +28,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         self._do_errors = do_errors # Whether to calculate and store the w**2 coefficients
         self._do_systematics = do_systematics # Whether to process systematic samples
-        
+
     @property
     def accumulator(self):
         return self._accumulator

--- a/analysis/topEFT/simple_processor.py
+++ b/analysis/topEFT/simple_processor.py
@@ -1,19 +1,11 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import cloudpickle
-import json
-import pprint
-import coffea
 import numpy as np
 import awkward as ak
 np.seterr(divide='ignore', invalid='ignore', over='ignore')
 from coffea import hist, processor
-from coffea.util import load, save
-from optparse import OptionParser
 from coffea.analysis_tools import PackedSelection
 
 from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import SFevaluator
 from topcoffea.modules.selection import *
 from topcoffea.modules.HistEFT import HistEFT
 import topcoffea.modules.eft_helper as efth
@@ -27,11 +19,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Create the histograms
         # In general, histograms depend on 'sample', 'channel' (final state) and 'cut' (level of selection)
         self._accumulator = processor.dict_accumulator({
-        'counts'  : hist.Hist("Events", hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("counts", "Counts", 1, 0, 2)),
-        'njets'   : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("njets",  "Jet multiplicity ", 12, 0, 12)),
-        'j0pt'    : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("j0pt",   "Leading jet  $p_{T}$ (GeV)", 10, 0, 600)),
-        'j0eta'   : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("j0eta",  "Leading jet  $\eta$", 10, -3.0, 3.0)),
-        'l0pt'    : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("l0pt",   "Leading lep $p_{T}$ (GeV)", 15, 0, 400)),
+            'counts'  : hist.Hist("Events", hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("counts", "Counts", 1, 0, 2)),
+            'njets'   : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("njets",  "Jet multiplicity ", 12, 0, 12)),
+            'j0pt'    : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("j0pt",   "Leading jet  $p_{T}$ (GeV)", 10, 0, 600)),
+            'j0eta'   : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("j0eta",  "Leading jet  $\eta$", 10, -3.0, 3.0)),
+            'l0pt'    : HistEFT("Events", wc_names_lst, hist.Cat("sample", "sample"), hist.Cat("channel", "channel"), hist.Cat("cut", "cut"), hist.Bin("l0pt",   "Leading lep $p_{T}$ (GeV)", 15, 0, 400)),
         })
 
         self._do_errors = do_errors # Whether to calculate and store the w**2 coefficients
@@ -55,8 +47,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         sow    = self._samples[dataset]['nSumOfWeights' ]
         isData = self._samples[dataset]['isData']
         datasets = ['SingleMuon', 'SingleElectron', 'EGamma', 'MuonEG', 'DoubleMuon', 'DoubleElectron']
-        for d in datasets: 
-          if d in dataset: dataset = dataset.split('_')[0] 
+        for d in datasets:
+            if d in dataset: dataset = dataset.split('_')[0] 
 
         # Extract the EFT quadratic coefficients and optionally use them to calculate the coefficients on the w**2 quartic function
         # eft_coeffs is never Jagged so convert immediately to numpy for ease of use.

--- a/analysis/topEFT/simple_processor.py
+++ b/analysis/topEFT/simple_processor.py
@@ -48,7 +48,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         isData = self._samples[dataset]['isData']
         datasets = ['SingleMuon', 'SingleElectron', 'EGamma', 'MuonEG', 'DoubleMuon', 'DoubleElectron']
         for d in datasets:
-            if d in dataset: dataset = dataset.split('_')[0] 
+            if d in dataset: dataset = dataset.split('_')[0]
 
         # Extract the EFT quadratic coefficients and optionally use them to calculate the coefficients on the w**2 quartic function
         # eft_coeffs is never Jagged so convert immediately to numpy for ease of use.
@@ -73,7 +73,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         print("\trun:",run)
         print("\tluminosityBlock:",luminosityBlock)
         print("\tevent:",event)
- 
+
         print("\nLeptons before selection:")
         print("\te pt",e.pt)
         print("\te eta",e.eta)

--- a/analysis/topEFT/sow_processor.py
+++ b/analysis/topEFT/sow_processor.py
@@ -66,7 +66,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 eft_coeffs = efth.remap_coeffs(self._samples[dataset]["WCnames"], self._wc_names_lst, eft_coeffs)
             if self._do_errors:
                 eft_w2_coeffs = efth.calc_w2_coeffs(eft_coeffs,self._dtype)
-    
+
         # Get nominal wgt
         counts = np.ones_like(events['event'])
         wgts = np.ones_like(events['event'])

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -430,7 +430,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                         weights_obj_base_for_kinematic_syst.add(f"btagSF{b_syst}", events.nom, (pDataUp/pMC)/(pData/pMC),(pDataDo/pMC)/(pData/pMC))
 
                 # Trigger SFs
-                GetTriggerSF(year,events,l0,l1)                
+                GetTriggerSF(year,events,l0,l1)
                 weights_obj_base_for_kinematic_syst.add(f"triggerSF_{year}", events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))            # In principle does not have to be in the lep cat loop
 
 

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -695,88 +695,88 @@ class AnalysisProcessor(processor.ProcessorABC):
                     },
                 },
                 "4l" : {
-                        "exactly_2j" : {
-                            "lep_chan_lst" : ["4l"],
-                            "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                            "appl_lst"     : ["isSR_4l"],
-                        },
-                        "exactly_3j" : {
-                            "lep_chan_lst" : ["4l"],
-                            "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                            "appl_lst"     : ["isSR_4l"],
-                        },
-                        "atleast_4j" : {
-                            "lep_chan_lst" : ["4l"],
-                            "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                            "appl_lst"     : ["isSR_4l"],
-                        },
+                    "exactly_2j" : {
+                        "lep_chan_lst" : ["4l"],
+                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                        "appl_lst"     : ["isSR_4l"],
+                    },
+                    "exactly_3j" : {
+                        "lep_chan_lst" : ["4l"],
+                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                        "appl_lst"     : ["isSR_4l"],
+                    },
+                    "atleast_4j" : {
+                        "lep_chan_lst" : ["4l"],
+                        "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                        "appl_lst"     : ["isSR_4l"],
+                    },
                 },
             }
 
             # This dictionary keeps track of which selections go with which CR categories
             cr_cat_dict = {
-              "2l_CRflip" : {
-                  "atmost_3j" : {
-                      "lep_chan_lst" : ["2lss_CRflip"],
-                      "lep_flav_lst" : ["ee"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-              },
-              "2l_CR" : {
-                  "exactly_1j" : {
-                      "lep_chan_lst" : ["2lss_CR"],
-                      "lep_flav_lst" : ["ee" , "em" , "mm"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-                  "exactly_2j" : {
-                      "lep_chan_lst" : ["2lss_CR"],
-                      "lep_flav_lst" : ["ee" , "em" , "mm"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-                  "exactly_3j" : {
-                      "lep_chan_lst" : ["2lss_CR"],
-                      "lep_flav_lst" : ["ee" , "em" , "mm"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-              },
-              "3l_CR" : {
-                  "exactly_0j" : {
-                      "lep_chan_lst" : ["3l_CR"],
-                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                      "appl_lst"     : ["isSR_3l" , "isAR_3l"],
-                  },
-                  "atleast_1j" : {
-                      "lep_chan_lst" : ["3l_CR"],
-                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                      "appl_lst"     : ["isSR_3l" , "isAR_3l"],
-                  },
-              },
-              "2los_CRtt" : {
-                  "exactly_2j"   : {
-                      "lep_chan_lst" : ["2los_CRtt"],
-                      "lep_flav_lst" : ["em"],
-                      "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
-                  },
-              },
-              "2los_CRZ" : {
-                  "atleast_0j"   : {
-                      "lep_chan_lst" : ["2los_CRZ"],
-                      "lep_flav_lst" : ["ee", "mm"],
-                      "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
-                  },
-              },
+                "2l_CRflip" : {
+                    "atmost_3j" : {
+                        "lep_chan_lst" : ["2lss_CRflip"],
+                        "lep_flav_lst" : ["ee"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                },
+                "2l_CR" : {
+                    "exactly_1j" : {
+                        "lep_chan_lst" : ["2lss_CR"],
+                        "lep_flav_lst" : ["ee" , "em" , "mm"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                    "exactly_2j" : {
+                        "lep_chan_lst" : ["2lss_CR"],
+                        "lep_flav_lst" : ["ee" , "em" , "mm"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                    "exactly_3j" : {
+                        "lep_chan_lst" : ["2lss_CR"],
+                        "lep_flav_lst" : ["ee" , "em" , "mm"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                },
+                "3l_CR" : {
+                    "exactly_0j" : {
+                        "lep_chan_lst" : ["3l_CR"],
+                        "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                        "appl_lst"     : ["isSR_3l" , "isAR_3l"],
+                    },
+                    "atleast_1j" : {
+                        "lep_chan_lst" : ["3l_CR"],
+                        "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                        "appl_lst"     : ["isSR_3l" , "isAR_3l"],
+                    },
+                },
+                "2los_CRtt" : {
+                    "exactly_2j"   : {
+                        "lep_chan_lst" : ["2los_CRtt"],
+                        "lep_flav_lst" : ["em"],
+                        "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                    },
+                },
+                "2los_CRZ" : {
+                    "atleast_0j"   : {
+                        "lep_chan_lst" : ["2los_CRZ"],
+                        "lep_flav_lst" : ["ee", "mm"],
+                        "appl_lst"     : ["isSR_2lOS" , "isAR_2lOS"],
+                    },
+                },
             }
 
             # Include SRs and CRs unless we asked to skip them
             cat_dict = {}
             if not self._skip_signal_regions:
-              cat_dict.update(sr_cat_dict)
+                cat_dict.update(sr_cat_dict)
             if not self._skip_control_regions:
-              cat_dict.update(cr_cat_dict)
+                cat_dict.update(cr_cat_dict)
             if (not self._skip_signal_regions and not self._skip_control_regions):
-              for k in sr_cat_dict:
-                  if k in cr_cat_dict:
-                      raise Exception(f"The key {k} is in both CR and SR dictionaries.")
+                for k in sr_cat_dict:
+                    if k in cr_cat_dict:
+                        raise Exception(f"The key {k} is in both CR and SR dictionaries.")
 
 
 

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -1,22 +1,17 @@
 #!/usr/bin/env python
-import lz4.frame as lz4f
-import cloudpickle
-import json
-import pprint
 import copy
 import coffea
 import numpy as np
 import awkward as ak
 np.seterr(divide='ignore', invalid='ignore', over='ignore')
 from coffea import hist, processor
-from coffea.util import load, save
-from optparse import OptionParser
+from coffea.util import load
 from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
 
 from topcoffea.modules.GetValuesFromJsons import get_param
 from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import SFevaluator, GetBTagSF, ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, GetPUSF, ApplyRochesterCorrections, ApplyJetSystematics, AttachPSWeights, AttachPdfWeights, AttachScaleWeights, GetTriggerSF
+from topcoffea.modules.corrections import GetBTagSF, ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, GetPUSF, ApplyRochesterCorrections, ApplyJetSystematics, AttachPSWeights, AttachScaleWeights, GetTriggerSF
 from topcoffea.modules.selection import *
 from topcoffea.modules.HistEFT import HistEFT
 from topcoffea.modules.paths import topcoffea_path
@@ -160,7 +155,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             sow_renormUp       = -1
             sow_renormDown     = -1
             sow_factUp         = -1
-            sow_factDown       = -1        
+            sow_factDown       = -1
             sow_renormfactUp   = -1
             sow_renormfactDown = -1
 

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -147,7 +147,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 sow_factDown       = self._samples[dataset]["nSumOfWeights_factDown"       ]
                 sow_renormfactUp   = self._samples[dataset]["nSumOfWeights_renormfactUp"   ]
                 sow_renormfactDown = self._samples[dataset]["nSumOfWeights_renormfactDown" ]
-        else: 
+        else:
             sow_ISRUp          = -1
             sow_ISRDown        = -1
             sow_FSRUp          = -1
@@ -160,7 +160,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             sow_renormfactDown = -1
 
         datasets = ["SingleMuon", "SingleElectron", "EGamma", "MuonEG", "DoubleMuon", "DoubleElectron", "DoubleEG"]
-        for d in datasets: 
+        for d in datasets:
             if d in dataset: dataset = dataset.split('_')[0]
 
         # Set the sampleType (used for MC matching requirement)
@@ -222,7 +222,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         e["isPres"] = isPresElec(e.pt, e.eta, e.dxy, e.dz, e.miniPFRelIso_all, e.sip3d, getattr(e,"mvaFall17V2noIso_WPL"))
         e["isLooseE"] = isLooseElec(e.miniPFRelIso_all,e.sip3d,e.lostHits)
         e["isFO"] = isFOElec(e.pt, e.conept, e.btagDeepFlavB, e.idEmu, e.convVeto, e.lostHits, e.mvaTTHUL, e.jetRelIso, e.mvaFall17V2noIso_WP90, year)
-        e["isTightLep"] = tightSelElec(e.isFO, e.mvaTTHUL)      
+        e["isTightLep"] = tightSelElec(e.isFO, e.mvaTTHUL)
 
         ################### Muon selection ####################
 
@@ -261,8 +261,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Attach per lepton fake rates
         AttachPerLeptonFR(e_fo, flavor = "Elec", year=year)
         AttachPerLeptonFR(m_fo, flavor = "Muon", year=year)
-        m_fo['convVeto'] = ak.ones_like(m_fo.charge); 
-        m_fo['lostHits'] = ak.zeros_like(m_fo.charge); 
+        m_fo['convVeto'] = ak.ones_like(m_fo.charge)
+        m_fo['lostHits'] = ak.zeros_like(m_fo.charge)
         l_fo = ak.with_name(ak.concatenate([e_fo, m_fo], axis=1), 'PtEtaPhiMCandidate')
         l_fo_conept_sorted = l_fo[ak.argsort(l_fo.conept, axis=-1,ascending=False)]
 
@@ -361,7 +361,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             elif year == "2018":
                 btagwpl = get_param("btag_wp_loose_UL18")
             elif year=="2016":
-                btagwpl = get_param("btag_wp_loose_UL16")          
+                btagwpl = get_param("btag_wp_loose_UL16")
             elif year=="2016APV":
                 btagwpl = get_param("btag_wp_loose_UL16APV")
             else:
@@ -371,7 +371,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             nbtagsl = ak.num(goodJets[isBtagJetsLoose])
 
             # Medium DeepJet WP
-            if year == "2017": 
+            if year == "2017":
                 btagwpm = get_param("btag_wp_medium_UL17")
             elif year == "2018":
                 btagwpm = get_param("btag_wp_medium_UL18")
@@ -409,7 +409,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             if not isData:
 
-                # Btag SF following 1a) in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods    
+                # Btag SF following 1a) in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods
                 isBtagJetsLooseNotMedium = (isBtagJetsLoose & isNotBtagJetsMedium)
                 bJetSF   = [GetBTagSF(goodJets, year, 'LOOSE'),GetBTagSF(goodJets, year, 'MEDIUM')]
                 bJetEff  = [GetBtagEff(goodJets, year, 'loose'),GetBtagEff(goodJets, year, 'medium')]
@@ -426,10 +426,10 @@ class AnalysisProcessor(processor.ProcessorABC):
                         bJetEff_dataUp = [bJetEff[0]*bJetSFUp[0],bJetEff[1]*bJetSFUp[1]]
                         bJetEff_dataDo = [bJetEff[0]*bJetSFDo[0],bJetEff[1]*bJetSFDo[1]]
                         pDataUp = ak.prod(bJetEff_dataUp[1][isBtagJetsMedium], axis=-1) * ak.prod((bJetEff_dataUp[0][isBtagJetsLooseNotMedium] - bJetEff_dataUp[1][isBtagJetsLooseNotMedium]), axis=-1) * ak.prod((1-bJetEff_dataUp[0][isNotBtagJetsLoose]), axis=-1)
-                        pDataDo = ak.prod(bJetEff_dataDo[1][isBtagJetsMedium], axis=-1) * ak.prod((bJetEff_dataDo[0][isBtagJetsLooseNotMedium] - bJetEff_dataDo[1][isBtagJetsLooseNotMedium]), axis=-1) * ak.prod((1-bJetEff_dataDo[0][isNotBtagJetsLoose]), axis=-1)           
+                        pDataDo = ak.prod(bJetEff_dataDo[1][isBtagJetsMedium], axis=-1) * ak.prod((bJetEff_dataDo[0][isBtagJetsLooseNotMedium] - bJetEff_dataDo[1][isBtagJetsLooseNotMedium]), axis=-1) * ak.prod((1-bJetEff_dataDo[0][isNotBtagJetsLoose]), axis=-1)
                         weights_obj_base_for_kinematic_syst.add(f"btagSF{b_syst}", events.nom, (pDataUp/pMC)/(pData/pMC),(pDataDo/pMC)/(pData/pMC))
 
-                # Trigger SFs 
+                # Trigger SFs
                 GetTriggerSF(year,events,l0,l1)                
                 weights_obj_base_for_kinematic_syst.add(f"triggerSF_{year}", events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))            # In principle does not have to be in the lep cat loop
 
@@ -517,7 +517,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # 2lss selection (enriched in 4 top)
             selections.add("2lss_4t_p", (events.is2l & chargel0_p & bmask_atleast1med_atleast2loose & pass_trg & bmask_atleast3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
             selections.add("2lss_4t_m", (events.is2l & chargel0_m & bmask_atleast1med_atleast2loose & pass_trg & bmask_atleast3med))  # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
-		
+
             # 2lss selection for CR
             selections.add("2lss_CR", (events.is2l & (chargel0_p | chargel0_m) & bmask_exactly1med & pass_trg)) # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis
             selections.add("2lss_CRflip", (events.is2l_nozeeveto & events.is_ee & sfasz_2l_mask & pass_trg)) # Note: The ss requirement has NOT yet been made at this point! We take care of it later with the appl axis, also note explicitly include the ee requirement here, so we don't have to rely on running with _split_by_lepton_flavor turned on to enforce this requirement
@@ -564,11 +564,11 @@ class AnalysisProcessor(processor.ProcessorABC):
             selections.add("atmost_3j" , (njets<=3))
 
             # AR/SR categories
-            selections.add("isSR_2lSS",    ( events.is2l_SR) & charge2l_1) 
-            selections.add("isAR_2lSS",    (~events.is2l_SR) & charge2l_1) 
+            selections.add("isSR_2lSS",    ( events.is2l_SR) & charge2l_1)
+            selections.add("isAR_2lSS",    (~events.is2l_SR) & charge2l_1)
             selections.add("isAR_2lSS_OS", ( events.is2l_SR) & charge2l_0) # Sideband for the charge flip
-            selections.add("isSR_2lOS",    ( events.is2l_SR) & charge2l_0) 
-            selections.add("isAR_2lOS",    (~events.is2l_SR) & charge2l_0) 
+            selections.add("isSR_2lOS",    ( events.is2l_SR) & charge2l_0)
+            selections.add("isAR_2lOS",    (~events.is2l_SR) & charge2l_0)
 
             selections.add("isSR_3l",  events.is3l_SR)
             selections.add("isAR_3l", ~events.is3l_SR)
@@ -642,75 +642,75 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # This dictionary keeps track of which selections go with which SR categories
             sr_cat_dict = {
-              "2l" : {
-                  "exactly_4j" : {
-                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                      "lep_flav_lst" : ["ee" , "em" , "mm"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-                  "exactly_5j" : {
-                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                      "lep_flav_lst" : ["ee" , "em" , "mm"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-                  "exactly_6j" : {
-                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                      "lep_flav_lst" : ["ee" , "em" , "mm"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-                  "atleast_7j" : {
-                      "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
-                      "lep_flav_lst" : ["ee" , "em" , "mm"],
-                      "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
-                  },
-              },
-              "3l" : {
-                  "exactly_2j" : {
-                      "lep_chan_lst" : [
-                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                      ],
-                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                  },
-                  "exactly_3j" : {
-                      "lep_chan_lst" : [
-                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                      ],
-                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                  },
-                  "exactly_4j" : {
-                      "lep_chan_lst" : [
-                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                      ],
-                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                  },
-                  "atleast_5j" : {
-                      "lep_chan_lst" : [
-                          "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
-                      ],
-                      "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
-                      "appl_lst"     : ["isSR_3l", "isAR_3l"],
-                  },
-              },
-              "4l" : {
-                      "exactly_2j" : {
-                          "lep_chan_lst" : ["4l"],
-                          "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                          "appl_lst"     : ["isSR_4l"],
-                      },
-                      "exactly_3j" : {
-                          "lep_chan_lst" : ["4l"],
-                          "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                          "appl_lst"     : ["isSR_4l"],
-                      },
-                      "atleast_4j" : {
-                          "lep_chan_lst" : ["4l"],
-                          "lep_flav_lst" : ["llll"], # Not keeping track of these separately
-                          "appl_lst"     : ["isSR_4l"],
-                      },
-              },
+                "2l" : {
+                    "exactly_4j" : {
+                        "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                        "lep_flav_lst" : ["ee" , "em" , "mm"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                    "exactly_5j" : {
+                        "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                        "lep_flav_lst" : ["ee" , "em" , "mm"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                    "exactly_6j" : {
+                        "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                        "lep_flav_lst" : ["ee" , "em" , "mm"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                    "atleast_7j" : {
+                        "lep_chan_lst" : ["2lss_p" , "2lss_m", "2lss_4t_p", "2lss_4t_m"],
+                        "lep_flav_lst" : ["ee" , "em" , "mm"],
+                        "appl_lst"     : ["isSR_2lSS" , "isAR_2lSS"] + (["isAR_2lSS_OS"] if isData else []),
+                    },
+                },
+                "3l" : {
+                    "exactly_2j" : {
+                        "lep_chan_lst" : [
+                            "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                        ],
+                        "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                        "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                    },
+                    "exactly_3j" : {
+                        "lep_chan_lst" : [
+                            "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                        ],
+                        "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                        "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                    },
+                    "exactly_4j" : {
+                        "lep_chan_lst" : [
+                            "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                        ],
+                        "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                        "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                    },
+                    "atleast_5j" : {
+                        "lep_chan_lst" : [
+                            "3l_p_offZ_1b" , "3l_m_offZ_1b" , "3l_p_offZ_2b" , "3l_m_offZ_2b" , "3l_onZ_1b" , "3l_onZ_2b",
+                        ],
+                        "lep_flav_lst" : ["eee" , "eem" , "emm", "mmm"],
+                        "appl_lst"     : ["isSR_3l", "isAR_3l"],
+                    },
+                },
+                "4l" : {
+                        "exactly_2j" : {
+                            "lep_chan_lst" : ["4l"],
+                            "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                            "appl_lst"     : ["isSR_4l"],
+                        },
+                        "exactly_3j" : {
+                            "lep_chan_lst" : ["4l"],
+                            "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                            "appl_lst"     : ["isSR_4l"],
+                        },
+                        "atleast_4j" : {
+                            "lep_chan_lst" : ["4l"],
+                            "lep_flav_lst" : ["llll"], # Not keeping track of these separately
+                            "appl_lst"     : ["isSR_4l"],
+                        },
+                },
             }
 
             # This dictionary keeps track of which selections go with which CR categories

--- a/analysis/topEFT/update_json_sow.py
+++ b/analysis/topEFT/update_json_sow.py
@@ -13,16 +13,16 @@ pjoin = os.path.join
 #   SumOfWeights histograms and then tries to find a matching json file from somewhere in the
 #   'topcoffea/json' directory. If it finds a matching file it replaces the value for the
 #   'nSumOfWeights' key in the file with the one computed from the histogram.
-# 
+#
 #   This is typically a pre-processing step to running the topeft processor so that both the central
 #   and private MC samples can be normalized and treated in the same way. The issue is that when the
 #   JSON files for the EFT samples are initially made, the 'nSumOfWeights' that is computed is not
 #   correct. This means we had to recompute this value to get the correct normaliztion, but only for
 #   the EFT samples! After running this script the EFT sample JSON files will have the correct value
 #   and can be treated the same as the central MC samples.
-# 
+#
 # Usage:
-#   
+#
 # Note:
 #   A current limitation of this script is that if it encounters two JSON files with the exact
 #   same name, but in different sub-directories, then it skips updating that file and instead prints
@@ -97,7 +97,8 @@ def main():
     match_files.extend(['.*\\.json'])                   # Make sure to always only find .json files
     ignore_files.extend(['lumi.json','params.json'])    # These are not sample json files
 
-    json_fpaths = get_files(json_dir,
+    json_fpaths = get_files(
+        json_dir,
         ignore_dirs=ignore_dirs,
         match_files=match_files,
         ignore_files=ignore_files,

--- a/analysis/topEFT/work_queue_run.py
+++ b/analysis/topEFT/work_queue_run.py
@@ -162,7 +162,7 @@ for f in allInputFiles:
                     else:
                         LoadJsonToSampleName(l, prefix)
 
-flist = {};
+flist = {}
 nevts_total = 0
 for sname in samplesdict.keys():
     redirector = samplesdict[sname]['redirector']

--- a/analysis/topEFT/work_queue_run.py
+++ b/analysis/topEFT/work_queue_run.py
@@ -1,24 +1,17 @@
 #!/usr/bin/env python
 
-import lz4.frame as lz4f
-import pickle
 import json
 import time
 import cloudpickle
 import gzip
 import os
-from optparse import OptionParser
 
-import uproot
 import numpy as np
 from coffea import hist, processor
-from coffea.util import load, save
 from coffea.nanoevents import NanoAODSchema
 
 import topeft
 import topcoffea.modules.utils as utils
-from topcoffea.modules import samples
-from topcoffea.modules import fileReader
 from topcoffea.modules.dataDrivenEstimation import DataDrivenProducer
 from topcoffea.modules.get_renormfact_envelope import get_renormfact_envelope
 import topcoffea.modules.remote_environment as remote_environment

--- a/analysis/topEFT/work_queue_run.py
+++ b/analysis/topEFT/work_queue_run.py
@@ -99,123 +99,129 @@ if len(port) == 1:
 
 # Figure out which hists to include
 if args.hist_list == ["ana"]:
-  # Here we hardcode a list of hists used for the analysis
-  hist_lst = ["njets","lj0pt","ptz"]
+    # Here we hardcode a list of hists used for the analysis
+    hist_lst = ["njets","lj0pt","ptz"]
 elif args.hist_list == ["cr"]:
-  # Here we hardcode a list of hists used for the CRs
-  hist_lst = ["lj0pt", "ptz", "met", "ljptsum", "l0pt", "l0eta", "l1pt", "l1eta", "j0pt", "j0eta", "njets", "nbtagsl", "invmass"]
+    # Here we hardcode a list of hists used for the CRs
+    hist_lst = ["lj0pt", "ptz", "met", "ljptsum", "l0pt", "l0eta", "l1pt", "l1eta", "j0pt", "j0eta", "njets", "nbtagsl", "invmass"]
 else:
-  # We want to specify a custom list
-  # If we don't specify this argument, it will be None, and the processor will fill all hists
-  hist_lst = args.hist_list
+    # We want to specify a custom list
+    # If we don't specify this argument, it will be None, and the processor will fill all hists
+    hist_lst = args.hist_list
 
 ### Load samples from json
 samplesdict = {}
 allInputFiles = []
 
 def LoadJsonToSampleName(jsonFile, prefix):
- sampleName = jsonFile if not '/' in jsonFile else jsonFile[jsonFile.rfind('/')+1:]
- if sampleName.endswith('.json'): sampleName = sampleName[:-5]
- with open(jsonFile) as jf:
-   samplesdict[sampleName] = json.load(jf)
-   samplesdict[sampleName]['redirector'] = prefix
+    sampleName = jsonFile if not '/' in jsonFile else jsonFile[jsonFile.rfind('/')+1:]
+    if sampleName.endswith('.json'): sampleName = sampleName[:-5]
+    with open(jsonFile) as jf:
+        samplesdict[sampleName] = json.load(jf)
+        samplesdict[sampleName]['redirector'] = prefix
 
-if   isinstance(jsonFiles, str) and ',' in jsonFiles: jsonFiles = jsonFiles.replace(' ', '').split(',')
-elif isinstance(jsonFiles, str)                     : jsonFiles = [jsonFiles]
+if isinstance(jsonFiles, str) and ',' in jsonFiles:
+    jsonFiles = jsonFiles.replace(' ', '').split(',')
+elif isinstance(jsonFiles, str):
+    jsonFiles = [jsonFiles]
 for jsonFile in jsonFiles:
-  if os.path.isdir(jsonFile):
-    if not jsonFile.endswith('/'): jsonFile+='/'
-    for f in os.path.listdir(jsonFile):
-      if f.endswith('.json'): allInputFiles.append(jsonFile+f)
-  else:
-    allInputFiles.append(jsonFile)
+    if os.path.isdir(jsonFile):
+        if not jsonFile.endswith('/'): jsonFile+='/'
+        for f in os.path.listdir(jsonFile):
+            if f.endswith('.json'): allInputFiles.append(jsonFile+f)
+    else:
+        allInputFiles.append(jsonFile)
 
 # Read from cfg files
 for f in allInputFiles:
-  if not os.path.isfile(f):
-    raise Exception(f'[ERROR] Input file {f} not found!')
-  # This input file is a json file, not a cfg
-  if f.endswith('.json'):
-    LoadJsonToSampleName(f, prefix)
-  # Open cfg files
-  else:
-    with open(f) as fin:
-      print(' >> Reading json from cfg file...')
-      lines = fin.readlines()
-      for l in lines:
-        if '#' in l: l=l[:l.find('#')]
-        l = l.replace(' ', '').replace('\n', '')
-        if l == '': continue
-        if ',' in l:
-          l = l.split(',')
-          for nl in l:
-            if not os.path.isfile(l): prefix = nl
-            else: LoadJsonToSampleName(nl, prefix)
-        else:
-          if not os.path.isfile(l): prefix = l
-          else: LoadJsonToSampleName(l, prefix)
+    if not os.path.isfile(f):
+        raise Exception(f'[ERROR] Input file {f} not found!')
+    # This input file is a json file, not a cfg
+    if f.endswith('.json'):
+        LoadJsonToSampleName(f, prefix)
+    # Open cfg files
+    else:
+        with open(f) as fin:
+            print(' >> Reading json from cfg file...')
+            lines = fin.readlines()
+            for l in lines:
+                if '#' in l:
+                    l=l[:l.find('#')]
+                l = l.replace(' ', '').replace('\n', '')
+                if l == '': continue
+                if ',' in l:
+                    l = l.split(',')
+                    for nl in l:
+                        if not os.path.isfile(l):
+                            prefix = nl
+                        else:
+                            LoadJsonToSampleName(nl, prefix)
+                else:
+                    if not os.path.isfile(l):
+                        prefix = l
+                    else:
+                        LoadJsonToSampleName(l, prefix)
 
 flist = {};
 nevts_total = 0
 for sname in samplesdict.keys():
-  redirector = samplesdict[sname]['redirector']
-  flist[sname] = [(redirector+f) for f in samplesdict[sname]['files']]
-  samplesdict[sname]['year'] = samplesdict[sname]['year']
-  samplesdict[sname]['xsec'] = float(samplesdict[sname]['xsec'])
-  samplesdict[sname]['nEvents'] = int(samplesdict[sname]['nEvents'])
-  nevts_total += samplesdict[sname]['nEvents']
-  samplesdict[sname]['nGenEvents'] = int(samplesdict[sname]['nGenEvents'])
-  samplesdict[sname]['nSumOfWeights'] = float(samplesdict[sname]['nSumOfWeights'])
-  if not samplesdict[sname]["isData"]:
-    for wgt_var in WGT_VAR_LST:
-      # Check that MC samples have all needed weight sums (only needed if doing systs)
-      if do_systs:
-          if (wgt_var not in samplesdict[sname]):
-            raise Exception(f"Missing weight variation \"{wgt_var}\".")
-          else:
-            samplesdict[sname][wgt_var] = float(samplesdict[sname][wgt_var])
-
-  # Print file info
-  print('>> '+sname)
-  print('   - isData?      : %s'   %('YES' if samplesdict[sname]['isData'] else 'NO'))
-  print('   - year         : %s'   %samplesdict[sname]['year'])
-  print('   - xsec         : %f'   %samplesdict[sname]['xsec'])
-  print('   - histAxisName : %s'   %samplesdict[sname]['histAxisName'])
-  print('   - options      : %s'   %samplesdict[sname]['options'])
-  print('   - tree         : %s'   %samplesdict[sname]['treeName'])
-  print('   - nEvents      : %i'   %samplesdict[sname]['nEvents'])
-  print('   - nGenEvents   : %i'   %samplesdict[sname]['nGenEvents'])
-  print('   - SumWeights   : %i'   %samplesdict[sname]['nSumOfWeights'])
-  if not samplesdict[sname]["isData"]:
-    for wgt_var in WGT_VAR_LST:
-      if wgt_var in samplesdict[sname]:
-        print(f'   - {wgt_var}: {samplesdict[sname][wgt_var]}')
-  print('   - Prefix       : %s'   %samplesdict[sname]['redirector'])
-  print('   - nFiles       : %i'   %len(samplesdict[sname]['files']))
-  for fname in samplesdict[sname]['files']: print('     %s'%fname)
+    redirector = samplesdict[sname]['redirector']
+    flist[sname] = [(redirector+f) for f in samplesdict[sname]['files']]
+    samplesdict[sname]['year'] = samplesdict[sname]['year']
+    samplesdict[sname]['xsec'] = float(samplesdict[sname]['xsec'])
+    samplesdict[sname]['nEvents'] = int(samplesdict[sname]['nEvents'])
+    nevts_total += samplesdict[sname]['nEvents']
+    samplesdict[sname]['nGenEvents'] = int(samplesdict[sname]['nGenEvents'])
+    samplesdict[sname]['nSumOfWeights'] = float(samplesdict[sname]['nSumOfWeights'])
+    if not samplesdict[sname]["isData"]:
+        for wgt_var in WGT_VAR_LST:
+            # Check that MC samples have all needed weight sums (only needed if doing systs)
+            if do_systs:
+                if (wgt_var not in samplesdict[sname]):
+                    raise Exception(f"Missing weight variation \"{wgt_var}\".")
+                else:
+                    samplesdict[sname][wgt_var] = float(samplesdict[sname][wgt_var])
+    # Print file info
+    print('>> '+sname)
+    print('   - isData?      : %s'   %('YES' if samplesdict[sname]['isData'] else 'NO'))
+    print('   - year         : %s'   %samplesdict[sname]['year'])
+    print('   - xsec         : %f'   %samplesdict[sname]['xsec'])
+    print('   - histAxisName : %s'   %samplesdict[sname]['histAxisName'])
+    print('   - options      : %s'   %samplesdict[sname]['options'])
+    print('   - tree         : %s'   %samplesdict[sname]['treeName'])
+    print('   - nEvents      : %i'   %samplesdict[sname]['nEvents'])
+    print('   - nGenEvents   : %i'   %samplesdict[sname]['nGenEvents'])
+    print('   - SumWeights   : %i'   %samplesdict[sname]['nSumOfWeights'])
+    if not samplesdict[sname]["isData"]:
+        for wgt_var in WGT_VAR_LST:
+            if wgt_var in samplesdict[sname]:
+                print(f'   - {wgt_var}: {samplesdict[sname][wgt_var]}')
+    print('   - Prefix       : %s'   %samplesdict[sname]['redirector'])
+    print('   - nFiles       : %i'   %len(samplesdict[sname]['files']))
+    for fname in samplesdict[sname]['files']: print('     %s'%fname)
 
 if pretend:
-  print('pretending...')
-  exit()
+    print('pretending...')
+    exit()
 
 # Extract the list of all WCs, as long as we haven't already specified one.
 if len(wc_lst) == 0:
- for k in samplesdict.keys():
-  for wc in samplesdict[k]['WCnames']:
-   if wc not in wc_lst:
-    wc_lst.append(wc)
+    for k in samplesdict.keys():
+        for wc in samplesdict[k]['WCnames']:
+            if wc not in wc_lst:
+                wc_lst.append(wc)
 
 if len(wc_lst) > 0:
- # Yes, why not have the output be in correct English?
- if len(wc_lst) == 1:
-  wc_print = wc_lst[0]
- elif len(wc_lst) == 2:
-  wc_print = wc_lst[0] + ' and ' + wc_lst[1]
- else:
-  wc_print = ', '.join(wc_lst[:-1]) + ', and ' + wc_lst[-1]
-  print('Wilson Coefficients: {}.'.format(wc_print))
+    # Yes, why not have the output be in correct English?
+    if len(wc_lst) == 1:
+        wc_print = wc_lst[0]
+    elif len(wc_lst) == 2:
+        wc_print = wc_lst[0] + ' and ' + wc_lst[1]
+    else:
+        wc_print = ', '.join(wc_lst[:-1]) + ', and ' + wc_lst[-1]
+        print('Wilson Coefficients: {}.'.format(wc_print))
 else:
- print('No Wilson coefficients specified')
+    print('No Wilson coefficients specified')
 
 processor_instance = topeft.AnalysisProcessor(samplesdict,wc_lst,hist_lst,ecut_threshold,do_errors,do_systs,split_lep_flavor,skip_sr,skip_cr)
 
@@ -228,7 +234,7 @@ executor_args = {
     'debug_log': 'debug.log',
     'transactions_log': 'tr.log',
     'stats_log': 'stats.log',
-	'tasks_accum_log': 'tasks.log',
+    'tasks_accum_log': 'tasks.log',
 
     'environment_file': remote_environment.get_environment(),
     'extra_input_files': ["topeft.py"],
@@ -310,20 +316,20 @@ if not os.path.isdir(outpath): os.system("mkdir -p %s"%outpath)
 out_pkl_file = os.path.join(outpath,outname+".pkl.gz")
 print(f"\nSaving output in {out_pkl_file}...")
 with gzip.open(out_pkl_file, "wb") as fout:
-  cloudpickle.dump(output, fout)
+    cloudpickle.dump(output, fout)
 print("Done!")
 
 # Run the data driven estimation, save the output
 if do_np:
-  print("\nDoing the nonprompt estimation...")
-  out_pkl_file_name_np = os.path.join(outpath,outname+"_np.pkl.gz")
-  ddp = DataDrivenProducer(out_pkl_file,out_pkl_file_name_np)
-  print(f"Saving output in {out_pkl_file_name_np}...")
-  ddp.dumpToPickle()
-  print("Done!")
-  # Run the renorm fact envelope calculation
-  if do_renormfact_envelope:
-      print("\nDoing the renorm. fact. envelope calculation...")
-      dict_of_histos = utils.get_hist_from_pkl(out_pkl_file_name_np,allow_empty=False)
-      dict_of_histos_after_applying_envelope = get_renormfact_envelope(dict_of_histos)
-      utils.dump_to_pkl(out_pkl_file_name_np,dict_of_histos_after_applying_envelope)
+    print("\nDoing the nonprompt estimation...")
+    out_pkl_file_name_np = os.path.join(outpath,outname+"_np.pkl.gz")
+    ddp = DataDrivenProducer(out_pkl_file,out_pkl_file_name_np)
+    print(f"Saving output in {out_pkl_file_name_np}...")
+    ddp.dumpToPickle()
+    print("Done!")
+    # Run the renorm fact envelope calculation
+    if do_renormfact_envelope:
+        print("\nDoing the renorm. fact. envelope calculation...")
+        dict_of_histos = utils.get_hist_from_pkl(out_pkl_file_name_np,allow_empty=False)
+        dict_of_histos_after_applying_envelope = get_renormfact_envelope(dict_of_histos)
+        utils.dump_to_pkl(out_pkl_file_name_np,dict_of_histos_after_applying_envelope)

--- a/tests/test_HistEFT_add.py
+++ b/tests/test_HistEFT_add.py
@@ -34,9 +34,12 @@ wc_names_lst = [
     "ctG"
 ]
 
-a = HistEFT("Events", wc_names_lst,
-                   hist.Cat("type", "type"),
-                   hist.Bin("x",  "x", 1, 0, 1))
+a = HistEFT(
+    "Events",
+    wc_names_lst,
+    hist.Cat("type", "type"),
+    hist.Bin("x",  "x", 1, 0, 1)
+)
 # Just need another one where I won't fill the EFT coefficients
 b = a.copy(content=False)
 
@@ -45,11 +48,11 @@ a.fill(type='eft', x=np.full(nevts,0.5), eft_coeff=eft_fit_coeffs)
 b.fill(type='non-eft', x=np.full(nevts,0.5))
 
 def test_scale_a_weights():
-    assert np.all(np.abs(a_w.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(a_w.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
     integral = a_w.integrate('type','eft').values()[()].sum()
     a_w.set_wilson_coeff_from_array(np.ones(a_w._nwc))
     assert a_w.integrate('type','eft').values()[()].sum() != integral
-    assert np.all(np.abs(a_w.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(a_w.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
     ones = dict(zip(wc_names_lst, np.ones(a_w._nwc)))
     a_w.set_wilson_coefficients(**ones)
     assert a_w.integrate('type','eft').values()[()].sum() != integral #FIXME we should compute the actual values
@@ -70,50 +73,50 @@ def test_group():
 
 def test_add_ab_noerrors():
     ab = a + b
-    assert np.all(ab.integrate('type','eft')._sumw[()][1] == sums) 
+    assert np.all(ab.integrate('type','eft')._sumw[()][1] == sums)
     assert ab.integrate('type','eft')._sumw2 is None
-    assert ab.integrate('type','non-eft')._sumw[()][1] == nevts 
+    assert ab.integrate('type','non-eft')._sumw[()][1] == nevts
     assert ab.integrate('type','non-eft')._sumw2 is None
 
 def test_add_ba_noerrors():
     ba = b + a
-    assert np.all(ba.integrate('type','eft')._sumw[()][1] == sums) 
+    assert np.all(ba.integrate('type','eft')._sumw[()][1] == sums)
     assert ba.integrate('type','eft')._sumw2 is None
-    assert ba.integrate('type','non-eft')._sumw[()][1] == nevts 
+    assert ba.integrate('type','non-eft')._sumw[()][1] == nevts
     assert ba.integrate('type','non-eft')._sumw2 is None
 
 def test_add_aba_noerrors():
     ab = a + b
     aba = ab + a
-    assert np.all(aba.integrate('type','eft')._sumw[()][1] == 2*sums) 
+    assert np.all(aba.integrate('type','eft')._sumw[()][1] == 2*sums)
     assert aba.integrate('type','eft')._sumw2 is None
-    assert aba.integrate('type','non-eft')._sumw[()][1] == nevts 
+    assert aba.integrate('type','non-eft')._sumw[()][1] == nevts
     assert aba.integrate('type','non-eft')._sumw2 is None
 
 def test_add_baa_noerrors():
     ba = b + a
     baa = ba + a
-    assert np.all(baa.integrate('type','eft')._sumw[()][1] == 2*sums) 
+    assert np.all(baa.integrate('type','eft')._sumw[()][1] == 2*sums)
     assert baa.integrate('type','eft')._sumw2 is None
-    assert baa.integrate('type','non-eft')._sumw[()][1] == nevts 
+    assert baa.integrate('type','non-eft')._sumw[()][1] == nevts
     assert baa.integrate('type','non-eft')._sumw2 is None
 
 def test_add_abb_noerrors():
     ab = a + b
     abb = ab + b
-    assert np.all(abb.integrate('type','eft')._sumw[()][1] == sums) 
+    assert np.all(abb.integrate('type','eft')._sumw[()][1] == sums)
     assert abb.integrate('type','eft')._sumw2 is None
-    assert abb.integrate('type','non-eft')._sumw[()][1] == 2*nevts 
+    assert abb.integrate('type','non-eft')._sumw[()][1] == 2*nevts
     assert abb.integrate('type','non-eft')._sumw2 is None
 
 def test_add_bab_noerrors():
     ba = b + a
     bab = ba + b
-    assert np.all(bab.integrate('type','eft')._sumw[()][1] == sums) 
+    assert np.all(bab.integrate('type','eft')._sumw[()][1] == sums)
     assert bab.integrate('type','eft')._sumw2 is None
-    assert bab.integrate('type','non-eft')._sumw[()][1] == 2*nevts 
+    assert bab.integrate('type','non-eft')._sumw[()][1] == 2*nevts
     assert bab.integrate('type','non-eft')._sumw2 is None
-    
+
 
 a_w = HistEFT("Events", wc_names_lst,
               hist.Cat("type", "type"),
@@ -128,14 +131,14 @@ b_w.fill(type='non-eft', x=np.full(nevts,0.5), weight=np.full(nevts,weight_val))
 
 def test_add_ab_weights():
     ab = a_w + b_w
-    assert np.all(np.abs(ab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(ab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
     assert ab.integrate('type','eft')._sumw2[()] is None
     assert abs(ab.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(ab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
 
 def test_add_ba_weights():
     ba = b_w + a_w
-    assert np.all(np.abs(ba.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(ba.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
     assert ba.integrate('type','eft')._sumw2[()] is None
     assert abs(ba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(ba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
@@ -143,7 +146,7 @@ def test_add_ba_weights():
 def test_add_aba_weights():
     ab = a_w + b_w
     aba = ab + a_w
-    assert np.all(np.abs(aba.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(aba.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
     assert aba.integrate('type','eft')._sumw2[()] is None
     assert abs(aba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(aba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
@@ -151,7 +154,7 @@ def test_add_aba_weights():
 def test_add_baa_weights():
     ba = b_w + a_w
     baa = ba + a_w
-    assert np.all(np.abs(baa.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(baa.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
     assert baa.integrate('type','eft')._sumw2[()] is None
     assert abs(baa.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(baa.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
@@ -159,7 +162,7 @@ def test_add_baa_weights():
 def test_add_abb_weights():
     ab = a_w + b_w
     abb = ab + b_w
-    assert np.all(np.abs(abb.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(abb.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
     assert abb.integrate('type','eft')._sumw2[()] is None
     assert abs(abb.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
     assert abs(abb.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
@@ -167,7 +170,7 @@ def test_add_abb_weights():
 def test_add_bab_weights():
     ba = b_w + a_w
     bab = ba + b_w
-    assert np.all(np.abs(bab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
+    assert np.all(np.abs(bab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
     assert bab.integrate('type','eft')._sumw2[()] is None
     assert abs(bab.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
     assert abs(bab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
@@ -190,50 +193,50 @@ b_e.fill(type='non-eft', x=np.full(nevts,0.5), weight=np.full(nevts,weight_val))
 
 def test_add_ab_errors():
     ab = a_e + b_e
-    assert np.all(np.abs(ab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
-    assert np.all(np.abs(ab.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10) 
+    assert np.all(np.abs(ab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
+    assert np.all(np.abs(ab.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
     assert abs(ab.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(ab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
 
 def test_add_ba_errors():
     ba = b_e + a_e
-    assert np.all(np.abs(ba.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
-    assert np.all(np.abs(ba.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10) 
+    assert np.all(np.abs(ba.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
+    assert np.all(np.abs(ba.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
     assert abs(ba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(ba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
 
 def test_add_aba_errors():
     ab = a_e + b_e
     aba = ab + a_e
-    assert np.all(np.abs(aba.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10) 
-    assert np.all(np.abs(aba.integrate('type','eft')._sumw2[()][1] - 2*(weight_val**2)*sums_w2) < 1e-10) 
+    assert np.all(np.abs(aba.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
+    assert np.all(np.abs(aba.integrate('type','eft')._sumw2[()][1] - 2*(weight_val**2)*sums_w2) < 1e-10)
     assert abs(aba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(aba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
 
 def test_add_baa_errors():
     ba = b_e + a_e
     baa = ba + a_e
-    assert np.all(np.abs(baa.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10) 
-    assert np.all(np.abs(baa.integrate('type','eft')._sumw2[()][1] - 2*(weight_val**2)*sums_w2) < 1e-10) 
+    assert np.all(np.abs(baa.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
+    assert np.all(np.abs(baa.integrate('type','eft')._sumw2[()][1] - 2*(weight_val**2)*sums_w2) < 1e-10)
     assert abs(baa.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
     assert abs(baa.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
 
 def test_add_abb_errors():
     ab = a_e + b_e
     abb = ab + b_e
-    assert np.all(np.abs(abb.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
-    assert np.all(np.abs(abb.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10) 
+    assert np.all(np.abs(abb.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
+    assert np.all(np.abs(abb.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
     assert abs(abb.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
     assert abs(abb.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
 
 def test_add_bab_errors():
     ba = b_e + a_e
     bab = ba + b_e
-    assert np.all(np.abs(bab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10) 
-    assert np.all(np.abs(bab.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10) 
+    assert np.all(np.abs(bab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
+    assert np.all(np.abs(bab.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
     assert abs(bab.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
     assert abs(bab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
-    
+
 def test_split_by_terms():
     integral = a.sum('type').values()[()].sum()
     c = a.split_by_terms(['x'], 'type')

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -1,8 +1,6 @@
 import subprocess
 import topcoffea.modules.dataDrivenEstimation as dataDrivenEstimation
-from work_queue import Factory
 from os.path import exists
-from os import getcwd
 from topcoffea.modules.comp_datacard import comp_datacard
 
 def test_topcoffea():
@@ -20,14 +18,14 @@ def test_topcoffea():
     # Run TopCoffea
     subprocess.run(args)
 
-    assert(exists('analysis/topEFT/histos/output_check_yields.pkl.gz'))
+    assert (exists('analysis/topEFT/histos/output_check_yields.pkl.gz'))
 
 
 def test_nonprompt():
     a=dataDrivenEstimation.DataDrivenProducer('analysis/topEFT/histos/output_check_yields.pkl.gz', 'analysis/topEFT/histos/output_check_yields_nonprompt')
     a.dumpToPickle() # Do we want to write this file when testing in CI? Maybe if we ever save the CI artifacts
 
-    assert(exists('analysis/topEFT/histos/output_check_yields_nonprompt.pkl.gz'))
+    assert (exists('analysis/topEFT/histos/output_check_yields_nonprompt.pkl.gz'))
 
 def test_datacardmaker():
     args = [
@@ -48,4 +46,4 @@ def test_datacardmaker():
     # Run datacard maker
     subprocess.run(args)
 
-    assert(comp_datacard('histos/ttx_multileptons-2lss_p_4j_lj0pt.txt','analysis/topEFT/test/ttx_multileptons-2lss_p_4j_lj0pt.txt'))
+    assert (comp_datacard('histos/ttx_multileptons-2lss_p_4j_lj0pt.txt','analysis/topEFT/test/ttx_multileptons-2lss_p_4j_lj0pt.txt'))

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -128,7 +128,7 @@ def test_stats():
         1.15, # (00)
         1.35,1.25, # (10) (11)
         0.25,0.75,1.00, # (20) (21) (22)
-        ]
+    ]
     # Make sure there are enough pts to fully determine the fit!
     pts = [
         [x0,-1.00, 0.00],
@@ -413,7 +413,7 @@ def test_histeft():
     chk_y = s00*1.0 + s10*chk_x + s11*chk_x*chk_x
     chk_vals = {wc_name:chk_x, 'ctZ':0.0}
     chk_pt.SetStrength(wc_name,chk_x)
-    
+
     h_new.set_wilson_coefficients(**chk_vals)
 
     # First check that h_new has the right value

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -431,7 +431,7 @@ def test_histeft():
     print('GetBinContent: ', result)
     print('test: ', chk_str)
     print('--------------\n')
-    
+
     chk_x = 0.75    # Needs to be w/e chk_x was before UNIT 6
     chk_y = s00*1.0 + s10*chk_x + s11*chk_x*chk_x
     chk_vals = {wc_name:chk_x, 'ctZ':0.0}

--- a/tests/test_update_json.py
+++ b/tests/test_update_json.py
@@ -16,7 +16,7 @@ def test_update_json():
     # Check to make sure that dry_run doesn't actually generate a file
     update_json(src_fname,dry_run=True,outname=dst_fname,verbose=True)
 
-    assert(not os.path.exists(dst_fname))
+    assert (not os.path.exists(dst_fname))
 
     # No updates, should just create a copy
     update_json(src_fname,outname=dst_fname,verbose=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import os
-import subprocess
+#import subprocess
 
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.utils import get_files

--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -1,7 +1,6 @@
 import subprocess
 from work_queue import Factory
 from os.path import exists
-from os import getcwd
 
 
 def test_topcoffea_wq():
@@ -36,4 +35,4 @@ def test_topcoffea_wq():
     with factory:
         subprocess.run(args, cwd="analysis/topEFT", timeout=400)
 
-    assert(exists('analysis/topEFT/histos/output_check_yields_wq.pkl.gz'))
+    assert (exists('analysis/topEFT/histos/output_check_yields_wq.pkl.gz'))

--- a/tests/test_yields.py
+++ b/tests/test_yields.py
@@ -1,9 +1,8 @@
 import subprocess
 from os.path import exists
-from os import getcwd
 
 def test_make_yields_after_processor():
-    assert(exists('analysis/topEFT/histos/output_check_yields.pkl.gz')) # Make sure the input pkl file exists
+    assert (exists('analysis/topEFT/histos/output_check_yields.pkl.gz')) # Make sure the input pkl file exists
 
     args = [
         "python",
@@ -16,7 +15,7 @@ def test_make_yields_after_processor():
 
     # Produce json
     subprocess.run(args)
-    assert(exists('analysis/topEFT/output_check_yields.json'))
+    assert (exists('analysis/topEFT/output_check_yields.json'))
 
 def test_compare_yields_after_processor():
     args = [
@@ -32,4 +31,4 @@ def test_compare_yields_after_processor():
 
     # Run comparison
     out = subprocess.run(args, stdout=True)
-    assert(out.returncode == 0) # Returns 0 if all pass
+    assert (out.returncode == 0) # Returns 0 if all pass

--- a/topcoffea/modules/DASsearch.py
+++ b/topcoffea/modules/DASsearch.py
@@ -85,7 +85,7 @@ def CheckDatasets(datasets):
     #   - flake8 says "GetDasGoClientCommand" is not defined, so this function is probably not usable
     #   - Based on a search of the repo, it seems topcoffea does not try to ever use this function
     #   - So probably we could remove the function, but in case someone wants to use it again, will leave a comment and exit
-    print("Note from Mar 25, 2023: flake8 says "GetDasGoClientCommand" is not defined, so commenting this function. So if you want to use this function, you will need to fix it first. Good luck. Exiting.")
+    print("Note from Mar 25, 2023: flake8 says \"GetDasGoClientCommand\" is not defined, so commenting this function. So if you want to use this function, you will need to fix it first. Good luck. Exiting.")
     exit()
 
     #command = GetDasGoClientCommand('')

--- a/topcoffea/modules/DASsearch.py
+++ b/topcoffea/modules/DASsearch.py
@@ -7,10 +7,12 @@
 # To get a dict with all the needed info to run:
 #  Get full dataset, all files: GetDatasetFromDAS(dataset, withRedirector='root://cms-xrd-global.cern.ch/')
 #  Get full dataset, n files  : GetDatasetFromDAS(dataset, nFiles, withRedirector='root://cms-xrd-global.cern.ch/')
-#  Get info for just n files  : GetDatasetFromDAS(dataset, nFiles, options='file', withRedirector='root://cms-xrd-global.cern.ch/') 
+#  Get info for just n files  : GetDatasetFromDAS(dataset, nFiles, options='file', withRedirector='root://cms-xrd-global.cern.ch/')
 #
 
-import os, sys, subprocess
+import os
+import sys
+import subprocess
 
 das_env = None
 das_OK = False
@@ -23,7 +25,7 @@ def CheckDasEnv():
         # If this didn't raise an exception, we're good!
         das_OK = True
         return
-    except:
+    except BaseException: # Flake8 says not to use bare exception, and that a bare exception is equivalent to "except BaseException" so replacing the bare exeption with that here (though it's possible that the original author's intention of the code was closer to "except Exception"?)
         # dasgoclient's not in the path.  Can we guess where it is?
         if os.path.isfile('/cvmfs/cms.cern.ch/common/dasgoclient'):
             # Found it!  I'm just adding this to the path because it's the only command we're calling.
@@ -47,7 +49,7 @@ def RunDasGoClientCommand(dataset, mode='dataset', do_json=False):
             print('stdout:\n{}'.format(e.stdout))
             print('stderr:\n{}'.format(e.stderr))
             raise
-        except:
+        except BaseException: # Flake8 says not to use bare exception, and that a bare exception is equivalent to "except BaseException" so replacing the bare exeption with that here (though it's possible that the original author's intention of the code was closer to "except Exception"?)
             print('Problem trying to use dasgoclient',file=sys.stderr)
             raise
 
@@ -78,12 +80,20 @@ def GetEvDic(l):
 
 def CheckDatasets(datasets):
     ''' Check that a dataset exist and is accesible '''
-    command = GetDasGoClientCommand('')
-    for d in datasets:
-        match = os.popen(command%d).read()
-        match = match.replace('\n', '')
-        warn = '\033[0;32mOK       \033[0m' if match == d else '\033[0;31mNOT FOUND\033[0m'
-        print('[%s] %s'%(warn, d))
+
+    # Note from Mar 25, 2023: 
+    #   - flake8 says "GetDasGoClientCommand" is not defined, so this function is probably not usable
+    #   - Based on a search of the repo, it seems topcoffea does not try to ever use this function
+    #   - So probably we could remove the function, but in case someone wants to use it again, will leave a comment and exit
+    print("Note from Mar 25, 2023: flake8 says "GetDasGoClientCommand" is not defined, so commenting this function. So if you want to use this function, you will need to fix it first. Good luck. Exiting.")
+    exit()
+
+    #command = GetDasGoClientCommand('')
+    #for d in datasets:
+    #    match = os.popen(command%d).read()
+    #    match = match.replace('\n', '')
+    #    warn = '\033[0;32mOK       \033[0m' if match == d else '\033[0;31mNOT FOUND\033[0m'
+    #    print('[%s] %s'%(warn, d))
 
 def GetFilesFromDatasets(datasets, nFiles=None, withRedirector='', verbose=False):
     ''' Get all the rootfiles associated to a dataset '''

--- a/topcoffea/modules/DASsearch.py
+++ b/topcoffea/modules/DASsearch.py
@@ -16,189 +16,184 @@ das_env = None
 das_OK = False
 
 def CheckDasEnv():
-  """Checks whether we have an environment we can use for DAS."""
-  # First just check to see whether the dasgoclient is in the path
-  try:
-    res = subprocess.run('which dasgoclient',shell=True,capture_output=True,check=True)
-    # If this didn't raise an exception, we're good!
-    das_OK = True
-    return
-  except:
-    # dasgoclient's not in the path.  Can we guess where it is?
-    if os.path.isfile('/cvmfs/cms.cern.ch/common/dasgoclient'):
-      # Found it!  I'm just adding this to the path because it's the only command we're calling.
-      das_env = {'PATH':'/cvmfs/cms.cern.ch/common'}
-      das_OK = True
-      return
-
-  # If we get here, we can't use DAS in this environment.  Better get the user's attention
-  raise RuntimeError('Not able to use DAS in this environment.  Check that DAS is available in the path or CVMFS.')
-  
-  
-def RunDasGoClientCommand(dataset, mode='dataset', do_json=False):
-
-  if not das_OK:
-    CheckDasEnv()
-
-    command = 'dasgoclient --query="{} dataset={}"'.format(mode,dataset)
-    if do_json:
-      command += ' -json'
-
+    """Checks whether we have an environment we can use for DAS."""
+    # First just check to see whether the dasgoclient is in the path
     try:
-      res = subprocess.run(command, shell=True, capture_output=True, check=True, text=True)
-      return res.stdout
-    except subprocess.CalledProcessError as e:
-      print('Non-Zero exit code from dasasgoclient',file=sys.stderr)
-      print('stdout:\n{}'.format(e.stdout))
-      print('stderr:\n{}'.format(e.stderr))
-      raise
+        res = subprocess.run('which dasgoclient',shell=True,capture_output=True,check=True)
+        # If this didn't raise an exception, we're good!
+        das_OK = True
+        return
     except:
-      print('Problem trying to use dasgoclient',file=sys.stderr)
-      raise
-    
+        # dasgoclient's not in the path.  Can we guess where it is?
+        if os.path.isfile('/cvmfs/cms.cern.ch/common/dasgoclient'):
+            # Found it!  I'm just adding this to the path because it's the only command we're calling.
+            das_env = {'PATH':'/cvmfs/cms.cern.ch/common'}
+            das_OK = True
+            return
+    # If we get here, we can't use DAS in this environment.  Better get the user's attention
+    raise RuntimeError('Not able to use DAS in this environment.  Check that DAS is available in the path or CVMFS.')
+
+def RunDasGoClientCommand(dataset, mode='dataset', do_json=False):
+    if not das_OK:
+        CheckDasEnv()
+        command = 'dasgoclient --query="{} dataset={}"'.format(mode,dataset)
+        if do_json:
+            command += ' -json'
+        try:
+            res = subprocess.run(command, shell=True, capture_output=True, check=True, text=True)
+            return res.stdout
+        except subprocess.CalledProcessError as e:
+            print('Non-Zero exit code from dasasgoclient',file=sys.stderr)
+            print('stdout:\n{}'.format(e.stdout))
+            print('stderr:\n{}'.format(e.stderr))
+            raise
+        except:
+            print('Problem trying to use dasgoclient',file=sys.stderr)
+            raise
 
 def ReadDatasetsFromFile(fname):
-  ''' Read datasets from a file with dataset names '''
-  datasets = []
-  if os.path.isfile(fname):
-    f = open(fname)
-    print('Opening file: %s'%fname)
-    for l in f.readlines():
-      if l.startswith('#'): continue
-      if '#' in l: l = l.split('#')[0]
-      l = l.replace(' ', '').replace('\n', '')
-      if l == '': continue
-      datasets.append(l)
-  else: datasets = [fname]
-  return datasets
+    ''' Read datasets from a file with dataset names '''
+    datasets = []
+    if os.path.isfile(fname):
+        f = open(fname)
+        print('Opening file: %s'%fname)
+        for l in f.readlines():
+            if l.startswith('#'): continue
+            if '#' in l:
+                l = l.split('#')[0]
+            l = l.replace(' ', '').replace('\n', '')
+            if l == '': continue
+            datasets.append(l)
+    else:
+        datasets = [fname]
+    return datasets
 
 def GetEvDic(l):
-  ''' Search for some values when using the -json options in dasgoclient '''
-  for d2 in l:
-    for d in d2['dataset']:
-      if 'nevents' in d.keys():
-        return d
-  return {}
-
+    ''' Search for some values when using the -json options in dasgoclient '''
+    for d2 in l:
+        for d in d2['dataset']:
+            if 'nevents' in d.keys():
+                return d
+    return {}
 
 def CheckDatasets(datasets):
-  ''' Check that a dataset exist and is accesible '''
-  command = GetDasGoClientCommand('')
-  for d in datasets:
-    match = os.popen(command%d).read()
-    match = match.replace('\n', '')
-    warn = '\033[0;32mOK       \033[0m' if match == d else '\033[0;31mNOT FOUND\033[0m'
-    print('[%s] %s'%(warn, d))
+    ''' Check that a dataset exist and is accesible '''
+    command = GetDasGoClientCommand('')
+    for d in datasets:
+        match = os.popen(command%d).read()
+        match = match.replace('\n', '')
+        warn = '\033[0;32mOK       \033[0m' if match == d else '\033[0;31mNOT FOUND\033[0m'
+        print('[%s] %s'%(warn, d))
 
 def GetFilesFromDatasets(datasets, nFiles=None, withRedirector='', verbose=False):
-  ''' Get all the rootfiles associated to a dataset '''
-  if isinstance(datasets, list) and len(datasets) == 1: datasets = datasets[0]
-  if isinstance(datasets, list):
-    files = {}
-    for d in datasets: files[d] = GetFilesFromDatasets(d)
-    return files
-  else:
-    match = RunDasGoClientCommand(datasets,mode='file')
-    if match.endswith('\n'): match=match[:-1]
-    match = match.replace(' ', '').split('\n')
-    if withRedirector != '':
-      #redirect = 'root://cms-xrd-global.cern.ch/' 
-      match = [withRedirector+s for s in match]
-    if verbose:
-      for d in match: print(d)
-    if not nFiles is None: return match[:nFiles]
-    return match
+    ''' Get all the rootfiles associated to a dataset '''
+    if isinstance(datasets, list) and len(datasets) == 1: datasets = datasets[0]
+    if isinstance(datasets, list):
+        files = {}
+        for d in datasets: files[d] = GetFilesFromDatasets(d)
+        return files
+    else:
+        match = RunDasGoClientCommand(datasets,mode='file')
+        if match.endswith('\n'): match=match[:-1]
+        match = match.replace(' ', '').split('\n')
+        if withRedirector != '':
+            #redirect = 'root://cms-xrd-global.cern.ch/' 
+            match = [withRedirector+s for s in match]
+        if verbose:
+            for d in match: print(d)
+        if not nFiles is None: return match[:nFiles]
+        return match
 
 def GetDatasetNumbers(dataset, options='', verbose=0):
-  ''' Get some info of a full dataset using dasgoclient -json '''
-  dic = {'events' : 0, 'nfiles' : 0, 'size' : 0}
-  if not isinstance(dataset, list): dataset=[dataset]
-  for d in dataset:
-    match = RunDasGoClientCommand(d, do_json=True)
-    match = match.replace('\n', '').replace('null', '""')
-    l = eval(match)
-    fdic = GetEvDic(l)
-    if fdic == {}:
-      print('\nWARNING: not found categories of dataset ', d)
-      return dic
-    dic['events'] += fdic['nevents']
-    dic['nfiles'] += fdic['nfiles']
-    dic['size'  ] += fdic['size']
-    size    = fdic['size']/1e6
-  if   options.lower() in ['events', 'evt', 'event', 'nevents', 'nevent']:
-    if verbose: print('Events = ', dic['events'])
-    return dic['events']
-  elif options.lower() in ['nfiles']:
-    if verbose: print('Number of files = ', dic['nfiles'])
-    return dic['nfiles']
-  elif options.lower() in ['size', 'store', 'storage']:
-    if verbose: print('Size = ', dic['size'])
-    return dic['size']
-  else:
-    if verbose: print('nevets = %i, nfiles = %i, size = %1.2f MB'%(dic['events'], dic['nfiles'], dic['size']))
-    return dic
+    ''' Get some info of a full dataset using dasgoclient -json '''
+    dic = {'events': 0, 'nfiles': 0, 'size': 0}
+    if not isinstance(dataset, list): dataset=[dataset]
+    for d in dataset:
+        match = RunDasGoClientCommand(d, do_json=True)
+        match = match.replace('\n', '').replace('null', '""')
+        l = eval(match)
+        fdic = GetEvDic(l)
+        if fdic == {}:
+            print('\nWARNING: not found categories of dataset ', d)
+            return dic
+        dic['events'] += fdic['nevents']
+        dic['nfiles'] += fdic['nfiles']
+        dic['size'  ] += fdic['size']
+        size = fdic['size']/1e6
+    if options.lower() in ['events', 'evt', 'event', 'nevents', 'nevent']:
+        if verbose: print('Events = ', dic['events'])
+        return dic['events']
+    elif options.lower() in ['nfiles']:
+        if verbose: print('Number of files = ', dic['nfiles'])
+        return dic['nfiles']
+    elif options.lower() in ['size', 'store', 'storage']:
+        if verbose: print('Size = ', dic['size'])
+        return dic['size']
+    else:
+        if verbose: print('nevets = %i, nfiles = %i, size = %1.2f MB'%(dic['events'], dic['nfiles'], dic['size']))
+        return dic
 
 def GetFilesInDataset(dataset, nFiles=1, withRedirector='', verbose=0):
-  ''' Get some info of nFiles in a dataset using dasgoclient -json '''
-  dic = {'events' : 0, 'nfiles' : 0, 'size' : 0, 'files' : []}
-  if not isinstance(dataset, list): dataset=[dataset]
-  for d in dataset:
-    match = RunDasGoClientCommand(d,mode='file',do_json=True)
-    match = match.replace('\n', '').replace('null', '""')
-    l = eval(match)
-    nf = 0
-    for f in l:
-      nf += 1
-      fdic = f['file'][0]
-      dic['events'] += fdic['nevents']
-      dic['files']  += [(withRedirector) + fdic['name']]
-      dic['size'  ] += fdic['size']
-      if nf == nFiles: break
-    dic['nfiles'] = len(dic['files'])
-    return dic
+    ''' Get some info of nFiles in a dataset using dasgoclient -json '''
+    dic = {'events': 0, 'nfiles': 0, 'size': 0, 'files': []}
+    if not isinstance(dataset, list):
+        dataset = [dataset]
+    for d in dataset:
+        match = RunDasGoClientCommand(d,mode='file',do_json=True)
+        match = match.replace('\n', '').replace('null', '""')
+        l = eval(match)
+        nf = 0
+        for f in l:
+            nf += 1
+            fdic = f['file'][0]
+            dic['events'] += fdic['nevents']
+            dic['files']  += [(withRedirector) + fdic['name']]
+            dic['size'  ] += fdic['size']
+            if nf == nFiles: break
+        dic['nfiles'] = len(dic['files'])
+        return dic
 
 def GetDatasetFromDAS(dataset, nFiles=None, options='', withRedirector='', includeRedirector=True, verbose=0):
-  ''' Get full dataset, all files: GetDatasetFromDAS(dataset, withRedirector='root://cms-xrd-global.cern.ch/')    
-      Get full dataset, n files  : GetDatasetFromDAS(dataset, nFiles, withRedirector='root://cms-xrd-global.cern.ch/')    
-      Get info for just n files  : GetDatasetFromDAS(dataset, nFiles, options='file', withRedirector='root://cms-xrd-global.cern.ch/') '''
-  if not 'file' in options.lower():
-    # Check event numbers for nFiles
-    dic = GetDatasetNumbers(dataset, withRedirector=withRedirector, verbose=verbose)
-    files = GetFilesFromDatasets(dataset, nFiles, withRedirector=withRedirector, verbose=verbose)
-    dic['files'] = files
-  else:
-    # Check event numbers for the full dataset
-    dic = GetFilesInDataset(dataset, nFiles, withRedirector, verbose)
-  print(dic['files'])
-  #if not includeRedirector: dic['files'] = [f[len(withRedirector):] ] dic['files']
-  
-  return dic
-
-
+    ''' Get full dataset, all files: GetDatasetFromDAS(dataset, withRedirector='root://cms-xrd-global.cern.ch/')    
+        Get full dataset, n files  : GetDatasetFromDAS(dataset, nFiles, withRedirector='root://cms-xrd-global.cern.ch/')    
+        Get info for just n files  : GetDatasetFromDAS(dataset, nFiles, options='file', withRedirector='root://cms-xrd-global.cern.ch/') '''
+    if not 'file' in options.lower():
+        # Check event numbers for nFiles
+        dic = GetDatasetNumbers(dataset, withRedirector=withRedirector, verbose=verbose)
+        files = GetFilesFromDatasets(dataset, nFiles, withRedirector=withRedirector, verbose=verbose)
+        dic['files'] = files
+    else:
+        # Check event numbers for the full dataset
+        dic = GetFilesInDataset(dataset, nFiles, withRedirector, verbose)
+    print(dic['files'])
+    #if not includeRedirector: dic['files'] = [f[len(withRedirector):] ] dic['files']
+    return dic
 
 def main():
-  ''' Executing from terminal, obtain info for some datasets '''
-  import argparse
-  parser = argparse.ArgumentParser(description='Look for datasets using dasgoclient')
-  parser.add_argument('--verbose','-v'    , default=0, help = 'Activate the verbosing')
-  parser.add_argument('--pretend','-p'    , action='store_true'  , help = 'Do pretend')
-  parser.add_argument('--test','-t'       , action='store_true'  , help = 'Do test')
-  parser.add_argument('--options','-o'    , default=''           , help = 'Options to pass to your producer')
-  parser.add_argument('dataset'           , default=''           , nargs='?', help = 'txt file with datasets or dataset name')
+    ''' Executing from terminal, obtain info for some datasets '''
+    import argparse
+    parser = argparse.ArgumentParser(description='Look for datasets using dasgoclient')
+    parser.add_argument('--verbose','-v'    , default=0, help = 'Activate the verbosing')
+    parser.add_argument('--pretend','-p'    , action='store_true'  , help = 'Do pretend')
+    parser.add_argument('--test','-t'       , action='store_true'  , help = 'Do test')
+    parser.add_argument('--options','-o'    , default=''           , help = 'Options to pass to your producer')
+    parser.add_argument('dataset'           , default=''           , nargs='?', help = 'txt file with datasets or dataset name')
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  verbose     = args.verbose
-  doPretend   = args.pretend
-  dotest      = args.test
-  dataset     = args.dataset
-  options     = args.options
+    verbose     = args.verbose
+    doPretend   = args.pretend
+    dotest      = args.test
+    dataset     = args.dataset
+    options     = args.options
 
-  CheckDasEnv()
-  datasets = ReadDatasetsFromFile(dataset)
-  #if   options == '': CheckDatasets(datasets)
-  if options in ['file', 'files']: GetFilesFromDatasets(datasets, verbose=True)
-  else : GetDatasetNumbers(datasets, options, verbose=True)
+    CheckDasEnv()
+    datasets = ReadDatasetsFromFile(dataset)
+    #if options == '': CheckDatasets(datasets)
+    if options in ['file', 'files']:
+        GetFilesFromDatasets(datasets, verbose=True)
+    else:
+        GetDatasetNumbers(datasets, options, verbose=True)
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/topcoffea/modules/DASsearch.py
+++ b/topcoffea/modules/DASsearch.py
@@ -5,8 +5,8 @@
 # python CheckDatasets.py /TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM -o nevents
 #
 # To get a dict with all the needed info to run:
-#  Get full dataset, all files: GetDatasetFromDAS(dataset, withRedirector='root://cms-xrd-global.cern.ch/')    
-#  Get full dataset, n files  : GetDatasetFromDAS(dataset, nFiles, withRedirector='root://cms-xrd-global.cern.ch/')    
+#  Get full dataset, all files: GetDatasetFromDAS(dataset, withRedirector='root://cms-xrd-global.cern.ch/')
+#  Get full dataset, n files  : GetDatasetFromDAS(dataset, nFiles, withRedirector='root://cms-xrd-global.cern.ch/')
 #  Get info for just n files  : GetDatasetFromDAS(dataset, nFiles, options='file', withRedirector='root://cms-xrd-global.cern.ch/') 
 #
 
@@ -97,7 +97,7 @@ def GetFilesFromDatasets(datasets, nFiles=None, withRedirector='', verbose=False
         if match.endswith('\n'): match=match[:-1]
         match = match.replace(' ', '').split('\n')
         if withRedirector != '':
-            #redirect = 'root://cms-xrd-global.cern.ch/' 
+            #redirect = 'root://cms-xrd-global.cern.ch/'
             match = [withRedirector+s for s in match]
         if verbose:
             for d in match: print(d)
@@ -154,8 +154,8 @@ def GetFilesInDataset(dataset, nFiles=1, withRedirector='', verbose=0):
         return dic
 
 def GetDatasetFromDAS(dataset, nFiles=None, options='', withRedirector='', includeRedirector=True, verbose=0):
-    ''' Get full dataset, all files: GetDatasetFromDAS(dataset, withRedirector='root://cms-xrd-global.cern.ch/')    
-        Get full dataset, n files  : GetDatasetFromDAS(dataset, nFiles, withRedirector='root://cms-xrd-global.cern.ch/')    
+    ''' Get full dataset, all files: GetDatasetFromDAS(dataset, withRedirector='root://cms-xrd-global.cern.ch/')
+        Get full dataset, n files  : GetDatasetFromDAS(dataset, nFiles, withRedirector='root://cms-xrd-global.cern.ch/')
         Get info for just n files  : GetDatasetFromDAS(dataset, nFiles, options='file', withRedirector='root://cms-xrd-global.cern.ch/') '''
     if not 'file' in options.lower():
         # Check event numbers for nFiles

--- a/topcoffea/modules/DASsearch.py
+++ b/topcoffea/modules/DASsearch.py
@@ -81,7 +81,7 @@ def GetEvDic(l):
 def CheckDatasets(datasets):
     ''' Check that a dataset exist and is accesible '''
 
-    # Note from Mar 25, 2023: 
+    # Note from Mar 25, 2023:
     #   - flake8 says "GetDasGoClientCommand" is not defined, so this function is probably not usable
     #   - Based on a search of the repo, it seems topcoffea does not try to ever use this function
     #   - So probably we could remove the function, but in case someone wants to use it again, will leave a comment and exit

--- a/topcoffea/modules/GetValuesFromJsons.py
+++ b/topcoffea/modules/GetValuesFromJsons.py
@@ -5,8 +5,8 @@ from topcoffea.modules.paths import topcoffea_path
 def get_lumi(year):
     lumi_json = topcoffea_path("json/lumi.json")
     with open(lumi_json) as f_lumi:
-       lumi = json.load(f_lumi)
-       lumi = lumi[year]
+        lumi = json.load(f_lumi)
+        lumi = lumi[year]
     return lumi
 
 
@@ -14,8 +14,8 @@ def get_lumi(year):
 def get_param(param_name):
     param_json = topcoffea_path("json/params.json")
     with open(param_json) as f_params:
-       params = json.load(f_params)
-       param_val = params[param_name]
+        params = json.load(f_params)
+        param_val = params[param_name]
     return param_val
 
 
@@ -81,4 +81,4 @@ def get_jet_dependent_syst_dict(process="Diboson"):
     syst_json = topcoffea_path("json/rate_systs.json")
     with open(syst_json) as f_systs:
         diboson_njets_dict = json.load(f_systs)["diboson_njets"]
-        return(diboson_njets_dict[process])
+        return (diboson_njets_dict[process])

--- a/topcoffea/modules/HTMLGenerator.py
+++ b/topcoffea/modules/HTMLGenerator.py
@@ -36,7 +36,7 @@ class BaseHTMLTag:
         for k,v in kwargs.items():
             # Skip already defined attributes
             if k in self.CLASS_TRANSLATION: k = 'class'
-            if self.hasAttribute(k): continue 
+            if self.hasAttribute(k): continue
             self.tag_attributes[k] = v
 
     # Modify existing attributes (if found)
@@ -163,7 +163,7 @@ class BaseHTMLTag:
                     string += tag_opt[0] + "=%d" % tag_opt[1]
                 else:
                     string += tag_opt[0] + "=\"%s\"" % tag_opt[1]
-        
+
         if self.getContent() == "" and len(self.nested_tags) == 0:
             # Format an empty tag
             string += "/>"
@@ -575,19 +575,6 @@ class HTMLGenerator:
         body_tag = self.getBodyTag()
         body_tag.addTag(new_tag)
 
-    # Adds a link tag to the head section of the html file
-    # TODO: Should probably remove this, since it can be done using the addHeadTag() method instead
-    def addLinkTag(self,_rel,_type,_href,opts={}):
-        link_tag = LinkTag()
-        link_tag.addAttributes(rel=_rel,type=_type,href=_href)
-        if opts: new_link_tag.addAttributes(**opts)
-        #new_link_tag.addAttribute('rel',_rel)
-        #new_link_tag.addAttribute('type',_type)
-        #new_link_tag.addAttribute('href',_href)
-        #for op in opts:
-        #    new_link_tag.addAttribute(op,opts[op])
-        self.addHeadTag(link_tag)
-
     # Dumps the entire html file to a string
     def dumpHTML(self):
         string = ""
@@ -600,10 +587,10 @@ class HTMLGenerator:
     def saveHTML(self,f_name='index.html',f_dir='.'):
         #output = self.html.dumpTag()
         output = self.dumpHTML()
-        f_path = os.path.join(f_dir,f_name);
-        
+        f_path = os.path.join(f_dir,f_name)
+
         print(f"Saving HTML output to: {f_path})")
-        
+
         #html_file = open(f_path,'wb')
         html_file = open(f_path,'w')
         html_file.write(output)

--- a/topcoffea/modules/HTMLGenerator.py
+++ b/topcoffea/modules/HTMLGenerator.py
@@ -575,6 +575,19 @@ class HTMLGenerator:
         body_tag = self.getBodyTag()
         body_tag.addTag(new_tag)
 
+    # Adds a link tag to the head section of the html file
+    # A shorthand for adding a link tag to the header
+    def addLinkTag(self,_rel,_type,_href,opts={}):
+        link_tag = LinkTag()
+        link_tag.addAttributes(rel=_rel,type=_type,href=_href)
+        if opts: link_tag.addAttributes(**opts)
+        #new_link_tag.addAttribute('rel',_rel)
+        #new_link_tag.addAttribute('type',_type)
+        #new_link_tag.addAttribute('href',_href)
+        #for op in opts:
+        #    new_link_tag.addAttribute(op,opts[op])
+        self.addHeadTag(link_tag)
+
     # Dumps the entire html file to a string
     def dumpHTML(self):
         string = ""

--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -4,7 +4,7 @@
  The plotting settings are inherited.
 
  Example of initizalization: 
-  HistEFT("Events", ['c1', 'c2', 'c3'], hist.Cat("sample", "sample"), hist.Cat("cut", "cut"), hist.Bin("met", "MET (GeV)", 40, 0, 400))
+    HistEFT("Events", ['c1', 'c2', 'c3'], hist.Cat("sample", "sample"), hist.Cat("cut", "cut"), hist.Bin("met", "MET (GeV)", 40, 0, 400))
 
  TODO: check the group and rebin functions... in particular, the part of grouping/rebinning the coefficients
  TODO: add sum of weights for normalization? 
@@ -24,68 +24,68 @@ import topcoffea.modules.eft_helper as efth
 
 class HistEFT(coffea.hist.Hist):
 
-  def __init__(self, label, wcnames, *axes, **kwargs):
-    """ Initialize """
-    if isinstance(wcnames, str) and ',' in wcnames: wcnames = wcnames.replace(' ', '').split(',')
-    n = len(wcnames) if isinstance(wcnames, list) else wcnames
-    self._wcnames = wcnames
-    self._nwc = n
-    self._ncoeffs = efth.n_quad_terms(n)
-    self._nerrcoeffs = efth.n_quartic_terms(n)
-    self._wcs = np.zeros(n)
+    def __init__(self, label, wcnames, *axes, **kwargs):
+        """ Initialize """
+        if isinstance(wcnames, str) and ',' in wcnames: wcnames = wcnames.replace(' ', '').split(',')
+        n = len(wcnames) if isinstance(wcnames, list) else wcnames
+        self._wcnames = wcnames
+        self._nwc = n
+        self._ncoeffs = efth.n_quad_terms(n)
+        self._nerrcoeffs = efth.n_quartic_terms(n)
+        self._wcs = np.zeros(n)
 
-    super().__init__(label, *axes, **kwargs)
+        super().__init__(label, *axes, **kwargs)
 
 
-  def _init_sumw2(self):
-    self._sumw2 = {}
-    for key in self._sumw.keys():
-      # Check if this is an EFT bin or a regular bin
-      if self.dense_dim() > 0:
-        is_eft_bin = (self._sumw[key].shape != self._dense_shape)
-      else:
-        is_eft_bin = isinstance(self._sumw[key],np.ndarray)
+    def _init_sumw2(self):
+        self._sumw2 = {}
+        for key in self._sumw.keys():
+            # Check if this is an EFT bin or a regular bin
+            if self.dense_dim() > 0:
+                is_eft_bin = (self._sumw[key].shape != self._dense_shape)
+            else:
+                is_eft_bin = isinstance(self._sumw[key],np.ndarray)
 
-      if is_eft_bin:
-        # EFT bins that already existed prior to calling sumw2 can't
-        # be converted into bins with errors
-        self._sumw2[key] = None
-      else:
-        self._sumw2[key] = self._sumw[key].copy()
-            
-  def set_wilson_coeff_from_array(self, values):
-    """Set the WC values used to evaluate the bin contents of this histogram to the contents of 
-       an array where the elements are ordered according to the order defined by wcnames.
-    """
-    self._wcs = np.asarray(values).copy()
+            if is_eft_bin:
+                # EFT bins that already existed prior to calling sumw2 can't
+                # be converted into bins with errors
+                self._sumw2[key] = None
+            else:
+                self._sumw2[key] = self._sumw[key].copy()
+                        
+    def set_wilson_coeff_from_array(self, values):
+        """Set the WC values used to evaluate the bin contents of this histogram to the contents of 
+           an array where the elements are ordered according to the order defined by wcnames.
+        """
+        self._wcs = np.asarray(values).copy()
 
-  def set_sm(self):
-    """Conveniece method to set the WC values to SM (all zero)"""
-    self._wcs = np.zeros(self._nwc)
-    
-  def set_wilson_coefficients(self, **values):
-    """Set the WC values used to evaluate the bin contents of this histogram
-       where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
-    """
-    self.set_sm()
-    for key in values:
-      try:
-        index = self._wcnames.index(key)
-        self._wcs[index] = values[key]
-      except ValueError:
-        msg = 'This HistEFT does not know about the "{}" Wilson coefficient.  '.format(key)
-        if self._nwc == 0:
-          msg += 'There are no Wilson coefficients defined for this HistEFT.'
-        else:
-          wc_string = ', '.join(self._wcnames)
-          part1, _, part2 = wc_string.rpartition(', ')
-          msg += ('Defined Wilson coefficients: '+part1 + ', and ' + part2+'.')
-        raise LookupError(msg)
+    def set_sm(self):
+        """Conveniece method to set the WC values to SM (all zero)"""
+        self._wcs = np.zeros(self._nwc)
+        
+    def set_wilson_coefficients(self, **values):
+        """Set the WC values used to evaluate the bin contents of this histogram
+           where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
+        """
+        self.set_sm()
+        for key in values:
+            try:
+                index = self._wcnames.index(key)
+                self._wcs[index] = values[key]
+            except ValueError:
+                msg = 'This HistEFT does not know about the "{}" Wilson coefficient.  '.format(key)
+                if self._nwc == 0:
+                    msg += 'There are no Wilson coefficients defined for this HistEFT.'
+                else:
+                    wc_string = ', '.join(self._wcnames)
+                    part1, _, part2 = wc_string.rpartition(', ')
+                    msg += ('Defined Wilson coefficients: '+part1 + ', and ' + part2+'.')
+                raise LookupError(msg)
 
-  def split_by_terms(self,axis_bins,axis_name='sample'):
-    """ Split the EFT contributions by unique term from the quadratic parameterization
-    Parameters
-    ----------
+    def split_by_terms(self,axis_bins,axis_name='sample'):
+        """ Split the EFT contributions by unique term from the quadratic parameterization
+        Parameters
+        ----------
         axis_bins : list
             A list of axis bins that should correspond to bins with an EFT parmeterization. These
             bins will be summed together and the resulting parameterization split term-by-term to
@@ -96,688 +96,688 @@ class HistEFT(coffea.hist.Hist):
             The name of the sparse axis that is to be regrouped. This should almsot always
             correspond to whichever sparse axis defines the different MC process samples.
 
-    Returns:
-        A new HistEFT with the matched axis bins summed over and the resulting EFT parameterization
-        split up term-by-term, with each term appearing as a new bin in the specified axis. The
-        original axis bins are removed from the axis before returning the histogram
+        Returns:
+            A new HistEFT with the matched axis bins summed over and the resulting EFT parameterization
+            split up term-by-term, with each term appearing as a new bin in the specified axis. The
+            original axis bins are removed from the axis before returning the histogram
 
-    TODO: We could probably preserve the EFT quadratic information by filling the new histogram with
-          the quadratic coefficient that corresponds to the specific bin being filled.
-    """
-    if self.dense_dim() > 1:
-      raise RuntimeError("Splitting by terms not implemented for histograms with more than 1 dense axis")
-    if not axis_name in self._axes:
-      raise KeyError(f"No axis {axis_name} found in {self}")
-    dense_ax = self.dense_axes()[0]
+        TODO: We could probably preserve the EFT quadratic information by filling the new histogram with
+              the quadratic coefficient that corresponds to the specific bin being filled.
+        """
+        if self.dense_dim() > 1:
+            raise RuntimeError("Splitting by terms not implemented for histograms with more than 1 dense axis")
+        if not axis_name in self._axes:
+            raise KeyError(f"No axis {axis_name} found in {self}")
+        dense_ax = self.dense_axes()[0]
 
-    # Combine together bins that we want to have included in the EFT contributions
-    old_ax = self.axis(axis_name)
-    new_ax = coffea.hist.Cat(old_ax.name,old_ax.label)
+        # Combine together bins that we want to have included in the EFT contributions
+        old_ax = self.axis(axis_name)
+        new_ax = coffea.hist.Cat(old_ax.name,old_ax.label)
 
-    GROUP_NAME = 'signals'
+        GROUP_NAME = 'signals'
 
-    ident_names = [x.name for x in self.identifiers(axis_name)]
-    to_group = {GROUP_NAME: regex_match(ident_names,regex_lst=axis_bins)}
-    for ident in old_ax.identifiers():  # Should this be 'old_ax' or self.identifiers()?
-      n = ident.name
-      if not n in to_group[GROUP_NAME]:
-        to_group[n] = [n]
-    new_h = self.group(old_ax,new_ax,to_group)
+        ident_names = [x.name for x in self.identifiers(axis_name)]
+        to_group = {GROUP_NAME: regex_match(ident_names,regex_lst=axis_bins)}
+        for ident in old_ax.identifiers():  # Should this be 'old_ax' or self.identifiers()?
+            n = ident.name
+            if not n in to_group[GROUP_NAME]:
+                to_group[n] = [n]
+        new_h = self.group(old_ax,new_ax,to_group)
 
-    # Now begin the actual splitting
-    wcs = np.hstack(("sm",new_h._wcnames))
-    wc_vals = np.hstack((np.ones(1),new_h._wcs))
+        # Now begin the actual splitting
+        wcs = np.hstack(("sm",new_h._wcnames))
+        wc_vals = np.hstack((np.ones(1),new_h._wcs))
 
-    # First we evaluate the wc0*wc1 part of the quadratic, since this will be the same for every
-    #   bin in the histogram. Each element of 'wc_terms' will correspond to a different term of
-    #   the quadratic, so all that is left is to get the structure constants and multiply
-    #   element-by-element to get the expected yield
-    n_wcs = len(wcs)
-    n_terms = int(n_wcs*(n_wcs+1)/2)
-    iarr = np.zeros(2)
-    wc_terms = np.zeros(n_terms)
-    for idx in range(n_terms):
-      efth.quadratic_term_to_factors(idx,iarr)
-      i,j = [int(x) for x in iarr]
-      val = wc_vals[i]*wc_vals[j]
-      wc_terms[idx] = val
+        # First we evaluate the wc0*wc1 part of the quadratic, since this will be the same for every
+        #   bin in the histogram. Each element of 'wc_terms' will correspond to a different term of
+        #   the quadratic, so all that is left is to get the structure constants and multiply
+        #   element-by-element to get the expected yield
+        n_wcs = len(wcs)
+        n_terms = int(n_wcs*(n_wcs+1)/2)
+        iarr = np.zeros(2)
+        wc_terms = np.zeros(n_terms)
+        for idx in range(n_terms):
+            efth.quadratic_term_to_factors(idx,iarr)
+            i,j = [int(x) for x in iarr]
+            val = wc_vals[i]*wc_vals[j]
+            wc_terms[idx] = val
 
-    # This relies heavily on the fact that the ordering of the sparse axes matches the ordering
-    #   in the sparse_key tuple that you get from self._sumw
-    sparse_axes = [x.name for x in new_h.sparse_axes()]
-    sparse_keys = [x for x in new_h._sumw.keys()]
-    for sparse_key in sparse_keys:
-      v = new_h._sumw[sparse_key]
-      if new_h.dense_dim() > 0:
-        is_eft_bin = (v.shape != new_h._dense_shape)
-      else:
-        is_eft_bin = isinstance(v,np.ndarray)
-
-      if is_eft_bin:
-        bins = v[1:-2,...]  # Chop off the '*-flow' bins
-        term_vals = bins*wc_terms
-        for idx,wgts in enumerate(term_vals.T):
-          efth.quadratic_term_to_factors(idx,iarr)    # Get the 'name' of this term
-          i,j = [int(x) for x in iarr]
-          n1 = wcs[i]
-          n2 = wcs[j]
-          fill_info = {}
-          # Just to reiterate, this for loop relies on the fact that the ordering of the sparse axes
-          #   matches the ordering of the sparse key tuple that you get from self._sumw
-          for sp_axis_name,sp_axis_bin in zip(sparse_axes,sparse_key):
-            fill_info[sp_axis_name] = sp_axis_bin
-          fill_info[dense_ax.name] = dense_ax.centers()
-          fill_info['weight'] = wgts
-          fill_info[axis_name] = f"{n1}.{n2}"  # This overwrites the category (which should've been GROUP_NAME)
-          new_h.fill(**fill_info)
-    new_h = new_h.remove([GROUP_NAME],axis_name)
-    return new_h
-
-  def copy(self, content=True):
-    """ Copy """
-    out = HistEFT(self._label, self._wcnames, *self._axes, dtype=self._dtype)
-    if self._sumw2 is not None: out._sumw2 = {}
-    out._wcs = copy.deepcopy(self._wcs)
-    if content:
-        out._sumw = copy.deepcopy(self._sumw)
-        out._sumw2 = copy.deepcopy(self._sumw2)
-    return out
-
-  def copy_sm(self):
-    """ Copy at the SM point. Setting sumw2 to zero """
-    out = HistEFT(self._label,[], *self._axes, dtype=self._dtype)
-    if self._sumw2 is not None: out._sumw2 = {}
-    """ Copy at the SM point. Setting sumw2 to zero """
-    out._sumw = {}
-    out._sumw2 = {}
-    for sparse_key in self._sumw.keys():
-      is_eft_bin = (self._sumw[sparse_key].shape != self._dense_shape)
-      if is_eft_bin:
-        out._sumw[sparse_key] = np.copy(self._sumw[sparse_key][:,0])
-      else:
-        out._sumw[sparse_key] = np.copy(self._sumw[sparse_key])
-      out._sumw2[sparse_key]=np.zeros_like(out._sumw[sparse_key])
-    return out
-
-  def identity(self):
-    return self.copy(content=False)
-
-  def clear(self):
-    self._sumw = {}
-    self._sumw2 = None
-
-  def fill(self, **values):
-    """ Fill histogram, incuding EFT fit coefficients """
-
-    # If we're not filling with EFT coefficients, just do the normal coffea.hist.Hist.fill().
-    eft_coeff = values.pop("eft_coeff",None)
-
-    # First, let's pull out the weight and handle that.
-    weight = values.pop("weight", None)
-    if isinstance(weight, (ak.Array, np.ndarray)):
-      weight = np.asarray(weight)
-    if isinstance(weight, numbers.Number):
-      weight = np.atleast_1d(weight)
-
-    # Next up, we need to pull out the error coefficients, if those exist
-    eft_err_coeff = values.pop("eft_err_coeff",None)
-
-    # Now all that's left should be axes, so let's double check that
-    # there aren't any extra or missing.  Note: We do this after
-    # popping the weight and EFT stuff so that we can feel confident
-    # that everything left is an axis.
-    if not all(d.name in values for d in self._axes):
-        missing = ", ".join(d.name for d in self._axes if d.name not in values)
-        raise ValueError(
-            "Not all axes specified for %r.  Missing: %s" % (self, missing)
-        )
-    if not all(name in self._axes for name in values):
-        extra = ", ".join(name for name in values if name not in self._axes)
-        raise ValueError(
-            "Unrecognized axes specified for %r.  Extraneous: %s" % (self, extra)
-        )
-
-    # Lookup which sparse bin (i.e. the indices of this bin along the non-dense axes.
-    sparse_key = tuple(d.index(values[d.name]) for d in self.sparse_axes())
-
-    # Check if we're actually doing all this EFT stuff or not
-    if eft_coeff is None:
-      # But wait.  Does this sparse bin look like it's got EFT coefficients stored in it?
-      if sparse_key in self._sumw:
-        if len(np.atleast_1d(self._sumw[sparse_key]).shape) != len(self._dense_shape):
-          raise ValueError("Attempt to fill an EFT bin with non-EFT events.")
-      # Wait! If weight is not None, but some axes have EFT weights,
-      # the base class _init_sumw2() will do the wrong thing, so call
-      # ours here!
-      if weight is not None and self._sumw2 is None:
-        self._init_sumw2()
-      # Put the weights back in!  We're just going to rely on the
-      # regular coffea.hist.Hist fill method to handle this.
-      values['weight']=weight
-      super().fill(**values)
-      return
-
-    # OK then, we're doing this with EFT coefficients.    
-
-    # We want this as a numpy array
-    eft_coeff = np.asarray(eft_coeff)
-
-    # Check that we have the right number of coefficients
-    if self._ncoeffs != eft_coeff.shape[1]:
-      raise ValueError(
-        "Wrong number of EFT coefficients.  "+
-        "Expecting {}, received {}".format(self._ncoeffs, eft_coeff.shape[1])
-      )
-    if eft_err_coeff is not None:
-      if self._nerrcoeffs != eft_err_coeff.shape[1]:
-        raise ValueError(
-          "Wrong number of EFT w*w coefficients.  "+
-          "Expecting {}, received {}".format(self._nerrcoeffs, eft_err_coeff.shape[1])
-        )
-      
-    # Next, if there are weights, we should multiply the EFT coefficients by those weights
-    if weight is not None:
-      eft_coeff = eft_coeff*weight[:,np.newaxis]
-      # Also, if there are EFT error coefficients, those need to be scaled by weight**2
-      if eft_err_coeff is not None:
-        eft_err_coeff = eft_err_coeff*(weight[:,np.newaxis]**2)
-
-    # At this point, we're ready to accumulate these coefficients with
-    # any of our previous ones.  Note: we're going to use the same
-    # "dense bins" structure as a regular histogram, but just extend
-    # it by one more index to track the necessary coefficients.
-
-    # If this bin has never been filled before, initialize the numpy
-    # arrays to hold the coefficient sums Note, if there are no dense
-    # axes, then this just becomes 1D numpy array to store the
-    # coefficients for this sparse bin (see below when we go to fill).
-    if sparse_key not in self._sumw:
-      self._sumw[sparse_key] = np.zeros(
-        shape=(*self._dense_shape,self._ncoeffs), dtype=self._dtype
-      )
-      if eft_err_coeff is not None:
-        if self._sumw2 is None:
-          self._init_sumw2()
-        self._sumw2[sparse_key] = np.zeros(
-          shape=(*self._dense_shape,self._nerrcoeffs), dtype=self._dtype
-        )
-      else:
-        if self._sumw2 is not None:
-          self._sumw2[sparse_key] = None
-
-    # This get a little weird now.  We want to use np.bincount to sum
-    # up the coefficients in our bins, but this only works for a 1D
-    # array.  So, we're going to construct flat arrays of which
-    # coefficients need to be incremented and then use np.bincount to
-    # do the actual summing.
-    if self.dense_dim() > 0: 
-      # repeat the dense indices ncoeffs times to account for the fact
-      # that we're filling that many numbers
-      dense_indices = tuple(
-        np.repeat(d.index(values[d.name]),self._ncoeffs) for d in self._axes if isinstance(d, DenseAxis)
-      )
-      # This will make sure that all the coefficients in the flattened
-      # array corresponding to the appropriate dense bin get filled
-      xy = np.atleast_1d(
-        np.ravel_multi_index(
-          (*dense_indices,np.tile(np.arange(self._ncoeffs),eft_coeff.shape[0])),
-          (*self._dense_shape,self._ncoeffs))
-      )
-      # This little bit of magic sums the coefficients into the right
-      # bins.  It's just like filling a regular histogram bin, except
-      # that we're doing it _ncoeffs times.
-      self._sumw[sparse_key] += np.bincount(
-        xy, weights=eft_coeff.flatten(),
-        minlength=np.array((*self._dense_shape,self._ncoeffs)).prod()
-      ).reshape((*self._dense_shape,self._ncoeffs))
-      # Ah, but what about those darned w**2 coefficients?
-      if eft_err_coeff is not None:
-        # We're doing the same thing as for the EFT weight coefficients, but with the err array
-        dense_indices = tuple(
-          np.repeat(d.index(values[d.name]),self._nerrcoeffs) for d in self._axes if isinstance(d, DenseAxis)
-        )
-        xy = np.atleast_1d(
-          np.ravel_multi_index(
-            (*dense_indices,np.tile(np.arange(self._nerrcoeffs),eft_err_coeff.shape[0])),
-          (*self._dense_shape,self._nerrcoeffs))
-        )
-        self._sumw2[sparse_key] += np.bincount(
-          xy, weights=eft_err_coeff.flatten(),
-          minlength=np.array((*self._dense_shape,self._nerrcoeffs)).prod()
-        ).reshape((*self._dense_shape,self._nerrcoeffs))
-    else:
-      # If we end up here, then the sparse bin has no dense bins.
-      # That means all our eft_coeff and eft_err_coeffs just need to
-      # be summed and stored in this bin directly
-      self._sumw[sparse_key] += np.sum(eft_coeff,axis=0)
-      if eft_err_coeff is not None:
-        self._sumw2[sparse_key] += np.sum(eft_err_coeff,axis=0)
-
-  def add(self, other):
-    """ Add another histogram into this one, in-place """
-
-    if not self.compatible(other):
-      raise ValueError("Cannot add this histogram with histogram %r of dissimilar dimensions" % other)
-    raxes = other.sparse_axes()
-
-    # Adds right to left
-    def add_dict(left, right):
-      for rkey in right.keys():
-        lkey = tuple(self.axis(rax).index(rax[ridx]) for rax, ridx in zip(raxes, rkey))
-        # If the lkey is not already in left, just take the value from right
-        # Note: We do not have to check if rkey is in right, since we're looping over right.keys()
-        if lkey not in left:
-          left[lkey] = copy.deepcopy(right[rkey])
-        # Check that neither value is none
-        elif (left[lkey] is not None) and (right[rkey] is not None):
-          # Check if we're trying to sum a regular and EFT bin
-          if ((self.dense_dim() > 0) and (left[lkey].shape != right[rkey].shape)):
-            if left[lkey].shape[0] == right[rkey].shape[0]:
-              # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
-              # But first we have to know which hist is the EFT one
-              if len(left[lkey].shape) == 2:
-                # The left hist is the one with eft weights
-                left[lkey][:,0] = left[lkey][:,0] + right[rkey] 
-              elif len(right[rkey].shape) == 2:
-                # The right hist is the one with eft weights
-                # So we want left to be equal to left plus right (where left is just added to the SM part of right), without modifying right
-                tmp = left[lkey]
-                left[lkey] = copy.deepcopy(right[rkey])
-                left[lkey][:,0] = left[lkey][:,0] + tmp
-              else:
-                raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+        # This relies heavily on the fact that the ordering of the sparse axes matches the ordering
+        #   in the sparse_key tuple that you get from self._sumw
+        sparse_axes = [x.name for x in new_h.sparse_axes()]
+        sparse_keys = [x for x in new_h._sumw.keys()]
+        for sparse_key in sparse_keys:
+            v = new_h._sumw[sparse_key]
+            if new_h.dense_dim() > 0:
+                is_eft_bin = (v.shape != new_h._dense_shape)
             else:
-              raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
-          elif ((self.dense_dim() < 1) and (isinstance(left[lkey],np.ndarray) != isinstance(right[rkey],np.ndarray))):
-            raise ValueError("Attempt to add histogram bins with EFT weights to ones without.")
-          else:
-            left[lkey] += right[rkey]
-        # If either is None, we want the value of the one that is not none (at least we take into account the uncertainties we can).
-        # if both are None, its None
-        if left[lkey] is None:
-          left[lkey] = right[rkey]
-        if right[rkey] is None:
-          pass
-        
+                is_eft_bin = isinstance(v,np.ndarray)
 
-    # Add the sumw2 values
-    if self._sumw2 is None and other._sumw2 is None: 
-      pass
-    elif self._sumw2 is None:
-      self._init_sumw2()
-      add_dict(self._sumw2, other._sumw2)
-    elif other._sumw2 is None:
-      
-      # This is a tricky case because we want to put in "sumw" for
-      # "sumw2" for any non-EFT sparse bins, but None for any EFT
-      # sparse bins
-      temp = {}
-      for key in other._sumw:
-        # If it's an EFT bin, there will be a bigger shape
-        if other._sumw[key].shape != self._dense_shape:
-          temp[key] = None
+            if is_eft_bin:
+                bins = v[1:-2,...]  # Chop off the '*-flow' bins
+                term_vals = bins*wc_terms
+                for idx,wgts in enumerate(term_vals.T):
+                    efth.quadratic_term_to_factors(idx,iarr)    # Get the 'name' of this term
+                    i,j = [int(x) for x in iarr]
+                    n1 = wcs[i]
+                    n2 = wcs[j]
+                    fill_info = {}
+                    # Just to reiterate, this for loop relies on the fact that the ordering of the sparse axes
+                    #   matches the ordering of the sparse key tuple that you get from self._sumw
+                    for sp_axis_name,sp_axis_bin in zip(sparse_axes,sparse_key):
+                        fill_info[sp_axis_name] = sp_axis_bin
+                    fill_info[dense_ax.name] = dense_ax.centers()
+                    fill_info['weight'] = wgts
+                    fill_info[axis_name] = f"{n1}.{n2}"  # This overwrites the category (which should've been GROUP_NAME)
+                    new_h.fill(**fill_info)
+        new_h = new_h.remove([GROUP_NAME],axis_name)
+        return new_h
+
+    def copy(self, content=True):
+        """ Copy """
+        out = HistEFT(self._label, self._wcnames, *self._axes, dtype=self._dtype)
+        if self._sumw2 is not None: out._sumw2 = {}
+        out._wcs = copy.deepcopy(self._wcs)
+        if content:
+            out._sumw = copy.deepcopy(self._sumw)
+            out._sumw2 = copy.deepcopy(self._sumw2)
+        return out
+
+    def copy_sm(self):
+        """ Copy at the SM point. Setting sumw2 to zero """
+        out = HistEFT(self._label,[], *self._axes, dtype=self._dtype)
+        if self._sumw2 is not None: out._sumw2 = {}
+        """ Copy at the SM point. Setting sumw2 to zero """
+        out._sumw = {}
+        out._sumw2 = {}
+        for sparse_key in self._sumw.keys():
+            is_eft_bin = (self._sumw[sparse_key].shape != self._dense_shape)
+            if is_eft_bin:
+                out._sumw[sparse_key] = np.copy(self._sumw[sparse_key][:,0])
+            else:
+                out._sumw[sparse_key] = np.copy(self._sumw[sparse_key])
+            out._sumw2[sparse_key]=np.zeros_like(out._sumw[sparse_key])
+        return out
+
+    def identity(self):
+        return self.copy(content=False)
+
+    def clear(self):
+        self._sumw = {}
+        self._sumw2 = None
+
+    def fill(self, **values):
+        """ Fill histogram, incuding EFT fit coefficients """
+
+        # If we're not filling with EFT coefficients, just do the normal coffea.hist.Hist.fill().
+        eft_coeff = values.pop("eft_coeff",None)
+
+        # First, let's pull out the weight and handle that.
+        weight = values.pop("weight", None)
+        if isinstance(weight, (ak.Array, np.ndarray)):
+            weight = np.asarray(weight)
+        if isinstance(weight, numbers.Number):
+            weight = np.atleast_1d(weight)
+
+        # Next up, we need to pull out the error coefficients, if those exist
+        eft_err_coeff = values.pop("eft_err_coeff",None)
+
+        # Now all that's left should be axes, so let's double check that
+        # there aren't any extra or missing.  Note: We do this after
+        # popping the weight and EFT stuff so that we can feel confident
+        # that everything left is an axis.
+        if not all(d.name in values for d in self._axes):
+            missing = ", ".join(d.name for d in self._axes if d.name not in values)
+            raise ValueError(
+                "Not all axes specified for %r.  Missing: %s" % (self, missing)
+            )
+        if not all(name in self._axes for name in values):
+            extra = ", ".join(name for name in values if name not in self._axes)
+            raise ValueError(
+                "Unrecognized axes specified for %r.  Extraneous: %s" % (self, extra)
+            )
+
+        # Lookup which sparse bin (i.e. the indices of this bin along the non-dense axes.
+        sparse_key = tuple(d.index(values[d.name]) for d in self.sparse_axes())
+
+        # Check if we're actually doing all this EFT stuff or not
+        if eft_coeff is None:
+            # But wait.  Does this sparse bin look like it's got EFT coefficients stored in it?
+            if sparse_key in self._sumw:
+                if len(np.atleast_1d(self._sumw[sparse_key]).shape) != len(self._dense_shape):
+                    raise ValueError("Attempt to fill an EFT bin with non-EFT events.")
+            # Wait! If weight is not None, but some axes have EFT weights,
+            # the base class _init_sumw2() will do the wrong thing, so call
+            # ours here!
+            if weight is not None and self._sumw2 is None:
+                self._init_sumw2()
+            # Put the weights back in!  We're just going to rely on the
+            # regular coffea.hist.Hist fill method to handle this.
+            values['weight']=weight
+            super().fill(**values)
+            return
+
+        # OK then, we're doing this with EFT coefficients.    
+
+        # We want this as a numpy array
+        eft_coeff = np.asarray(eft_coeff)
+
+        # Check that we have the right number of coefficients
+        if self._ncoeffs != eft_coeff.shape[1]:
+            raise ValueError(
+                "Wrong number of EFT coefficients.  "+
+                "Expecting {}, received {}".format(self._ncoeffs, eft_coeff.shape[1])
+            )
+        if eft_err_coeff is not None:
+            if self._nerrcoeffs != eft_err_coeff.shape[1]:
+                raise ValueError(
+                    "Wrong number of EFT w*w coefficients.  "+
+                    "Expecting {}, received {}".format(self._nerrcoeffs, eft_err_coeff.shape[1])
+                )
+            
+        # Next, if there are weights, we should multiply the EFT coefficients by those weights
+        if weight is not None:
+            eft_coeff = eft_coeff*weight[:,np.newaxis]
+            # Also, if there are EFT error coefficients, those need to be scaled by weight**2
+            if eft_err_coeff is not None:
+                eft_err_coeff = eft_err_coeff*(weight[:,np.newaxis]**2)
+
+        # At this point, we're ready to accumulate these coefficients with
+        # any of our previous ones.  Note: we're going to use the same
+        # "dense bins" structure as a regular histogram, but just extend
+        # it by one more index to track the necessary coefficients.
+
+        # If this bin has never been filled before, initialize the numpy
+        # arrays to hold the coefficient sums Note, if there are no dense
+        # axes, then this just becomes 1D numpy array to store the
+        # coefficients for this sparse bin (see below when we go to fill).
+        if sparse_key not in self._sumw:
+            self._sumw[sparse_key] = np.zeros(
+                shape=(*self._dense_shape,self._ncoeffs), dtype=self._dtype
+            )
+            if eft_err_coeff is not None:
+                if self._sumw2 is None:
+                    self._init_sumw2()
+                self._sumw2[sparse_key] = np.zeros(
+                    shape=(*self._dense_shape,self._nerrcoeffs), dtype=self._dtype
+                )
+            else:
+                if self._sumw2 is not None:
+                    self._sumw2[sparse_key] = None
+
+        # This get a little weird now.  We want to use np.bincount to sum
+        # up the coefficients in our bins, but this only works for a 1D
+        # array.  So, we're going to construct flat arrays of which
+        # coefficients need to be incremented and then use np.bincount to
+        # do the actual summing.
+        if self.dense_dim() > 0: 
+            # repeat the dense indices ncoeffs times to account for the fact
+            # that we're filling that many numbers
+            dense_indices = tuple(
+                np.repeat(d.index(values[d.name]),self._ncoeffs) for d in self._axes if isinstance(d, DenseAxis)
+            )
+            # This will make sure that all the coefficients in the flattened
+            # array corresponding to the appropriate dense bin get filled
+            xy = np.atleast_1d(
+                np.ravel_multi_index(
+                    (*dense_indices,np.tile(np.arange(self._ncoeffs),eft_coeff.shape[0])),
+                    (*self._dense_shape,self._ncoeffs))
+            )
+            # This little bit of magic sums the coefficients into the right
+            # bins.  It's just like filling a regular histogram bin, except
+            # that we're doing it _ncoeffs times.
+            self._sumw[sparse_key] += np.bincount(
+                xy, weights=eft_coeff.flatten(),
+                minlength=np.array((*self._dense_shape,self._ncoeffs)).prod()
+            ).reshape((*self._dense_shape,self._ncoeffs))
+            # Ah, but what about those darned w**2 coefficients?
+            if eft_err_coeff is not None:
+                # We're doing the same thing as for the EFT weight coefficients, but with the err array
+                dense_indices = tuple(
+                    np.repeat(d.index(values[d.name]),self._nerrcoeffs) for d in self._axes if isinstance(d, DenseAxis)
+                )
+                xy = np.atleast_1d(
+                    np.ravel_multi_index(
+                        (*dense_indices,np.tile(np.arange(self._nerrcoeffs),eft_err_coeff.shape[0])),
+                    (*self._dense_shape,self._nerrcoeffs))
+                )
+                self._sumw2[sparse_key] += np.bincount(
+                    xy, weights=eft_err_coeff.flatten(),
+                    minlength=np.array((*self._dense_shape,self._nerrcoeffs)).prod()
+                ).reshape((*self._dense_shape,self._nerrcoeffs))
         else:
-          # Regular bins can just copy over sumw for sumw2
-          temp[key] = other._sumw[key]
-      add_dict(self._sumw2, temp)
-    else:
-      add_dict(self._sumw2, other._sumw2)
+            # If we end up here, then the sparse bin has no dense bins.
+            # That means all our eft_coeff and eft_err_coeffs just need to
+            # be summed and stored in this bin directly
+            self._sumw[sparse_key] += np.sum(eft_coeff,axis=0)
+            if eft_err_coeff is not None:
+                self._sumw2[sparse_key] += np.sum(eft_err_coeff,axis=0)
 
-    # Add the sumw values
-    add_dict(self._sumw, other._sumw)
+    def add(self, other):
+        """ Add another histogram into this one, in-place """
 
-    return self 
+        if not self.compatible(other):
+            raise ValueError("Cannot add this histogram with histogram %r of dissimilar dimensions" % other)
+        raxes = other.sparse_axes()
 
-  def __getitem__(self, keys):
-    """ Extended from parent class """
-    if not isinstance(keys, tuple): keys = (keys,)
-    if len(keys) > self.dim():  raise IndexError("Too many indices for this histogram")
-    elif len(keys) < self.dim():
-      if Ellipsis in keys:
-        idx = keys.index(Ellipsis)
-        slices = (slice(None),) * (self.dim() - len(keys) + 1)
-        keys = keys[:idx] + slices + keys[idx + 1:]
-      else:
-        slices = (slice(None),) * (self.dim() - len(keys))
-        keys += slices
-    sparse_idx, dense_idx, new_dims = [], [], []
+        # Adds right to left
+        def add_dict(left, right):
+            for rkey in right.keys():
+                lkey = tuple(self.axis(rax).index(rax[ridx]) for rax, ridx in zip(raxes, rkey))
+                # If the lkey is not already in left, just take the value from right
+                # Note: We do not have to check if rkey is in right, since we're looping over right.keys()
+                if lkey not in left:
+                    left[lkey] = copy.deepcopy(right[rkey])
+                # Check that neither value is none
+                elif (left[lkey] is not None) and (right[rkey] is not None):
+                    # Check if we're trying to sum a regular and EFT bin
+                    if ((self.dense_dim() > 0) and (left[lkey].shape != right[rkey].shape)):
+                        if left[lkey].shape[0] == right[rkey].shape[0]:
+                            # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
+                            # But first we have to know which hist is the EFT one
+                            if len(left[lkey].shape) == 2:
+                                # The left hist is the one with eft weights
+                                left[lkey][:,0] = left[lkey][:,0] + right[rkey] 
+                            elif len(right[rkey].shape) == 2:
+                                # The right hist is the one with eft weights
+                                # So we want left to be equal to left plus right (where left is just added to the SM part of right), without modifying right
+                                tmp = left[lkey]
+                                left[lkey] = copy.deepcopy(right[rkey])
+                                left[lkey][:,0] = left[lkey][:,0] + tmp
+                            else:
+                                raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                        else:
+                            raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                    elif ((self.dense_dim() < 1) and (isinstance(left[lkey],np.ndarray) != isinstance(right[rkey],np.ndarray))):
+                        raise ValueError("Attempt to add histogram bins with EFT weights to ones without.")
+                    else:
+                        left[lkey] += right[rkey]
+                # If either is None, we want the value of the one that is not none (at least we take into account the uncertainties we can).
+                # if both are None, its None
+                if left[lkey] is None:
+                    left[lkey] = right[rkey]
+                if right[rkey] is None:
+                    pass
+                
 
-    for s, ax in zip(keys, self._axes):
-      if isinstance(ax, coffea.hist.hist_tools.SparseAxis):
-        sparse_idx.append(ax._ireduce(s))
-        new_dims.append(ax)
-      else:
-        islice = ax._ireduce(s)
-        dense_idx.append(islice)
-        new_dims.append(ax.reduced(islice))
-    dense_idx = tuple(dense_idx)
-
-    def dense_op(array):
-      return np.block(coffea.hist.hist_tools.assemble_blocks(array, dense_idx))
-
-    out = HistEFT(self._label, self._wcnames, *new_dims, dtype=self._dtype)
-    out._wcs = copy.deepcopy(self._wcs)
-    if self._sumw2 is not None: out._init_sumw2()
-    for sparse_key in self._sumw:
-      if not all(k in idx for k, idx in zip(sparse_key, sparse_idx)):
-        continue
-      if sparse_key in out._sumw:
-        out._sumw[sparse_key] += dense_op(self._sumw[sparse_key])
-
-        # Handle the sumw2 values
-        # Note: This is copied directly from the implementation in sum(), with key->sparse_key, new_key->sparse_key
-        if self._sumw2 is not None:
-          # If neither sumw2 value is None, add them
-          # First check if we're trying to add regular errors to eft errors
-          # Note: This is really the same as in sumw, so would be better to have a function instead of copy paste
-          if (self._sumw2[sparse_key] is not None) and (out._sumw2[sparse_key] is not None):
-            if (out._sumw2[sparse_key].shape != self._sumw2[sparse_key].shape):
-              if out._sumw2[sparse_key].shape[0] == self._sumw2[sparse_key].shape[0]:
-                # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
-                # But first we have to know which hist is the EFT one
-                if len(out._sumw2[sparse_key].shape) == 2:
-                  # The out hist is the one with eft weights
-                  out._sumw2[sparse_key][:,0] = out._sumw2[sparse_key][:,0] + self._sumw2[sparse_key]
-                elif len(self._sumw2[sparse_key].shape) == 2:
-                  # The original hist self is the one with eft weights
-                  # So we want out to be equal to self plus out (where out is just added to the SM part of self), without modifying self
-                  tmp2 = out._sumw2[sparse_key]
-                  out._sumw2[sparse_key] = copy.deepcopy(self._sumw2[sparse_key])
-                  out._sumw2[sparse_key][:,0] = out._sumw2[sparse_key][:,0] + tmp2
+        # Add the sumw2 values
+        if self._sumw2 is None and other._sumw2 is None: 
+            pass
+        elif self._sumw2 is None:
+            self._init_sumw2()
+            add_dict(self._sumw2, other._sumw2)
+        elif other._sumw2 is None:
+            
+            # This is a tricky case because we want to put in "sumw" for
+            # "sumw2" for any non-EFT sparse bins, but None for any EFT
+            # sparse bins
+            temp = {}
+            for key in other._sumw:
+                # If it's an EFT bin, there will be a bigger shape
+                if other._sumw[key].shape != self._dense_shape:
+                    temp[key] = None
                 else:
-                  raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
-              else:
-                raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
-            else:
-              out._sumw2[sparse_key] += dense_op(self._sumw2[sparse_key])
-          # If either sumw2 value is None, we will set the out sumw2 to None
-          else:
-            out._sumw2[sparse_key] = None
-
-      else:
-        out._sumw[sparse_key] = dense_op(self._sumw[sparse_key]).copy()
-        if self._sumw2 is not None:
-          if self._sumw2[sparse_key] is not None:
-            out._sumw2[sparse_key] = dense_op(self._sumw2[sparse_key]).copy()
-          else:
-            out._sumw2[sparse_key] = None
-    return out
-
-  def sum(self, *axes, **kwargs):
-    """ Integrates out a set of axes, producing a new histogram 
-        Project() and integrate() depends on sum() and are heritated """
-    overflow = kwargs.pop('overflow', 'none')
-    axes = [self.axis(ax) for ax in axes]
-    reduced_dims = [ax for ax in self._axes if ax not in axes]
-    out = HistEFT(self._label, self._wcnames, *reduced_dims, dtype=self._dtype)
-    out._wcs = copy.deepcopy(self._wcs)
-    if self._sumw2 is not None: out._init_sumw2()
-
-    sparse_drop = []
-    dense_slice = [slice(None)] * self.dense_dim()
-    dense_sum_dim = []
-    for axis in axes:
-      if isinstance(axis, coffea.hist.hist_tools.DenseAxis):
-        idense = self._idense(axis)
-        dense_sum_dim.append(idense)
-        dense_slice[idense] = coffea.hist.hist_tools.overflow_behavior(overflow)
-      elif isinstance(axis, coffea.hist.hist_tools.SparseAxis):
-        isparse = self._isparse(axis)
-        sparse_drop.append(isparse)
-    dense_slice = tuple(dense_slice)
-    dense_sum_dim = tuple(dense_sum_dim)
-
-    def dense_op(array):
-      if len(dense_sum_dim) > 0:
-        return np.sum(array[dense_slice], axis=dense_sum_dim)
-      return array
-
-    for key in self._sumw.keys():
-
-      new_key = tuple(k for i, k in enumerate(key) if i not in sparse_drop)
-      if new_key in out._sumw:
-
-        # Handle the sumw values
-        # Check if we're trying to combine EFT and non-EFT bins
-        if ((self.dense_dim() > 0) and (out._sumw[new_key].shape != self._sumw[key].shape)):
-          if out._sumw[new_key].shape[0] == self._sumw[key].shape[0]:
-            # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
-            # But first we have to know which hist is the EFT one
-            if len(out._sumw[new_key].shape) == 2:
-              # The out hist is the one with eft weights
-              out._sumw[new_key][:,0] = out._sumw[new_key][:,0] + self._sumw[key]
-            elif len(self._sumw[key].shape) == 2:
-              # The original hist self is the one with eft weights
-              # So we want out to be equal to self plus out (where out is just added to the SM part of self), without modifying self
-              tmp = out._sumw[new_key]
-              out._sumw[new_key] = copy.deepcopy(self._sumw[key])
-              out._sumw[new_key][:,0] = out._sumw[new_key][:,0] + tmp
-            else:
-              raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
-          else:
-            raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
-        elif ((self.dense_dim() == 0) and (isinstance(out._sumw[new_key],np.ndarray) != isinstance(self._sumw[key],np.ndarray))):
-          raise ValueError("Attempt to sum bins with EFT weights to ones without.")
+                    # Regular bins can just copy over sumw for sumw2
+                    temp[key] = other._sumw[key]
+            add_dict(self._sumw2, temp)
         else:
-          out._sumw[new_key] += dense_op(self._sumw[key])
+            add_dict(self._sumw2, other._sumw2)
 
-        # Handle the sumw2 values
-        if self._sumw2 is not None:
-          # If neither sumw2 value is None, add them
-          # First check if we're trying to add regular errors to eft errors
-          # Note: This is really the same as in sumw, so would be better to have a function instead of copy paste
-          if (self._sumw2[key] is not None) and (out._sumw2[new_key] is not None):
-            if (out._sumw2[new_key].shape != self._sumw2[key].shape):
-              if out._sumw2[new_key].shape[0] == self._sumw2[key].shape[0]:
-                # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
-                # But first we have to know which hist is the EFT one
-                if len(out._sumw2[new_key].shape) == 2:
-                  # The out hist is the one with eft weights
-                  out._sumw2[new_key][:,0] = out._sumw2[new_key][:,0] + self._sumw2[key]
-                elif len(self._sumw2[key].shape) == 2:
-                  # The original hist self is the one with eft weights
-                  # So we want out to be equal to self plus out (where out is just added to the SM part of self), without modifying self
-                  tmp2 = out._sumw2[new_key]
-                  out._sumw2[new_key] = copy.deepcopy(self._sumw2[key])
-                  out._sumw2[new_key][:,0] = out._sumw2[new_key][:,0] + tmp2
+        # Add the sumw values
+        add_dict(self._sumw, other._sumw)
+
+        return self 
+
+    def __getitem__(self, keys):
+        """ Extended from parent class """
+        if not isinstance(keys, tuple): keys = (keys,)
+        if len(keys) > self.dim():  raise IndexError("Too many indices for this histogram")
+        elif len(keys) < self.dim():
+            if Ellipsis in keys:
+                idx = keys.index(Ellipsis)
+                slices = (slice(None),) * (self.dim() - len(keys) + 1)
+                keys = keys[:idx] + slices + keys[idx + 1:]
+            else:
+                slices = (slice(None),) * (self.dim() - len(keys))
+                keys += slices
+        sparse_idx, dense_idx, new_dims = [], [], []
+
+        for s, ax in zip(keys, self._axes):
+            if isinstance(ax, coffea.hist.hist_tools.SparseAxis):
+                sparse_idx.append(ax._ireduce(s))
+                new_dims.append(ax)
+            else:
+                islice = ax._ireduce(s)
+                dense_idx.append(islice)
+                new_dims.append(ax.reduced(islice))
+        dense_idx = tuple(dense_idx)
+
+        def dense_op(array):
+            return np.block(coffea.hist.hist_tools.assemble_blocks(array, dense_idx))
+
+        out = HistEFT(self._label, self._wcnames, *new_dims, dtype=self._dtype)
+        out._wcs = copy.deepcopy(self._wcs)
+        if self._sumw2 is not None: out._init_sumw2()
+        for sparse_key in self._sumw:
+            if not all(k in idx for k, idx in zip(sparse_key, sparse_idx)):
+                continue
+            if sparse_key in out._sumw:
+                out._sumw[sparse_key] += dense_op(self._sumw[sparse_key])
+
+                # Handle the sumw2 values
+                # Note: This is copied directly from the implementation in sum(), with key->sparse_key, new_key->sparse_key
+                if self._sumw2 is not None:
+                    # If neither sumw2 value is None, add them
+                    # First check if we're trying to add regular errors to eft errors
+                    # Note: This is really the same as in sumw, so would be better to have a function instead of copy paste
+                    if (self._sumw2[sparse_key] is not None) and (out._sumw2[sparse_key] is not None):
+                        if (out._sumw2[sparse_key].shape != self._sumw2[sparse_key].shape):
+                            if out._sumw2[sparse_key].shape[0] == self._sumw2[sparse_key].shape[0]:
+                                # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
+                                # But first we have to know which hist is the EFT one
+                                if len(out._sumw2[sparse_key].shape) == 2:
+                                    # The out hist is the one with eft weights
+                                    out._sumw2[sparse_key][:,0] = out._sumw2[sparse_key][:,0] + self._sumw2[sparse_key]
+                                elif len(self._sumw2[sparse_key].shape) == 2:
+                                    # The original hist self is the one with eft weights
+                                    # So we want out to be equal to self plus out (where out is just added to the SM part of self), without modifying self
+                                    tmp2 = out._sumw2[sparse_key]
+                                    out._sumw2[sparse_key] = copy.deepcopy(self._sumw2[sparse_key])
+                                    out._sumw2[sparse_key][:,0] = out._sumw2[sparse_key][:,0] + tmp2
+                                else:
+                                    raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                            else:
+                                raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                        else:
+                            out._sumw2[sparse_key] += dense_op(self._sumw2[sparse_key])
+                    # If either sumw2 value is None, we will set the out sumw2 to None
+                    else:
+                        out._sumw2[sparse_key] = None
+
+            else:
+                out._sumw[sparse_key] = dense_op(self._sumw[sparse_key]).copy()
+                if self._sumw2 is not None:
+                    if self._sumw2[sparse_key] is not None:
+                        out._sumw2[sparse_key] = dense_op(self._sumw2[sparse_key]).copy()
+                    else:
+                        out._sumw2[sparse_key] = None
+        return out
+
+    def sum(self, *axes, **kwargs):
+        """ Integrates out a set of axes, producing a new histogram 
+                Project() and integrate() depends on sum() and are heritated """
+        overflow = kwargs.pop('overflow', 'none')
+        axes = [self.axis(ax) for ax in axes]
+        reduced_dims = [ax for ax in self._axes if ax not in axes]
+        out = HistEFT(self._label, self._wcnames, *reduced_dims, dtype=self._dtype)
+        out._wcs = copy.deepcopy(self._wcs)
+        if self._sumw2 is not None: out._init_sumw2()
+
+        sparse_drop = []
+        dense_slice = [slice(None)] * self.dense_dim()
+        dense_sum_dim = []
+        for axis in axes:
+            if isinstance(axis, coffea.hist.hist_tools.DenseAxis):
+                idense = self._idense(axis)
+                dense_sum_dim.append(idense)
+                dense_slice[idense] = coffea.hist.hist_tools.overflow_behavior(overflow)
+            elif isinstance(axis, coffea.hist.hist_tools.SparseAxis):
+                isparse = self._isparse(axis)
+                sparse_drop.append(isparse)
+        dense_slice = tuple(dense_slice)
+        dense_sum_dim = tuple(dense_sum_dim)
+
+        def dense_op(array):
+            if len(dense_sum_dim) > 0:
+                return np.sum(array[dense_slice], axis=dense_sum_dim)
+            return array
+
+        for key in self._sumw.keys():
+
+            new_key = tuple(k for i, k in enumerate(key) if i not in sparse_drop)
+            if new_key in out._sumw:
+
+                # Handle the sumw values
+                # Check if we're trying to combine EFT and non-EFT bins
+                if ((self.dense_dim() > 0) and (out._sumw[new_key].shape != self._sumw[key].shape)):
+                    if out._sumw[new_key].shape[0] == self._sumw[key].shape[0]:
+                        # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
+                        # But first we have to know which hist is the EFT one
+                        if len(out._sumw[new_key].shape) == 2:
+                            # The out hist is the one with eft weights
+                            out._sumw[new_key][:,0] = out._sumw[new_key][:,0] + self._sumw[key]
+                        elif len(self._sumw[key].shape) == 2:
+                            # The original hist self is the one with eft weights
+                            # So we want out to be equal to self plus out (where out is just added to the SM part of self), without modifying self
+                            tmp = out._sumw[new_key]
+                            out._sumw[new_key] = copy.deepcopy(self._sumw[key])
+                            out._sumw[new_key][:,0] = out._sumw[new_key][:,0] + tmp
+                        else:
+                            raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                    else:
+                        raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                elif ((self.dense_dim() == 0) and (isinstance(out._sumw[new_key],np.ndarray) != isinstance(self._sumw[key],np.ndarray))):
+                    raise ValueError("Attempt to sum bins with EFT weights to ones without.")
                 else:
-                  raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
-              else:
-                raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                    out._sumw[new_key] += dense_op(self._sumw[key])
+
+                # Handle the sumw2 values
+                if self._sumw2 is not None:
+                    # If neither sumw2 value is None, add them
+                    # First check if we're trying to add regular errors to eft errors
+                    # Note: This is really the same as in sumw, so would be better to have a function instead of copy paste
+                    if (self._sumw2[key] is not None) and (out._sumw2[new_key] is not None):
+                        if (out._sumw2[new_key].shape != self._sumw2[key].shape):
+                            if out._sumw2[new_key].shape[0] == self._sumw2[key].shape[0]:
+                                # Add the non-EFT bin contents to the 0th element (SM element) of the EFT bin
+                                # But first we have to know which hist is the EFT one
+                                if len(out._sumw2[new_key].shape) == 2:
+                                    # The out hist is the one with eft weights
+                                    out._sumw2[new_key][:,0] = out._sumw2[new_key][:,0] + self._sumw2[key]
+                                elif len(self._sumw2[key].shape) == 2:
+                                    # The original hist self is the one with eft weights
+                                    # So we want out to be equal to self plus out (where out is just added to the SM part of self), without modifying self
+                                    tmp2 = out._sumw2[new_key]
+                                    out._sumw2[new_key] = copy.deepcopy(self._sumw2[key])
+                                    out._sumw2[new_key][:,0] = out._sumw2[new_key][:,0] + tmp2
+                                else:
+                                    raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                            else:
+                                raise ValueError("Cannot sum these histograms, the values are not an expected shape.")
+                        else:
+                            out._sumw2[new_key] += dense_op(self._sumw2[key])
+                    # If either sumw2 value is None, we will set the out sumw2 to None
+                    else:
+                        out._sumw2[new_key] = None
+
+            # The new_key in not in out._sumw yet, so just take the val from self
             else:
-              out._sumw2[new_key] += dense_op(self._sumw2[key])
-          # If either sumw2 value is None, we will set the out sumw2 to None
-          else:
-            out._sumw2[new_key] = None
+                out._sumw[new_key] = dense_op(self._sumw[key]).copy()
+                if self._sumw2 is not None:
+                    if self._sumw2[key] is not None:
+                        out._sumw2[new_key] = dense_op(self._sumw2[key]).copy()
+                    else:
+                        out._sumw2[new_key] = None
+                            
+        return out
 
-      # The new_key in not in out._sumw yet, so just take the val from self
-      else:
-        out._sumw[new_key] = dense_op(self._sumw[key]).copy()
-        if self._sumw2 is not None:
-          if self._sumw2[key] is not None:
-            out._sumw2[new_key] = dense_op(self._sumw2[key]).copy()
-          else:
-            out._sumw2[new_key] = None
-              
-    return out
+    def group(self, old_axes, new_axis, mapping, overflow='none'): 
+        """ Group a set of slices on old axes into a single new axis """
+        ### WARNING: check that this function works properly... (TODO) --> Are the EFT coefficients properly grouped?
+        if not isinstance(new_axis, coffea.hist.hist_tools.SparseAxis):
+            raise TypeError("New axis must be a sparse axis.  Note: Hist.group() signature has changed to group(old_axes, new_axis, ...)!")
+        if new_axis in self.axes() and self.axis(new_axis) is new_axis:
+            raise RuntimeError("new_axis is already in the list of axes.  Note: Hist.group() signature has changed to group(old_axes, new_axis, ...)!")
+        if not isinstance(old_axes, tuple): old_axes = (old_axes,)
+        old_axes = [self.axis(ax) for ax in old_axes]
+        old_indices = [i for i, ax in enumerate(self._axes) if ax in old_axes]
+        new_dims = [new_axis] + [ax for ax in self._axes if ax not in old_axes]
+        out = HistEFT(self._label, self._wcnames, *new_dims, dtype=self._dtype)
+        out._wcs = copy.deepcopy(self._wcs)
+        if self._sumw2 is not None: out._init_sumw2()
+        for new_cat in mapping.keys():
+            the_slice = mapping[new_cat]
+            if not isinstance(the_slice, tuple): the_slice = (the_slice,)
+            if len(the_slice) != len(old_axes):
+                raise Exception("Slicing does not match number of axes being rebinned")
+            full_slice = [slice(None)] * self.dim()
+            for idx, s in zip(old_indices, the_slice): full_slice[idx] = s
+            full_slice = tuple(full_slice)
+            reduced_hist = self[full_slice].sum(*tuple(ax.name for ax in old_axes), overflow=overflow)  # slice may change old axis binning
+            new_idx = new_axis.index(new_cat)
+            for key in reduced_hist._sumw:
+                new_key = (new_idx,) + key
+                out._sumw[new_key] = reduced_hist._sumw[key]
+                if self._sumw2 is not None:
+                    if reduced_hist._sumw2[key] is not None:
+                        out._sumw2[new_key] = reduced_hist._sumw2[key]
+                    else:
+                        out._sumw2[new_key] = None
 
-  def group(self, old_axes, new_axis, mapping, overflow='none'): 
-    """ Group a set of slices on old axes into a single new axis """
-    ### WARNING: check that this function works properly... (TODO) --> Are the EFT coefficients properly grouped?
-    if not isinstance(new_axis, coffea.hist.hist_tools.SparseAxis):
-      raise TypeError("New axis must be a sparse axis.  Note: Hist.group() signature has changed to group(old_axes, new_axis, ...)!")
-    if new_axis in self.axes() and self.axis(new_axis) is new_axis:
-      raise RuntimeError("new_axis is already in the list of axes.  Note: Hist.group() signature has changed to group(old_axes, new_axis, ...)!")
-    if not isinstance(old_axes, tuple): old_axes = (old_axes,)
-    old_axes = [self.axis(ax) for ax in old_axes]
-    old_indices = [i for i, ax in enumerate(self._axes) if ax in old_axes]
-    new_dims = [new_axis] + [ax for ax in self._axes if ax not in old_axes]
-    out = HistEFT(self._label, self._wcnames, *new_dims, dtype=self._dtype)
-    out._wcs = copy.deepcopy(self._wcs)
-    if self._sumw2 is not None: out._init_sumw2()
-    for new_cat in mapping.keys():
-      the_slice = mapping[new_cat]
-      if not isinstance(the_slice, tuple): the_slice = (the_slice,)
-      if len(the_slice) != len(old_axes):
-        raise Exception("Slicing does not match number of axes being rebinned")
-      full_slice = [slice(None)] * self.dim()
-      for idx, s in zip(old_indices, the_slice): full_slice[idx] = s
-      full_slice = tuple(full_slice)
-      reduced_hist = self[full_slice].sum(*tuple(ax.name for ax in old_axes), overflow=overflow)  # slice may change old axis binning
-      new_idx = new_axis.index(new_cat)
-      for key in reduced_hist._sumw:
-        new_key = (new_idx,) + key
-        out._sumw[new_key] = reduced_hist._sumw[key]
-        if self._sumw2 is not None:
-          if reduced_hist._sumw2[key] is not None:
-            out._sumw2[new_key] = reduced_hist._sumw2[key]
-          else:
-            out._sumw2[new_key] = None
+        return out
 
-    return out
+    def rebin(self, old_axis, new_axis):
+        """ Rebin a dense axis """
+        old_axis = self.axis(old_axis)
+        if isinstance(new_axis, numbers.Integral):
+            new_axis = coffea.hist.Bin(old_axis.name, old_axis.label, old_axis.edges()[::new_axis])
+        new_dims = [ax if ax != old_axis else new_axis for ax in self._axes]
+        out = HistEFT(self._label, self._wcnames, *new_dims, dtype=self._dtype)
+        out._wcs = copy.deepcopy(self._wcs)
+        if self._sumw2 is not None: out._init_sumw2()
+        idense = self._idense(old_axis)
 
-  def rebin(self, old_axis, new_axis):
-    """ Rebin a dense axis """
-    old_axis = self.axis(old_axis)
-    if isinstance(new_axis, numbers.Integral):
-        new_axis = coffea.hist.Bin(old_axis.name, old_axis.label, old_axis.edges()[::new_axis])
-    new_dims = [ax if ax != old_axis else new_axis for ax in self._axes]
-    out = HistEFT(self._label, self._wcnames, *new_dims, dtype=self._dtype)
-    out._wcs = copy.deepcopy(self._wcs)
-    if self._sumw2 is not None: out._init_sumw2()
-    idense = self._idense(old_axis)
+        def view_ax(idx):
+            fullindex = [slice(None)] * self.dense_dim()
+            fullindex[idense] = idx
+            return tuple(fullindex)
+        binmap = [new_axis.index(i) for i in old_axis.identifiers(overflow='allnan')]
 
-    def view_ax(idx):
-      fullindex = [slice(None)] * self.dense_dim()
-      fullindex[idense] = idx
-      return tuple(fullindex)
-    binmap = [new_axis.index(i) for i in old_axis.identifiers(overflow='allnan')]
+        def dense_op(array):
+            if array.shape != self._dense_shape:
+                newshape = (*out._dense_shape,out._ncoeffs)
+            else:
+                newshape = out._dense_shape
 
-    def dense_op(array):
-      if array.shape != self._dense_shape:
-        newshape = (*out._dense_shape,out._ncoeffs)
-      else:
-        newshape = out._dense_shape
+            anew = np.zeros(shape=newshape, dtype=out._dtype)
+            for iold, inew in enumerate(binmap):
+                anew[view_ax(inew)] += array[view_ax(iold)]
+            return anew
 
-      anew = np.zeros(shape=newshape, dtype=out._dtype)
-      for iold, inew in enumerate(binmap):
-        anew[view_ax(inew)] += array[view_ax(iold)]
-      return anew
+        for key in self._sumw:
+            out._sumw[key] = dense_op(self._sumw[key])
+            if self._sumw2 is not None:
+                if self._sumw2[key] is not None:
+                    out._sumw2[key] = dense_op(self._sumw2[key])
+                else:
+                    out._sumw2[key] = None
 
-    for key in self._sumw:
-      out._sumw[key] = dense_op(self._sumw[key])
-      if self._sumw2 is not None:
-        if self._sumw2[key] is not None:
-          out._sumw2[key] = dense_op(self._sumw2[key])
-        else:
-          out._sumw2[key] = None
+        return out
 
-    return out
-
-  def values(self, sumw2=False, overflow="none", debug=False):
-    """Extract the sum of weights arrays from this histogram
-    Parameters
-    ----------
+    def values(self, sumw2=False, overflow="none", debug=False):
+        """Extract the sum of weights arrays from this histogram
+        Parameters
+        ----------
         sumw2 : bool
             If True, frequencies is a tuple of arrays (sum weights, sum squared weights)
         overflow
-           See `sum` description for meaning of allowed values
-    
-    Returns a mapping ``{(sparse identifier, ...): numpy.array(...), ...}``
-    where each array has dimension `dense_dim` and shape matching
-    the number of bins per axis, plus 0-3 overflow bins depending
-    on the ``overflow`` argument.
-    """
+            See `sum` description for meaning of allowed values
+        
+        Returns a mapping ``{(sparse identifier, ...): numpy.array(...), ...}``
+        where each array has dimension `dense_dim` and shape matching
+        the number of bins per axis, plus 0-3 overflow bins depending
+        on the ``overflow`` argument.
+        """
 
-    def view_dim(arr):
-      if self.dense_dim() == 0:
-        return arr
-      else:
-        return arr[
-          tuple(coffea.hist.hist_tools.overflow_behavior(overflow) for _ in range(self.dense_dim()))
-        ]
-
-    out = {}
-    for sparse_key in self._sumw.keys():
-      id_key = tuple(ax[k] for ax, k in zip(self.sparse_axes(), sparse_key))
-
-      # Now we have to "pay the piper" an actually calculate bin contents from the bin coefficients
-      # Start by figuring out if this is an EFT bin or not
-      if self.dense_dim() > 0:
-        is_eft_bin = (self._sumw[sparse_key].shape != self._dense_shape)
-      else:
-        is_eft_bin = isinstance(self._sumw[sparse_key],np.ndarray)
-
-      if is_eft_bin:
-        _sumw = efth.calc_eft_weights(self._sumw[sparse_key],self._wcs)
-      else:
-        _sumw = self._sumw[sparse_key]
-
-      if sumw2:
-        if self._sumw2 is not None:
-            if is_eft_bin:
-              if self._sumw2[sparse_key] is not None:
-                _sumw2 = efth.calc_eft_w2(self._sumw2[sparse_key],self._wcs)
-              else:
-                # Set really tiny error bars (e.g. one one-millionth the size of the average bin)
-                _sumw2 = np.full_like(_sumw,1e-30*np.mean(_sumw))
+        def view_dim(arr):
+            if self.dense_dim() == 0:
+                return arr
             else:
-              _sumw2 = self._sumw2[sparse_key]
+                return arr[
+                    tuple(coffea.hist.hist_tools.overflow_behavior(overflow) for _ in range(self.dense_dim()))
+                ]
+
+        out = {}
+        for sparse_key in self._sumw.keys():
+            id_key = tuple(ax[k] for ax, k in zip(self.sparse_axes(), sparse_key))
+
+            # Now we have to "pay the piper" an actually calculate bin contents from the bin coefficients
+            # Start by figuring out if this is an EFT bin or not
+            if self.dense_dim() > 0:
+                is_eft_bin = (self._sumw[sparse_key].shape != self._dense_shape)
+            else:
+                is_eft_bin = isinstance(self._sumw[sparse_key],np.ndarray)
+
+            if is_eft_bin:
+                _sumw = efth.calc_eft_weights(self._sumw[sparse_key],self._wcs)
+            else:
+                _sumw = self._sumw[sparse_key]
+
+            if sumw2:
+                if self._sumw2 is not None:
+                        if is_eft_bin:
+                            if self._sumw2[sparse_key] is not None:
+                                _sumw2 = efth.calc_eft_w2(self._sumw2[sparse_key],self._wcs)
+                            else:
+                                # Set really tiny error bars (e.g. one one-millionth the size of the average bin)
+                                _sumw2 = np.full_like(_sumw,1e-30*np.mean(_sumw))
+                        else:
+                            _sumw2 = self._sumw2[sparse_key]
+                else:
+                    if is_eft_bin:
+                        # Set really tiny error bars (e.g. one one-millionth the size of the average bin)
+                        _sumw2 = np.full_like(_sumw,1e-30*np.mean(_sumw))
+                    else:
+                        _sumw2 = _sumw
+                w2 = view_dim(_sumw2)
+                out[id_key] = (view_dim(_sumw), w2)
+            else:
+                out[id_key] = view_dim(_sumw)
+
+        return out
+
+    def scale(self, factor, axis=None):
+        """Scale histogram in-place by factor
+        Parameters
+        ----------
+        factor : float or dict
+            A number or mapping of identifier to number
+        axis : optional
+            Which (sparse) axis the dict applies to, may be a tuples of axes.
+            The dict keys must follow the same structure.
+        Examples
+        --------
+        This function is useful to quickly reweight according to some
+        weight mapping along a sparse axis, such as the ``species`` axis
+        in the `Hist` example:
+        >>> h.scale({'ducks': 0.3, 'geese': 1.2}, axis='species')
+        >>> h.scale({('ducks',): 0.5}, axis=('species',))
+        >>> h.scale({('geese', 'honk'): 5.0}, axis=('species', 'vocalization'))
+        """
+        if self._sumw2 is None:
+            self._init_sumw2()
+        if isinstance(factor, numbers.Number) and axis is None:
+            for key in self._sumw.keys():
+                self._sumw[key] *= factor
+                if self._sumw2[key] is not None:
+                    self._sumw2[key] *= factor ** 2
+        elif isinstance(factor, dict):
+            if not isinstance(axis, tuple):
+                axis = (axis,)
+                factor = {(k,): v for k, v in factor.items()}
+            axis = tuple(map(self.axis, axis))
+            isparse = list(map(self._isparse, axis))
+            factor = {
+                tuple(a.index(e) for a, e in zip(axis, k)): v for k, v in factor.items()
+            }
+            for key in self._sumw.keys():
+                factor_key = tuple(key[i] for i in isparse)
+                if factor_key in factor:
+                    self._sumw[key] *= factor[factor_key]
+                    if self._sumw2[key] is not None:
+                        self._sumw2[key] *= factor[factor_key] ** 2
+        elif isinstance(factor, numpy.ndarray):
+            axis = self.axis(axis)
+            raise NotImplementedError("Scale dense dimension by a factor")
         else:
-          if is_eft_bin:
-            # Set really tiny error bars (e.g. one one-millionth the size of the average bin)
-            _sumw2 = np.full_like(_sumw,1e-30*np.mean(_sumw))
-          else:
-            _sumw2 = _sumw
-        w2 = view_dim(_sumw2)
-        out[id_key] = (view_dim(_sumw), w2)
-      else:
-        out[id_key] = view_dim(_sumw)
-
-    return out
-
-  def scale(self, factor, axis=None):
-    """Scale histogram in-place by factor
-    Parameters
-    ----------
-      factor : float or dict
-              A number or mapping of identifier to number
-      axis : optional
-             Which (sparse) axis the dict applies to, may be a tuples of axes.
-             The dict keys must follow the same structure.
-    Examples
-    --------
-    This function is useful to quickly reweight according to some
-    weight mapping along a sparse axis, such as the ``species`` axis
-    in the `Hist` example:
-    >>> h.scale({'ducks': 0.3, 'geese': 1.2}, axis='species')
-    >>> h.scale({('ducks',): 0.5}, axis=('species',))
-    >>> h.scale({('geese', 'honk'): 5.0}, axis=('species', 'vocalization'))
-    """
-    if self._sumw2 is None:
-      self._init_sumw2()
-    if isinstance(factor, numbers.Number) and axis is None:
-      for key in self._sumw.keys():
-        self._sumw[key] *= factor
-        if self._sumw2[key] is not None:
-          self._sumw2[key] *= factor ** 2
-    elif isinstance(factor, dict):
-      if not isinstance(axis, tuple):
-        axis = (axis,)
-        factor = {(k,): v for k, v in factor.items()}
-      axis = tuple(map(self.axis, axis))
-      isparse = list(map(self._isparse, axis))
-      factor = {
-        tuple(a.index(e) for a, e in zip(axis, k)): v for k, v in factor.items()
-      }
-      for key in self._sumw.keys():
-        factor_key = tuple(key[i] for i in isparse)
-        if factor_key in factor:
-          self._sumw[key] *= factor[factor_key]
-          if self._sumw2[key] is not None:
-            self._sumw2[key] *= factor[factor_key] ** 2
-    elif isinstance(factor, numpy.ndarray):
-      axis = self.axis(axis)
-      raise NotImplementedError("Scale dense dimension by a factor")
-    else:
-      raise TypeError("Could not interpret scale factor")
+            raise TypeError("Could not interpret scale factor")

--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -3,11 +3,11 @@
  Deals with EFT coefficients. Most common methods of the parent class are redefined in order to account for the EFT coefficients
  The plotting settings are inherited.
 
- Example of initizalization: 
+ Example of initizalization:
     HistEFT("Events", ['c1', 'c2', 'c3'], hist.Cat("sample", "sample"), hist.Cat("cut", "cut"), hist.Bin("met", "MET (GeV)", 40, 0, 400))
 
  TODO: check the group and rebin functions... in particular, the part of grouping/rebinning the coefficients
- TODO: add sum of weights for normalization? 
+ TODO: add sum of weights for normalization?
 """
 
 
@@ -52,9 +52,9 @@ class HistEFT(coffea.hist.Hist):
                 self._sumw2[key] = None
             else:
                 self._sumw2[key] = self._sumw[key].copy()
-                        
+
     def set_wilson_coeff_from_array(self, values):
-        """Set the WC values used to evaluate the bin contents of this histogram to the contents of 
+        """Set the WC values used to evaluate the bin contents of this histogram to the contents of
            an array where the elements are ordered according to the order defined by wcnames.
         """
         self._wcs = np.asarray(values).copy()
@@ -62,7 +62,7 @@ class HistEFT(coffea.hist.Hist):
     def set_sm(self):
         """Conveniece method to set the WC values to SM (all zero)"""
         self._wcs = np.zeros(self._nwc)
-        
+
     def set_wilson_coefficients(self, **values):
         """Set the WC values used to evaluate the bin contents of this histogram
            where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
@@ -257,7 +257,7 @@ class HistEFT(coffea.hist.Hist):
             super().fill(**values)
             return
 
-        # OK then, we're doing this with EFT coefficients.    
+        # OK then, we're doing this with EFT coefficients.
 
         # We want this as a numpy array
         eft_coeff = np.asarray(eft_coeff)
@@ -265,16 +265,16 @@ class HistEFT(coffea.hist.Hist):
         # Check that we have the right number of coefficients
         if self._ncoeffs != eft_coeff.shape[1]:
             raise ValueError(
-                "Wrong number of EFT coefficients.  "+
+                "Wrong number of EFT coefficients.  " +
                 "Expecting {}, received {}".format(self._ncoeffs, eft_coeff.shape[1])
             )
         if eft_err_coeff is not None:
             if self._nerrcoeffs != eft_err_coeff.shape[1]:
                 raise ValueError(
-                    "Wrong number of EFT w*w coefficients.  "+
+                    "Wrong number of EFT w*w coefficients.  " +
                     "Expecting {}, received {}".format(self._nerrcoeffs, eft_err_coeff.shape[1])
                 )
-            
+
         # Next, if there are weights, we should multiply the EFT coefficients by those weights
         if weight is not None:
             eft_coeff = eft_coeff*weight[:,np.newaxis]
@@ -310,7 +310,7 @@ class HistEFT(coffea.hist.Hist):
         # array.  So, we're going to construct flat arrays of which
         # coefficients need to be incremented and then use np.bincount to
         # do the actual summing.
-        if self.dense_dim() > 0: 
+        if self.dense_dim() > 0:
             # repeat the dense indices ncoeffs times to account for the fact
             # that we're filling that many numbers
             dense_indices = tuple(
@@ -339,7 +339,8 @@ class HistEFT(coffea.hist.Hist):
                 xy = np.atleast_1d(
                     np.ravel_multi_index(
                         (*dense_indices,np.tile(np.arange(self._nerrcoeffs),eft_err_coeff.shape[0])),
-                    (*self._dense_shape,self._nerrcoeffs))
+                        (*self._dense_shape,self._nerrcoeffs)
+                    )
                 )
                 self._sumw2[sparse_key] += np.bincount(
                     xy, weights=eft_err_coeff.flatten(),
@@ -377,7 +378,7 @@ class HistEFT(coffea.hist.Hist):
                             # But first we have to know which hist is the EFT one
                             if len(left[lkey].shape) == 2:
                                 # The left hist is the one with eft weights
-                                left[lkey][:,0] = left[lkey][:,0] + right[rkey] 
+                                left[lkey][:,0] = left[lkey][:,0] + right[rkey]
                             elif len(right[rkey].shape) == 2:
                                 # The right hist is the one with eft weights
                                 # So we want left to be equal to left plus right (where left is just added to the SM part of right), without modifying right
@@ -398,16 +399,14 @@ class HistEFT(coffea.hist.Hist):
                     left[lkey] = right[rkey]
                 if right[rkey] is None:
                     pass
-                
 
         # Add the sumw2 values
-        if self._sumw2 is None and other._sumw2 is None: 
+        if self._sumw2 is None and other._sumw2 is None:
             pass
         elif self._sumw2 is None:
             self._init_sumw2()
             add_dict(self._sumw2, other._sumw2)
         elif other._sumw2 is None:
-            
             # This is a tricky case because we want to put in "sumw" for
             # "sumw2" for any non-EFT sparse bins, but None for any EFT
             # sparse bins
@@ -426,12 +425,12 @@ class HistEFT(coffea.hist.Hist):
         # Add the sumw values
         add_dict(self._sumw, other._sumw)
 
-        return self 
+        return self
 
     def __getitem__(self, keys):
         """ Extended from parent class """
         if not isinstance(keys, tuple): keys = (keys,)
-        if len(keys) > self.dim():  raise IndexError("Too many indices for this histogram")
+        if len(keys) > self.dim(): raise IndexError("Too many indices for this histogram")
         elif len(keys) < self.dim():
             if Ellipsis in keys:
                 idx = keys.index(Ellipsis)
@@ -493,7 +492,6 @@ class HistEFT(coffea.hist.Hist):
                     # If either sumw2 value is None, we will set the out sumw2 to None
                     else:
                         out._sumw2[sparse_key] = None
-
             else:
                 out._sumw[sparse_key] = dense_op(self._sumw[sparse_key]).copy()
                 if self._sumw2 is not None:
@@ -504,7 +502,7 @@ class HistEFT(coffea.hist.Hist):
         return out
 
     def sum(self, *axes, **kwargs):
-        """ Integrates out a set of axes, producing a new histogram 
+        """ Integrates out a set of axes, producing a new histogram
                 Project() and integrate() depends on sum() and are heritated """
         overflow = kwargs.pop('overflow', 'none')
         axes = [self.axis(ax) for ax in axes]
@@ -533,10 +531,8 @@ class HistEFT(coffea.hist.Hist):
             return array
 
         for key in self._sumw.keys():
-
             new_key = tuple(k for i, k in enumerate(key) if i not in sparse_drop)
             if new_key in out._sumw:
-
                 # Handle the sumw values
                 # Check if we're trying to combine EFT and non-EFT bins
                 if ((self.dense_dim() > 0) and (out._sumw[new_key].shape != self._sumw[key].shape)):
@@ -560,7 +556,6 @@ class HistEFT(coffea.hist.Hist):
                     raise ValueError("Attempt to sum bins with EFT weights to ones without.")
                 else:
                     out._sumw[new_key] += dense_op(self._sumw[key])
-
                 # Handle the sumw2 values
                 if self._sumw2 is not None:
                     # If neither sumw2 value is None, add them
@@ -598,10 +593,9 @@ class HistEFT(coffea.hist.Hist):
                         out._sumw2[new_key] = dense_op(self._sumw2[key]).copy()
                     else:
                         out._sumw2[new_key] = None
-                            
         return out
 
-    def group(self, old_axes, new_axis, mapping, overflow='none'): 
+    def group(self, old_axes, new_axis, mapping, overflow='none'):
         """ Group a set of slices on old axes into a single new axis """
         ### WARNING: check that this function works properly... (TODO) --> Are the EFT coefficients properly grouped?
         if not isinstance(new_axis, coffea.hist.hist_tools.SparseAxis):
@@ -682,7 +676,7 @@ class HistEFT(coffea.hist.Hist):
             If True, frequencies is a tuple of arrays (sum weights, sum squared weights)
         overflow
             See `sum` description for meaning of allowed values
-        
+
         Returns a mapping ``{(sparse identifier, ...): numpy.array(...), ...}``
         where each array has dimension `dense_dim` and shape matching
         the number of bins per axis, plus 0-3 overflow bins depending
@@ -715,14 +709,14 @@ class HistEFT(coffea.hist.Hist):
 
             if sumw2:
                 if self._sumw2 is not None:
-                        if is_eft_bin:
-                            if self._sumw2[sparse_key] is not None:
-                                _sumw2 = efth.calc_eft_w2(self._sumw2[sparse_key],self._wcs)
-                            else:
-                                # Set really tiny error bars (e.g. one one-millionth the size of the average bin)
-                                _sumw2 = np.full_like(_sumw,1e-30*np.mean(_sumw))
+                    if is_eft_bin:
+                        if self._sumw2[sparse_key] is not None:
+                            _sumw2 = efth.calc_eft_w2(self._sumw2[sparse_key],self._wcs)
                         else:
-                            _sumw2 = self._sumw2[sparse_key]
+                            # Set really tiny error bars (e.g. one one-millionth the size of the average bin)
+                            _sumw2 = np.full_like(_sumw,1e-30*np.mean(_sumw))
+                    else:
+                        _sumw2 = self._sumw2[sparse_key]
                 else:
                     if is_eft_bin:
                         # Set really tiny error bars (e.g. one one-millionth the size of the average bin)
@@ -776,7 +770,7 @@ class HistEFT(coffea.hist.Hist):
                     self._sumw[key] *= factor[factor_key]
                     if self._sumw2[key] is not None:
                         self._sumw2[key] *= factor[factor_key] ** 2
-        elif isinstance(factor, numpy.ndarray):
+        elif isinstance(factor, np.ndarray):
             axis = self.axis(axis)
             raise NotImplementedError("Scale dense dimension by a factor")
         else:

--- a/topcoffea/modules/QuadFitTools.py
+++ b/topcoffea/modules/QuadFitTools.py
@@ -1,11 +1,8 @@
 import os
-from coffea.nanoevents import NanoEventsFactory
 import awkward as ak
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-import topcoffea.modules.fileReader as fr
 
 # Some useful dictionaries (should these go somewhere else?)
 
@@ -80,7 +77,7 @@ ARXIV1901_LIMS = {
     "cQt8" : [-12.0,10.0]
 }
 
-FIT_RANGES = {  
+FIT_RANGES = {
     'ctW':(-4,4),     'ctZ':(-5,5),
     'cpt':(-40,30),   'ctp':(-35,65),
     'ctli':(-10,10),  'ctlSi':(-10,10),
@@ -147,7 +144,7 @@ def make_1d_quad_plot(quad_params_dict,xaxis_name,yaxis_name,title,xaxis_range=[
         # Get the quad fit params from the list
         if len(quad_params) != 3:
             raise Exception(f"Error: Wrong number of parameters specified for 1d quadratic. Require 3, received {len(quad_params)}.")
-        s0 = quad_params[0] 
+        s0 = quad_params[0]
         s1 = quad_params[1]
         s2 = quad_params[2]
 
@@ -168,7 +165,7 @@ def make_1d_quad_plot(quad_params_dict,xaxis_name,yaxis_name,title,xaxis_range=[
         if key_name != "none": tag = key_name + " "
         else: tag = ""
         if key_name in quad_params_dict.keys():
-            s0 = quad_params_dict[key_name][0] 
+            s0 = quad_params_dict[key_name][0]
             s1 = quad_params_dict[key_name][1]
             s2 = quad_params_dict[key_name][2]
             leg_str = get_fit_str(tag+"fit",xaxis_name,s0,s1,s2)
@@ -203,7 +200,7 @@ def get_summed_quad_fit_arr(events):
         raise Exception("Error: This file does not have any EFT fit coefficients.")
 
     # Get array of quad coeffs
-    quad_coeffs_arr = ak.to_numpy(events["EFTfitCoefficients"]) 
+    quad_coeffs_arr = ak.to_numpy(events["EFTfitCoefficients"])
     quad_coeffs_arr = ak.sum(quad_coeffs_arr,axis=0)
 
     return quad_coeffs_arr
@@ -252,7 +249,7 @@ def get_1d_fit(fit_dict,wc):
 def scale_fit_dict(fit_dict,scale_val):
     ret_dict = {}
     for k,v in fit_dict.items():
-       ret_dict[k] = v*scale_val 
+        ret_dict[k] = v*scale_val
     return ret_dict
 
 # Scale all values in a fit to the SM value, returns a new dictionary
@@ -287,7 +284,7 @@ def eval_fit(fit_dict,wcpt_dict):
 # Evaluate a 1d quadratic at a given point
 def eval_1d_quad( quad_params_1d,x):
     if len(quad_params_1d) != 3:
-        raise Exception(f"Error: Wrong number of parameters specified for 1d quadratic. Require 3, received {len(quad_params)}.")
+        raise Exception(f"Error: Wrong number of parameters specified for 1d quadratic. Require 3, received {len(quad_params_1d)}.")
     y = quad_params_1d[0] + quad_params_1d[1]*x + quad_params_1d[2]*x*x
     return y
 
@@ -297,7 +294,7 @@ def find_where_fit_crosses_threshold(quad_params_1d,threshold):
 
     # Get the individual params
     if len(quad_params_1d) != 3:
-        raise Exception(f"Error: Wrong number of parameters specified for 1d quadratic. Require 3, received {len(quad_params)}.")
+        raise Exception(f"Error: Wrong number of parameters specified for 1d quadratic. Require 3, received {len(quad_params_1d)}.")
     s0 = quad_params_1d[0]
     s1 = quad_params_1d[1]
     s2 = quad_params_1d[2]

--- a/topcoffea/modules/YieldTools.py
+++ b/topcoffea/modules/YieldTools.py
@@ -1,10 +1,8 @@
-import json
 import numpy as np
 import copy
 import coffea
 from coffea import hist
 from topcoffea.modules.HistEFT import HistEFT
-from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.GetValuesFromJsons import get_lumi
 import topcoffea.modules.utils as utils
 
@@ -235,7 +233,7 @@ class YieldTools():
     #   - Returns the long (i.e. the name of the category in the smples axis) corresponding to the short name
     def get_long_name(self,long_name_lst_in,short_name_in):
         ret_name = None
-        for long_name in PROC_MAP[short_name_in]:
+        for long_name in self.PROC_MAP[short_name_in]:
             for long_name_in in long_name_lst_in:
                 if long_name_in == long_name:
                     ret_name = long_name
@@ -390,28 +388,28 @@ class YieldTools():
                 is_a_jet_str = True
             return is_a_jet_str
 
-        # Assumes the str is separated by underscores 
+        # Assumes the str is separated by underscores
         str_components_lst = in_str.split("_")
         keep_lst = []
         for component in str_components_lst:
             if not is_jet_str(component):
                 keep_lst.append(component)
         ret_str  = "_".join(keep_lst)
-        return(ret_str)
+        return (ret_str)
 
 
     # Remove the lepflav component of a category name, returns a new str
     def get_str_without_lepflav(self,in_str):
         # The list of lep flavors we consider (this is a bit hardcoded...)
         lepflav_lst = ["ee","em","mm","eee","eem","emm","mmm"]
-        # Assumes the str is separated by underscores 
+        # Assumes the str is separated by underscores
         str_components_lst = in_str.split("_")
         keep_lst = []
         for component in str_components_lst:
             if not component in lepflav_lst:
                 keep_lst.append(component)
         ret_str  = "_".join(keep_lst)
-        return(ret_str)
+        return (ret_str)
 
 
     # This should return true if the hist is split by lep flavor, definitely not a bullet proof check..
@@ -461,7 +459,7 @@ class YieldTools():
         else:
             print("Already integrated out the appl axis. Continuing...")
         return histo_integrated
-            
+
 
     # Get the difference between values in nested dictionary, currently can get either percent diff, or absolute diff
     # Returns a dictionary in the same format (currently does not propagate errors, just returns None)
@@ -513,7 +511,7 @@ class YieldTools():
             # Should not be here unless "UL16APV" not in sample_name
             lumi = 1000.0*get_lumi("2016")
         else:
-            raise Exception(f"Error: Unknown year \"{year}\".")
+            raise Exception(f"Error: Unknown year for \"{sample_name}\".")
         return lumi
 
 
@@ -568,7 +566,7 @@ class YieldTools():
 
     ######### Functions specifically for getting yields #########
 
-    # Sum all the values of a hist 
+    # Sum all the values of a hist
     #    - The hist you pass should have two axes (all other should already be integrated out)
     #    - The two axes should be the samples axis, and the dense axis (e.g. ht)
     #    - You pass a process name, and we select just that category from the sample axis
@@ -596,7 +594,7 @@ class YieldTools():
 
         # Reweight the hist
         if rwgt_pt is not None:
-            hist.set_wilson_coefficients(**wc_vals)
+            hist.set_wilson_coefficients(**rwgt_pt)
         else:
             h.set_sm()
 
@@ -744,7 +742,7 @@ class YieldTools():
                 else:
                     out_vals[subk][0] = out_vals[subk][0] + in_dict[k][subk][0]
         return out_vals
-    
+
     # This function
     #   - Takes as input a yld_dict
     #   - Combines the bkg processes (e.g. combine all diboson processes)

--- a/topcoffea/modules/comp_datacard.py
+++ b/topcoffea/modules/comp_datacard.py
@@ -1,7 +1,6 @@
-import json
 import argparse
 import re
- 
+
 tolerance = 0.5e-5
 
 '''
@@ -72,14 +71,14 @@ def comp_datacard_dict(wc1, wc2):
 def comp_datacard(fin1, fin2):
     wc1,_ = strip(fin1)
     wc2,_ = strip(fin2)
-    
+
     return comp_datacard_dict(wc1,wc2)
 
 if __name__ == '__main__':
- 
+
     parser = argparse.ArgumentParser(description='You can select which file to run over')
     parser.add_argument('fin1'           , nargs='?', default=''           , help = 'First input file')
     parser.add_argument('fin2'           , nargs='?', default=''           , help = 'Second input file')
     args = parser.parse_args()
-    
+
     comp_datacard(args.fin1, args.fin2)

--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -160,7 +160,7 @@ def AttachPerLeptonFR(leps, flavor, year):
     if year == '2018':
         leps['fakefactor_elclosurefactor'] = (np.abs(leps.pdgId)==11) * ((np.abs(leps.eta) > 1.5)*0.5 + (np.abs(leps.eta) < 1.5)*0.1) + 1.0
         leps['fakefactor_muclosurefactor'] = (np.abs(leps.pdgId)==13)*0.05 + 1.0
-  
+
     for flav in ['el','mu']:
         leps['fakefactor_%sclosuredown' % flav] = leps['fakefactor'] / leps['fakefactor_%sclosurefactor' % flav]
         leps['fakefactor_%sclosureup' % flav]   = leps['fakefactor'] * leps['fakefactor_%sclosurefactor' % flav]
@@ -202,8 +202,8 @@ def AttachMuonSF(muons, year):
     reco_err = np.where(pt < 20,SFevaluator['MuonRecoSF_{year}_er'.format(year=year)](eta,pt),0) # sf error =0 when pt>20 becuase there is no reco SF available
     loose_sf  = SFevaluator['MuonLooseSF_{year}'.format(year=year)](eta,pt)
     loose_err = np.sqrt(
-        SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt)
-        + SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt)
+        SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) +
+        SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt)
     )
     iso_sf  = SFevaluator['MuonIsoSF_{year}'.format(year=year)](eta,pt)
     iso_err = SFevaluator['MuonIsoSF_{year}_er'.format(year=year)](eta,pt)
@@ -485,7 +485,7 @@ def AttachPSWeights(events):
     ISRup = 2
     FSRup = 3
     if events.PSWeight is None:
-        raise Exception(f'PSWeight not!')
+        raise Exception('PSWeight not found!')
     # Add up variation event weights
     events['ISRUp'] = events.PSWeight[:, ISRup]
     events['FSRUp'] = events.PSWeight[:, FSRup]
@@ -558,7 +558,7 @@ def AttachPdfWeights(events):
         Should be 100 weights for NNPDF 3.1
     '''
     if events.LHEPdfWeight is None:
-        raise Exception(f'LHEPdfWeight not found!')
+        raise Exception('LHEPdfWeight not found!')
     pdf_weight = ak.Array(events.LHEPdfWeight)
     #events['Pdf'] = ak.Array(events.nLHEPdfWeight) # FIXME not working
 

--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -6,13 +6,11 @@
 #import uproot, uproot_methods
 import uproot
 from coffea import hist, lookup_tools
-import os, sys
 from topcoffea.modules.paths import topcoffea_path
 import numpy as np
 import awkward as ak
 import gzip
 import pickle
-from coffea.jetmet_tools import FactorizedJetCorrector, JetCorrectionUncertainty
 from coffea.jetmet_tools import JECStack, CorrectedJetsFactory, CorrectedMETFactory
 from coffea.btag_tools.btagscalefactor import BTagScaleFactor
 from topcoffea.modules.GetValuesFromJsons import get_param

--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -118,7 +118,7 @@ extLepSF.add_weight_sets(["ElecSF_2016APV_2lss_er EGamma_SF2D_error %s" % topcof
 extLepSF.add_weight_sets(["ElecSF_2016APV_3l EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_3l_EGM2D.root')])
 extLepSF.add_weight_sets(["ElecSF_2016APV_3l_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_3l_EGM2D.root')])
 
-# Fake rate 
+# Fake rate
 for year in ['2016APV_2016', 2017, 2018]:
     for syst in ['','_up','_down','_be1','_be2','_pt1','_pt2']:
         extLepSF.add_weight_sets([("MuonFR_{year}{syst} FR_mva085_mu_data_comb_recorrected{syst} %s" % topcoffea_path(basepathFromTTH + 'fakerate/fr_{year}_recorrected.root')).format(year=year,syst=syst)])
@@ -160,10 +160,10 @@ def AttachPerLeptonFR(leps, flavor, year):
     if year == '2018':
         leps['fakefactor_elclosurefactor'] = (np.abs(leps.pdgId)==11) * ((np.abs(leps.eta) > 1.5)*0.5 + (np.abs(leps.eta) < 1.5)*0.1) + 1.0
         leps['fakefactor_muclosurefactor'] = (np.abs(leps.pdgId)==13)*0.05 + 1.0
-      
+  
     for flav in ['el','mu']:
-        leps['fakefactor_%sclosuredown' % flav] = leps['fakefactor'] / leps['fakefactor_%sclosurefactor' % flav] 
-        leps['fakefactor_%sclosureup' % flav]   = leps['fakefactor'] * leps['fakefactor_%sclosurefactor' % flav] 
+        leps['fakefactor_%sclosuredown' % flav] = leps['fakefactor'] / leps['fakefactor_%sclosurefactor' % flav]
+        leps['fakefactor_%sclosureup' % flav]   = leps['fakefactor'] * leps['fakefactor_%sclosurefactor' % flav]
 
     if flavor == "Elec":
         leps['fliprate'] = (chargeflip_sf)*(flip_lookup(leps.pt,abs(leps.eta)))
@@ -172,14 +172,14 @@ def AttachPerLeptonFR(leps, flavor, year):
 
 def fakeRateWeight2l(events, lep1, lep2):
     for syst in ffSysts+['_elclosureup','_elclosuredown','_muclosureup','_muclosuredown']:
-        fakefactor_2l = -1*(~lep1.isTightLep | ~lep2.isTightLep) + 1*(lep1.isTightLep & lep2.isTightLep) # if all are tight the FF is 1 because events are in the SR 
+        fakefactor_2l = -1*(~lep1.isTightLep | ~lep2.isTightLep) + 1*(lep1.isTightLep & lep2.isTightLep) # if all are tight the FF is 1 because events are in the SR
         fakefactor_2l = fakefactor_2l * (lep1.isTightLep + (~lep1.isTightLep) * getattr(lep1,'fakefactor%s' % syst))
         fakefactor_2l = fakefactor_2l * (lep2.isTightLep + (~lep2.isTightLep) * getattr(lep2,'fakefactor%s' % syst))
         events['fakefactor_2l%s' % syst] = fakefactor_2l
     # Calculation of flip factor: flip_factor_2l = 1*(isSS) + (fliprate1 + fliprate2)*(isOS):
     #     - For SS events = 1
     #     - For OS events = (fliprate1 + fliprate2)
-    events['flipfactor_2l'] = 1*((lep1.charge + lep2.charge) != 0) + (((lep1.fliprate + lep2.fliprate)) * ((lep1.charge + lep2.charge) == 0)) # only apply fliprate for OS events. to handle the OS control regions later :) #  + 
+    events['flipfactor_2l'] = 1*((lep1.charge + lep2.charge) != 0) + (((lep1.fliprate + lep2.fliprate)) * ((lep1.charge + lep2.charge) == 0)) # only apply fliprate for OS events. to handle the OS control regions later :)
 
 def fakeRateWeight3l(events, lep1, lep2, lep3):
     for syst in ffSysts+['_elclosureup','_elclosuredown','_muclosureup','_muclosuredown'] :
@@ -198,12 +198,12 @@ def AttachMuonSF(muons, year):
     eta = np.abs(muons.eta)
     pt = muons.pt
     if year not in ['2016','2016APV','2017','2018']: raise Exception(f"Error: Unknown year \"{year}\".")
-    reco_sf  = np.where(pt < 20,SFevaluator['MuonRecoSF_{year}'.format(year=year)](eta,pt),1) #sf=1 when pt>20 becuase there is no reco SF available
-    reco_err = np.where(pt < 20,SFevaluator['MuonRecoSF_{year}_er'.format(year=year)](eta,pt),0) #sf error =0 when pt>20 becuase there is no reco SF available
+    reco_sf  = np.where(pt < 20,SFevaluator['MuonRecoSF_{year}'.format(year=year)](eta,pt),1) # sf=1 when pt>20 becuase there is no reco SF available
+    reco_err = np.where(pt < 20,SFevaluator['MuonRecoSF_{year}_er'.format(year=year)](eta,pt),0) # sf error =0 when pt>20 becuase there is no reco SF available
     loose_sf  = SFevaluator['MuonLooseSF_{year}'.format(year=year)](eta,pt)
     loose_err = np.sqrt(
-        SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) +
-        SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt)
+        SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt)
+        + SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt)
     )
     iso_sf  = SFevaluator['MuonIsoSF_{year}'.format(year=year)](eta,pt)
     iso_err = SFevaluator['MuonIsoSF_{year}_er'.format(year=year)](eta,pt)
@@ -234,7 +234,7 @@ def AttachElectronSF(electrons, year):
 
     if year not in ['2016','2016APV','2017','2018']:
         raise Exception(f"Error: Unknown year \"{year}\".")
-  
+
     reco_sf  = np.where(
         pt < 20,
         SFevaluator['ElecRecoSFBe_{year}'.format(year=year)](eta,pt),
@@ -313,14 +313,14 @@ def GetBtagEff(jets, year, wp='medium'):
         raise Exception(f"Error: Unknown year \"{year}\".")
     return GetMCeffFunc(year,wp)(jets.pt, np.abs(jets.eta), jets.hadronFlavour)
 
-def GetBTagSF(jets, year, wp='MEDIUM', sys='central'):
-    if   year == '2016': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/DeepJet_106XUL16postVFPSF_v2.csv"),wp) 
-    elif year == '2016APV': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL16preVFP_v2.csv"),wp) 
+def GetBTagSF(jets, year, wp='MEDIUM', syst='central'):
+    if   year == '2016': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/DeepJet_106XUL16postVFPSF_v2.csv"),wp)
+    elif year == '2016APV': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL16preVFP_v2.csv"),wp)
     elif year == '2017': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL17_v3.csv"),wp)
     elif year == '2018': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL18_v2.csv"),wp)
     else: raise Exception(f"Error: Unknown year \"{year}\".")
 
-    pt = jets.pt; abseta = np.abs(jets.eta)
+    pt = jets.pt
     SF = SFevaluatorBtag.eval('central',jets.hadronFlavour,np.abs(jets.eta),jets.pt)
 
     # Workaround: For UL16, use the SFs from the UL16APV for light flavor jets
@@ -330,7 +330,7 @@ def GetBTagSF(jets, year, wp='MEDIUM', sys='central'):
         SF_UL16APV = SFevaluatorBtag_UL16APV.eval('central',jets.hadronFlavour,np.abs(jets.eta),jets.pt)
         SF = ak.where(had_flavor == 0,SF_UL16APV,SF)
 
-    if sys == 'central':    
+    if syst == 'central':
         # If we are just getting the central, return here
         return (SF)
     else:
@@ -340,60 +340,60 @@ def GetBTagSF(jets, year, wp='MEDIUM', sys='central'):
             4: ["bc_corr",f"bc_{year}"],
             5: ["bc_corr",f"bc_{year}"]
         }
-        jets[f"btag_{sys}_up"] = SF
-        jets[f"btag_{sys}_down"] = SF
+        jets[f"btag_{syst}_up"] = SF
+        jets[f"btag_{syst}_down"] = SF
         for f, f_syst in flavors.items():
-            if sys in f_syst:
+            if syst in f_syst:
                 # Workaround: For UL16, use the SFs from the UL16APV for light flavor jets
                 if (f == 0) and (year == "2016"):
-                    if f"{year}" in sys:
-                        jets[f"btag_{sys}_up"] = np.where(
+                    if f"{year}" in syst:
+                        jets[f"btag_{syst}_up"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag_UL16APV.eval("up_uncorrelated",jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_up"]
+                            jets[f"btag_{syst}_up"]
                         )
-                        jets[f"btag_{sys}_down"] = np.where(
+                        jets[f"btag_{syst}_down"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag_UL16APV.eval("down_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_down"]
+                            jets[f"btag_{syst}_down"]
                         )
                     else:
-                        jets[f"btag_{sys}_up"] = np.where(
+                        jets[f"btag_{syst}_up"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag_UL16APV.eval("up_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_up"]
+                            jets[f"btag_{syst}_up"]
                         )
-                        jets[f"btag_{sys}_down"] = np.where(
+                        jets[f"btag_{syst}_down"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag_UL16APV.eval("down_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_down"]
+                            jets[f"btag_{syst}_down"]
                         )
                 # Otherwise, proceed as usual
                 else:
-                    if f"{year}" in sys:
-                        jets[f"btag_{sys}_up"] = np.where(
+                    if f"{year}" in syst:
+                        jets[f"btag_{syst}_up"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag.eval("up_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_up"]
+                            jets[f"btag_{syst}_up"]
                         )
-                        jets[f"btag_{sys}_down"] = np.where(
+                        jets[f"btag_{syst}_down"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag.eval("down_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_down"]
+                            jets[f"btag_{syst}_down"]
                         )
                     else:
-                        jets[f"btag_{sys}_up"] = np.where(
+                        jets[f"btag_{syst}_up"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag.eval("up_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_up"]
+                            jets[f"btag_{syst}_up"]
                         )
-                        jets[f"btag_{sys}_down"] = np.where(
+                        jets[f"btag_{syst}_down"] = np.where(
                             abs(jets.hadronFlavour) == f,
                             SFevaluatorBtag.eval("down_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
-                            jets[f"btag_{sys}_down"]
+                            jets[f"btag_{syst}_down"]
                         )
-    return ([jets[f"btag_{sys}_up"],jets[f"btag_{sys}_down"]])
- 
+    return ([jets[f"btag_{syst}_up"],jets[f"btag_{syst}_down"]])
+
 ###### Pileup reweighing
 ##############################################
 ## Get central PU data and MC profiles and calculate reweighting
@@ -458,7 +458,7 @@ for year in ['2016', '2016APV', '2017', '2018']:
 def GetPUSF(nTrueInt, year, var='nominal'):
     year = str(year)
     if year not in ['2016','2016APV','2017','2018']:
-      raise Exception(f"Error: Unknown year \"{year}\".")
+        raise Exception(f"Error: Unknown year \"{year}\".")
     nMC = PUfunc[year]['MC'](nTrueInt+1)
     data_dir = 'Data'
     if var == 'up':
@@ -485,7 +485,7 @@ def AttachPSWeights(events):
     ISRup = 2
     FSRup = 3
     if events.PSWeight is None:
-        raise Exception(f'PSWeight not found in {fname}!')
+        raise Exception(f'PSWeight not!')
     # Add up variation event weights
     events['ISRUp'] = events.PSWeight[:, ISRup]
     events['FSRUp'] = events.PSWeight[:, FSRup]
@@ -522,7 +522,7 @@ def AttachScaleWeights(events):
     all_len_9_or_0_bool = ak.all((len_of_wgts==9) | (len_of_wgts==0))
     all_len_8_or_0_bool = ak.all((len_of_wgts==8) | (len_of_wgts==0))
     if all_len_9_or_0_bool:
-        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 9), 1) # FIXME this is a bandaid until we understand _why_ some are empty 
+        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 9), 1) # FIXME this is a bandaid until we understand _why_ some are empty
         renormDown_factDown = 0
         renormDown          = 1
         renormDown_factUp   = 2
@@ -533,7 +533,7 @@ def AttachScaleWeights(events):
         renormUp            = 7
         renormUp_factUp     = 8
     elif all_len_8_or_0_bool:
-        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 8), 1) # FIXME this is a bandaid until we understand _why_ some are empty 
+        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 8), 1) # FIXME this is a bandaid until we understand _why_ some are empty
         renormDown_factDown = 0
         renormDown          = 1
         renormDown_factUp   = 2
@@ -543,7 +543,7 @@ def AttachScaleWeights(events):
         renormUp            = 6
         renormUp_factUp     = 7
     else:
-        raise Exception(f"Unknown weight type")
+        raise Exception("Unknown weight type")
     # Get the weights from the event
     events['renormfactDown'] = scale_weights[:,renormDown_factDown]
     events['renormDown']     = scale_weights[:,renormDown]
@@ -558,11 +558,11 @@ def AttachPdfWeights(events):
         Should be 100 weights for NNPDF 3.1
     '''
     if events.LHEPdfWeight is None:
-        raise Exception(f'LHEPdfWeight not found in {fname}!')
+        raise Exception(f'LHEPdfWeight not found!')
     pdf_weight = ak.Array(events.LHEPdfWeight)
     #events['Pdf'] = ak.Array(events.nLHEPdfWeight) # FIXME not working
 
-####### JEC 
+####### JEC
 ##############################################
 # JER: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution
 # JES: https://twiki.cern.ch/twiki/bin/view/CMS/JECDataMC
@@ -604,7 +604,7 @@ def ApplyJetCorrections(year, corr_type):
     jec_names.extend(jec_regroup)
     extJEC.finalize()
     JECevaluator = extJEC.make_evaluator()
-    jec_inputs = {name: JECevaluator[name] for name in jec_names} 
+    jec_inputs = {name: JECevaluator[name] for name in jec_names}
     jec_stack = JECStack(jec_inputs)
     name_map = jec_stack.blank_name_map
     name_map['JetPt'] = 'pt'
@@ -728,15 +728,16 @@ def GetClopperPearsonInterval(hnum, hden):
             den[i] = np.array(StackOverUnderflow(list(den[i])), dtype=float)
         den = StackOverUnderflow(den)
         num = StackOverUnderflow(num)
-    else: 
+    else:
         num = np.array(StackOverUnderflow(num), dtype=float)
         den = np.array(StackOverUnderflow(den), dtype=float)
-    num = np.array(num); den = np.array(den)
-    num[num>den] = den[num>den]
+    num = np.array(num)
+    den = np.array(den)
+    num[num>den] = den[num > den]
     down, up = hist.clopper_pearson_interval(num, den)
     ratio = np.array(num, dtype=float) / den
     return [ratio, down, up]
-  
+
 def GetEff(num, den):
     ''' Compute efficiency values from numerator and denominator histograms '''
     ratio, down, up = GetClopperPearsonInterval(num, den)
@@ -753,12 +754,12 @@ def GetSFfromCountsHisto(hnumMC, hdenMC, hnumData, hdenData):
     Xda, Yda = GetEff(hnumData, hdenData)
     ratio, do, up = GetRatioAssymetricUncertainties(Yda[0], Yda[1], Yda[2], Ymc[0], Ymc[1], Ymc[2])
     return ratio, do, up
-    
+
 def GetRatioAssymetricUncertainties(num, numDo, numUp, den, denDo, denUp):
     ''' Compute efficiencies from numerator and denominator counts histograms and uncertainties '''
     ratio = num / den
-    uncUp = ratio * np.sqrt(numUp * numUp + denUp * denUp) 
-    uncDo = ratio * np.sqrt(numDo * numDo + denDo * denDo) 
+    uncUp = ratio * np.sqrt(numUp * numUp + denUp * denUp)
+    uncDo = ratio * np.sqrt(numDo * numDo + denDo * denDo)
     return ratio, -uncDo, uncUp
 
 ######  Scale Factors
@@ -798,6 +799,6 @@ def GetTriggerSF(year, events, lep0, lep1):
         '''
         ls.append(SF_ee * SF_em * SF_mm)
     ls[1] = np.where(ls[1] == 1.0, 0.0, ls[1]) # stat unc. down
-    events['trigger_sf'] = ls[0] #nominal
+    events['trigger_sf'] = ls[0] # nominal
     events['trigger_sfDown'] = ls[0] - np.sqrt(ls[1] * ls[1] + ls[0]*0.02*ls[0]*0.02)
-    events['trigger_sfUp'] = ls[0] + np.sqrt(ls[1] * ls[1] + ls[0]*0.02*ls[0]*0.02) 
+    events['trigger_sfUp'] = ls[0] + np.sqrt(ls[1] * ls[1] + ls[0]*0.02*ls[0]*0.02)

--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -26,244 +26,246 @@ extLepSF = lookup_tools.extractor()
 
 # New UL Lepton SFs
 # Muon: reco
-extLepSF.add_weight_sets(["MuonRecoSF_2018 NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2018_UL_trackerMuon.json')])
-extLepSF.add_weight_sets(["MuonRecoSF_2018_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2018_UL_trackerMuon.json')])
-extLepSF.add_weight_sets(["MuonRecoSF_2017 NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2017_UL_trackerMuon.json')])
-extLepSF.add_weight_sets(["MuonRecoSF_2017_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2017_UL_trackerMuon.json')])
-extLepSF.add_weight_sets(["MuonRecoSF_2016 NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016postVFP_UL_trackerMuon.json')])
-extLepSF.add_weight_sets(["MuonRecoSF_2016_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016postVFP_UL_trackerMuon.json')])
-extLepSF.add_weight_sets(["MuonRecoSF_2016APV NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016preVFP_UL_trackerMuon.json')])
-extLepSF.add_weight_sets(["MuonRecoSF_2016APV_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s"%topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016preVFP_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2018 NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2018_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2018_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2018_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2017 NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2017_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2017_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2017_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2016 NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016postVFP_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2016_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016postVFP_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2016APV NUM_TrackerMuons_DEN_genTracks/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016preVFP_UL_trackerMuon.json')])
+extLepSF.add_weight_sets(["MuonRecoSF_2016APV_er NUM_TrackerMuons_DEN_genTracks/abseta_pt_error %s" % topcoffea_path('data/leptonSF/muon/Efficiency_muon_generalTracks_Run2016preVFP_UL_trackerMuon.json')])
 # Muon: loose POG
-extLepSF.add_weight_sets(["MuonLooseSF_2018 NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2018_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2018_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2017 NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2017_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2017_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2016 NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2016_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2016_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2016APV NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2016APV_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.json')])
-extLepSF.add_weight_sets(["MuonLooseSF_2016APV_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s"%topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2018 NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2018_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2018_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2017 NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2017_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2017_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2016 NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2016_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2016_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2016APV NUM_LooseID_DEN_TrackerMuons/abseta_pt_value %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2016APV_stat NUM_LooseID_DEN_TrackerMuons/abseta_pt_stat %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.json')])
+extLepSF.add_weight_sets(["MuonLooseSF_2016APV_syst NUM_LooseID_DEN_TrackerMuons/abseta_pt_syst %s" % topcoffea_path('data/leptonSF/muon/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.json')])
 # Muon: ISO + IP (Barbara)
-extLepSF.add_weight_sets(["MuonIsoSF_2018 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2018_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonIsoSF_2018_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2018_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonIsoSF_2017_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2017_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonIsoSF_2017 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2017_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonIsoSF_2016_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonIsoSF_2016 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonIsoSF_2016APV_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonIsoSF_2016APV EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2018 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2018_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2018_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2018_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2017_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2017_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2017 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2017_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2016_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2016 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2016APV_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonIsoSF_2016APV EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_iso_EGM2D.root')])
 # Muon: looseMVA&tight (Barbara)
-extLepSF.add_weight_sets(["MuonSF_2018 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2018_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonSF_2018_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2018_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonSF_2017_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2017_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonSF_2017 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2017_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonSF_2016_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonSF_2016 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonSF_2016APV_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_EGM2D.root')])
-extLepSF.add_weight_sets(["MuonSF_2016APV EGamma_SF2D %s"%topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2018 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2018_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2018_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2018_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2017_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2017_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2017 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2017_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2016_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2016 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2016APV_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_EGM2D.root')])
+extLepSF.add_weight_sets(["MuonSF_2016APV EGamma_SF2D %s" % topcoffea_path('data/leptonSF/muon/egammaEffi2016APV_EGM2D.root')])
 # Elec: reco
-extLepSF.add_weight_sets(["ElecRecoSFAb_2018 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFAb_2018_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2018 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptBelow20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2018_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptBelow20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFAb_2017 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFAb_2017_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2017 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptBelow20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2017_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptBelow20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFAb_2016 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFAb_2016_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2016 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptBelow20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2016_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptBelow20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFAb_2016APV EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFAb_2016APV_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptAbove20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2016APV EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptBelow20_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecRecoSFBe_2016APV_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2018 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2018_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2018 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2018_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2017 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2017_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2017 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2017_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2016 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2016_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2016 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2016_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2016APV EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFAb_2016APV_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptAbove20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2016APV EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptBelow20_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecRecoSFBe_2016APV_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_ptBelow20_EGM2D.root')])
 # Elec: loose (Barbara)
-extLepSF.add_weight_sets(["ElecLooseSF_2018 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_recoToloose_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecLooseSF_2018_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_recoToloose_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecLooseSF_2017_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_recoToloose_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecLooseSF_2017 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_recoToloose_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecLooseSF_2016_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_recoToloose_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecLooseSF_2016 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_recoToloose_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecLooseSF_2016APV_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_recoToloose_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecLooseSF_2016APV EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2018 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2018_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2017_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2017 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2016_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2016 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2016APV_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_recoToloose_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecLooseSF_2016APV EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_recoToloose_EGM2D.root')])
 # Elec: ISO + IP (Barbara)
-extLepSF.add_weight_sets(["ElecIsoSF_2018 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecIsoSF_2018_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecIsoSF_2017_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecIsoSF_2017 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecIsoSF_2016_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecIsoSF_2016 EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecIsoSF_2016APV_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_iso_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecIsoSF_2016APV EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2018 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2018_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2017_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2017 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2016_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2016 EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2016APV_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_iso_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecIsoSF_2016APV EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_iso_EGM2D.root')])
 # Elec: looseMVA&tight (Barbara)
-extLepSF.add_weight_sets(["ElecSF_2018_2lss EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2018_2lss_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2018_3l EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_3l_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2018_3l_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2018_3l_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2017_2lss EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2017_2lss_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2017_3l EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_3l_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2017_3l_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2017_3l_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016_2lss EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016_2lss_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016_3l EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_3l_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016_3l_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016_3l_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016APV_2lss EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016APV_2lss_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_2lss_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016APV_3l EGamma_SF2D %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_3l_EGM2D.root')])
-extLepSF.add_weight_sets(["ElecSF_2016APV_3l_er EGamma_SF2D_error %s"%topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2018_2lss EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2018_2lss_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2018_3l EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2018_3l_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2018_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2017_2lss EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2017_2lss_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2017_3l EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2017_3l_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2017_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016_2lss EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016_2lss_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016_3l EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016_3l_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016APV_2lss EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016APV_2lss_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_2lss_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016APV_3l EGamma_SF2D %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_3l_EGM2D.root')])
+extLepSF.add_weight_sets(["ElecSF_2016APV_3l_er EGamma_SF2D_error %s" % topcoffea_path('data/leptonSF/elec/egammaEffi2016APV_3l_EGM2D.root')])
 
 # Fake rate 
 for year in ['2016APV_2016', 2017, 2018]:
-  for syst in ['','_up','_down','_be1','_be2','_pt1','_pt2']:
-    extLepSF.add_weight_sets([("MuonFR_{year}{syst} FR_mva085_mu_data_comb_recorrected{syst} %s"%topcoffea_path(basepathFromTTH+'fakerate/fr_{year}_recorrected.root')).format(year=year,syst=syst)])
-    extLepSF.add_weight_sets([("ElecFR_{year}{syst} FR_mva090_el_data_comb_NC_recorrected{syst} %s"%topcoffea_path(basepathFromTTH+'fakerate/fr_{year}_recorrected.root')).format(year=year,syst=syst)])
-
+    for syst in ['','_up','_down','_be1','_be2','_pt1','_pt2']:
+        extLepSF.add_weight_sets([("MuonFR_{year}{syst} FR_mva085_mu_data_comb_recorrected{syst} %s" % topcoffea_path(basepathFromTTH + 'fakerate/fr_{year}_recorrected.root')).format(year=year,syst=syst)])
+        extLepSF.add_weight_sets([("ElecFR_{year}{syst} FR_mva090_el_data_comb_NC_recorrected{syst} %s" % topcoffea_path(basepathFromTTH + 'fakerate/fr_{year}_recorrected.root')).format(year=year,syst=syst)])
 
 extLepSF.finalize()
 SFevaluator = extLepSF.make_evaluator()
 
-
 ffSysts=['','_up','_down','_be1','_be2','_pt1','_pt2']
 def AttachPerLeptonFR(leps, flavor, year):
+    # Get the flip rates lookup object
+    if year == "2016APV": flip_year_name = "UL16APV"
+    elif year == "2016": flip_year_name = "UL16"
+    elif year == "2017": flip_year_name = "UL17"
+    elif year == "2018": flip_year_name = "UL18"
+    else: raise Exception(f"Not a known year: {year}")
+    with gzip.open(topcoffea_path(f"data/fliprates/flip_probs_topcoffea_{flip_year_name}.pkl.gz")) as fin:
+        flip_hist = pickle.load(fin)
+        flip_lookup = lookup_tools.dense_lookup.dense_lookup(flip_hist.values()[()],[flip_hist.axis("pt").edges(),flip_hist.axis("eta").edges()])
 
-  # Get the flip rates lookup object
-  if year == "2016APV": flip_year_name = "UL16APV"
-  elif year == "2016": flip_year_name = "UL16"
-  elif year == "2017": flip_year_name = "UL17"
-  elif year == "2018": flip_year_name = "UL18"
-  else: raise Exception(f"Not a known year: {year}")
-  with gzip.open(topcoffea_path(f"data/fliprates/flip_probs_topcoffea_{flip_year_name}.pkl.gz")) as fin:
-    flip_hist = pickle.load(fin)
-    flip_lookup = lookup_tools.dense_lookup.dense_lookup(flip_hist.values()[()],[flip_hist.axis("pt").edges(),flip_hist.axis("eta").edges()])
+    # Get the fliprate scaling factor for the given year
+    chargeflip_sf = get_param("chargeflip_sf_dict")[flip_year_name]
 
-  # Get the fliprate scaling factor for the given year
-  chargeflip_sf = get_param("chargeflip_sf_dict")[flip_year_name]
+    # For FR filepath naming conventions
+    if '2016' in year:
+        year = '2016APV_2016'
 
-  # For FR filepath naming conventions
-  if '2016' in year:
-    year = '2016APV_2016'
+    # Add the flip/fake info into the leps opject
+    for syst in ffSysts:
+        fr = SFevaluator['{flavor}FR_{year}{syst}'.format(flavor=flavor,year=year,syst=syst)](leps.conept, np.abs(leps.eta) )
+        leps['fakefactor%s' % syst] = ak.fill_none(-fr/(1-fr),0) # this is the factor that actually enters the expressions
 
-    
+    if year == '2016APV_2016':
+        leps['fakefactor_elclosurefactor'] = (np.abs(leps.pdgId)==11) * ((np.abs(leps.eta) > 1.5)*0.5 + (np.abs(leps.eta) < 1.5)*0.1) + 1.0
+        leps['fakefactor_muclosurefactor'] = (np.abs(leps.pdgId)==13)*0.05 + 1.0
+    if year == '2017':
+        leps['fakefactor_elclosurefactor'] = (np.abs(leps.pdgId)==11)*0.2 + 1.0
+        leps['fakefactor_muclosurefactor'] = (np.abs(leps.pdgId)==13)*0.2 + 1.0
+    if year == '2018':
+        leps['fakefactor_elclosurefactor'] = (np.abs(leps.pdgId)==11) * ((np.abs(leps.eta) > 1.5)*0.5 + (np.abs(leps.eta) < 1.5)*0.1) + 1.0
+        leps['fakefactor_muclosurefactor'] = (np.abs(leps.pdgId)==13)*0.05 + 1.0
+      
+    for flav in ['el','mu']:
+        leps['fakefactor_%sclosuredown' % flav] = leps['fakefactor'] / leps['fakefactor_%sclosurefactor' % flav] 
+        leps['fakefactor_%sclosureup' % flav]   = leps['fakefactor'] * leps['fakefactor_%sclosurefactor' % flav] 
 
-  # Add the flip/fake info into the leps opject
-  for syst in ffSysts:
-    fr=SFevaluator['{flavor}FR_{year}{syst}'.format(flavor=flavor,year=year,syst=syst)](leps.conept, np.abs(leps.eta) )
-    leps['fakefactor%s'%syst]=ak.fill_none(-fr/(1-fr),0) # this is the factor that actually enters the expressions
-
-  if year == '2016APV_2016':
-    leps['fakefactor_elclosurefactor']=(np.abs(leps.pdgId)==11)*( (np.abs(leps.eta) > 1.5)*0.5 + (np.abs(leps.eta) < 1.5)*0.1) + 1.0
-    leps['fakefactor_muclosurefactor']=(np.abs(leps.pdgId)==13)*0.05 + 1.0
-  if year == '2017':
-    leps['fakefactor_elclosurefactor']=(np.abs(leps.pdgId)==11)*0.2 + 1.0
-    leps['fakefactor_muclosurefactor']=(np.abs(leps.pdgId)==13)*0.2 + 1.0
-  if year == '2018':
-    leps['fakefactor_elclosurefactor']=(np.abs(leps.pdgId)==11)*( (np.abs(leps.eta) > 1.5)*0.5 + (np.abs(leps.eta) < 1.5)*0.1) + 1.0
-    leps['fakefactor_muclosurefactor']=(np.abs(leps.pdgId)==13)*0.05 + 1.0
-    
-  for flav in ['el','mu']:
-    leps['fakefactor_%sclosuredown'%flav]=leps['fakefactor']/leps['fakefactor_%sclosurefactor'%flav] 
-    leps['fakefactor_%sclosureup'%flav]=leps['fakefactor']*leps['fakefactor_%sclosurefactor'%flav] 
-
-
-  if flavor=="Elec":
-    leps['fliprate'] = (chargeflip_sf)*(flip_lookup(leps.pt,abs(leps.eta)))
-  else:
-    leps['fliprate'] = np.zeros_like(leps.pt)
-
+    if flavor == "Elec":
+        leps['fliprate'] = (chargeflip_sf)*(flip_lookup(leps.pt,abs(leps.eta)))
+    else:
+        leps['fliprate'] = np.zeros_like(leps.pt)
 
 def fakeRateWeight2l(events, lep1, lep2):
-  for syst in ffSysts+['_elclosureup','_elclosuredown','_muclosureup','_muclosuredown']:
-    fakefactor_2l =  (~lep1.isTightLep | ~lep2.isTightLep)*(-1) + (1)*(lep1.isTightLep & lep2.isTightLep) # if all are tight the FF is 1 because events are in the SR 
-    fakefactor_2l =  fakefactor_2l*(lep1.isTightLep + (~lep1.isTightLep)*getattr(lep1,'fakefactor%s'%syst))
-    fakefactor_2l =  fakefactor_2l*(lep2.isTightLep + (~lep2.isTightLep)*getattr(lep2,'fakefactor%s'%syst))
-    events['fakefactor_2l%s'%syst]=fakefactor_2l
-  # Calculation of flip factor: flip_factor_2l = 1*(isSS) + (fliprate1 + fliprate2)*(isOS):
-  #     - For SS events = 1
-  #     - For OS events = (fliprate1 + fliprate2)
-  events['flipfactor_2l']=1*((lep1.charge+lep2.charge)!=0) + (((lep1.fliprate+lep2.fliprate))*((lep1.charge+lep2.charge)==0)) # only apply fliprate for OS events. to handle the OS control regions later :) #  + 
+    for syst in ffSysts+['_elclosureup','_elclosuredown','_muclosureup','_muclosuredown']:
+        fakefactor_2l = -1*(~lep1.isTightLep | ~lep2.isTightLep) + 1*(lep1.isTightLep & lep2.isTightLep) # if all are tight the FF is 1 because events are in the SR 
+        fakefactor_2l = fakefactor_2l * (lep1.isTightLep + (~lep1.isTightLep) * getattr(lep1,'fakefactor%s' % syst))
+        fakefactor_2l = fakefactor_2l * (lep2.isTightLep + (~lep2.isTightLep) * getattr(lep2,'fakefactor%s' % syst))
+        events['fakefactor_2l%s' % syst] = fakefactor_2l
+    # Calculation of flip factor: flip_factor_2l = 1*(isSS) + (fliprate1 + fliprate2)*(isOS):
+    #     - For SS events = 1
+    #     - For OS events = (fliprate1 + fliprate2)
+    events['flipfactor_2l'] = 1*((lep1.charge + lep2.charge) != 0) + (((lep1.fliprate + lep2.fliprate)) * ((lep1.charge + lep2.charge) == 0)) # only apply fliprate for OS events. to handle the OS control regions later :) #  + 
 
 def fakeRateWeight3l(events, lep1, lep2, lep3):
-  for syst in ffSysts+['_elclosureup','_elclosuredown','_muclosureup','_muclosuredown'] :
-    fakefactor_3l = (~lep1.isTightLep | ~lep2.isTightLep | ~lep3.isTightLep)*(-1) + (1)*(lep1.isTightLep & lep2.isTightLep & lep3.isTightLep) # if all are tight the FF is 1 because events are in the SR  and we dont want to weight them
-    fakefactor_3l = fakefactor_3l*(lep1.isTightLep + (~lep1.isTightLep)*getattr(lep1,'fakefactor%s'%syst))
-    fakefactor_3l = fakefactor_3l*(lep2.isTightLep + (~lep2.isTightLep)*getattr(lep2,'fakefactor%s'%syst))
-    fakefactor_3l = fakefactor_3l*(lep3.isTightLep + (~lep3.isTightLep)*getattr(lep3,'fakefactor%s'%syst))
-    events['fakefactor_3l%s'%syst]=fakefactor_3l
-
+    for syst in ffSysts+['_elclosureup','_elclosuredown','_muclosureup','_muclosuredown'] :
+        fakefactor_3l = -1*(~lep1.isTightLep | ~lep2.isTightLep | ~lep3.isTightLep) + 1*(lep1.isTightLep & lep2.isTightLep & lep3.isTightLep) # if all are tight the FF is 1 because events are in the SR  and we dont want to weight them
+        fakefactor_3l = fakefactor_3l * (lep1.isTightLep + (~lep1.isTightLep) * getattr(lep1,'fakefactor%s' % syst))
+        fakefactor_3l = fakefactor_3l * (lep2.isTightLep + (~lep2.isTightLep) * getattr(lep2,'fakefactor%s' % syst))
+        fakefactor_3l = fakefactor_3l * (lep3.isTightLep + (~lep3.isTightLep) * getattr(lep3,'fakefactor%s' % syst))
+        events['fakefactor_3l%s' % syst] = fakefactor_3l
 
 def AttachMuonSF(muons, year):
-  '''
-    Description:
-      Inserts 'sf_nom', 'sf_hi', and 'sf_lo' into the muons array passed to this function. These
-      values correspond to the nominal, up, and down muon scalefactor values respectively.
-  '''
-  eta = np.abs(muons.eta)
-  pt = muons.pt
-  if year not in ['2016','2016APV','2017','2018']: raise Exception(f"Error: Unknown year \"{year}\".")
-  reco_sf  = np.where(pt<20,SFevaluator['MuonRecoSF_{year}'.format(year=year)](eta,pt),1) #sf=1 when pt>20 becuase there is no reco SF available
-  reco_err = np.where(pt<20,SFevaluator['MuonRecoSF_{year}_er'.format(year=year)](eta,pt),0) #sf error =0 when pt>20 becuase there is no reco SF available
-  loose_sf  = SFevaluator['MuonLooseSF_{year}'.format(year=year)](eta,pt)
-  loose_err = np.sqrt(SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt)*SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt)+SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt)*SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt))
-  iso_sf  = SFevaluator['MuonIsoSF_{year}'.format(year=year)](eta,pt)
-  iso_err = SFevaluator['MuonIsoSF_{year}_er'.format(year=year)](eta,pt)
-  new_sf  = SFevaluator['MuonSF_{year}'.format(year=year)](eta,pt)
-  new_err = SFevaluator['MuonSF_{year}_er'.format(year=year)](eta,pt)
+    '''
+      Description:
+          Inserts 'sf_nom', 'sf_hi', and 'sf_lo' into the muons array passed to this function. These
+          values correspond to the nominal, up, and down muon scalefactor values respectively.
+    '''
+    eta = np.abs(muons.eta)
+    pt = muons.pt
+    if year not in ['2016','2016APV','2017','2018']: raise Exception(f"Error: Unknown year \"{year}\".")
+    reco_sf  = np.where(pt < 20,SFevaluator['MuonRecoSF_{year}'.format(year=year)](eta,pt),1) #sf=1 when pt>20 becuase there is no reco SF available
+    reco_err = np.where(pt < 20,SFevaluator['MuonRecoSF_{year}_er'.format(year=year)](eta,pt),0) #sf error =0 when pt>20 becuase there is no reco SF available
+    loose_sf  = SFevaluator['MuonLooseSF_{year}'.format(year=year)](eta,pt)
+    loose_err = np.sqrt(
+        SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_stat'.format(year=year)](eta,pt) +
+        SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt) * SFevaluator['MuonLooseSF_{year}_syst'.format(year=year)](eta,pt)
+    )
+    iso_sf  = SFevaluator['MuonIsoSF_{year}'.format(year=year)](eta,pt)
+    iso_err = SFevaluator['MuonIsoSF_{year}_er'.format(year=year)](eta,pt)
+    new_sf  = SFevaluator['MuonSF_{year}'.format(year=year)](eta,pt)
+    new_err = SFevaluator['MuonSF_{year}_er'.format(year=year)](eta,pt)
 
-  muons['sf_nom_2l_muon'] = new_sf * reco_sf * loose_sf * iso_sf
-  muons['sf_hi_2l_muon']  = (new_sf + new_err) * (reco_sf + reco_err) * (loose_sf + loose_err) * (iso_sf + iso_err)
-  muons['sf_lo_2l_muon']  = (new_sf - new_err) * (reco_sf - reco_err) * (loose_sf - loose_err) * (iso_sf - iso_err)
-  muons['sf_nom_3l_muon'] = new_sf * reco_sf * loose_sf
-  muons['sf_hi_3l_muon']  = (new_sf + new_err) * (reco_sf + reco_err) * (loose_sf + loose_err) * (iso_sf + iso_err)
-  muons['sf_lo_3l_muon']  = (new_sf - new_err) * (reco_sf - reco_err) * (loose_sf - loose_err) * (iso_sf - iso_err)
-  muons['sf_nom_2l_elec'] = ak.ones_like(new_sf)
-  muons['sf_hi_2l_elec']  = ak.ones_like(new_sf)
-  muons['sf_lo_2l_elec']  = ak.ones_like(new_sf)
-  muons['sf_nom_3l_elec'] = ak.ones_like(new_sf)
-  muons['sf_hi_3l_elec']  = ak.ones_like(new_sf)
-  muons['sf_lo_3l_elec']  = ak.ones_like(new_sf)
-
+    muons['sf_nom_2l_muon'] = new_sf * reco_sf * loose_sf * iso_sf
+    muons['sf_hi_2l_muon']  = (new_sf + new_err) * (reco_sf + reco_err) * (loose_sf + loose_err) * (iso_sf + iso_err)
+    muons['sf_lo_2l_muon']  = (new_sf - new_err) * (reco_sf - reco_err) * (loose_sf - loose_err) * (iso_sf - iso_err)
+    muons['sf_nom_3l_muon'] = new_sf * reco_sf * loose_sf
+    muons['sf_hi_3l_muon']  = (new_sf + new_err) * (reco_sf + reco_err) * (loose_sf + loose_err) * (iso_sf + iso_err)
+    muons['sf_lo_3l_muon']  = (new_sf - new_err) * (reco_sf - reco_err) * (loose_sf - loose_err) * (iso_sf - iso_err)
+    muons['sf_nom_2l_elec'] = ak.ones_like(new_sf)
+    muons['sf_hi_2l_elec']  = ak.ones_like(new_sf)
+    muons['sf_lo_2l_elec']  = ak.ones_like(new_sf)
+    muons['sf_nom_3l_elec'] = ak.ones_like(new_sf)
+    muons['sf_hi_3l_elec']  = ak.ones_like(new_sf)
+    muons['sf_lo_3l_elec']  = ak.ones_like(new_sf)
 
 def AttachElectronSF(electrons, year):
-  '''
-    Description:
-      Inserts 'sf_nom', 'sf_hi', and 'sf_lo' into the electrons array passed to this function. These
-      values correspond to the nominal, up, and down electron scalefactor values respectively.
-  '''
-  eta = electrons.eta
-  pt = electrons.pt
+    '''
+      Description:
+          Inserts 'sf_nom', 'sf_hi', and 'sf_lo' into the electrons array passed to this function. These
+          values correspond to the nominal, up, and down electron scalefactor values respectively.
+    '''
+    eta = electrons.eta
+    pt = electrons.pt
 
-  if year not in ['2016','2016APV','2017','2018']: raise Exception(f"Error: Unknown year \"{year}\".")
+    if year not in ['2016','2016APV','2017','2018']:
+        raise Exception(f"Error: Unknown year \"{year}\".")
   
-  reco_sf  = np.where(pt<20,SFevaluator['ElecRecoSFBe_{year}'.format(year=year)](eta,pt),SFevaluator['ElecRecoSFAb_{year}'.format(year=year)](eta,pt))
-  reco_err = np.where(pt<20,SFevaluator['ElecRecoSFBe_{year}_er'.format(year=year)](eta,pt),SFevaluator['ElecRecoSFAb_{year}_er'.format(year=year)](eta,pt))
-  new_sf_2l  = SFevaluator['ElecSF_{year}_2lss'.format(year=year)](np.abs(eta),pt)
-  new_err_2l = SFevaluator['ElecSF_{year}_2lss_er'.format(year=year)](np.abs(eta),pt)
-  new_sf_3l  = SFevaluator['ElecSF_{year}_3l'.format(year=year)](np.abs(eta),pt)
-  new_err_3l = SFevaluator['ElecSF_{year}_3l_er'.format(year=year)](np.abs(eta),pt)
-  loose_sf  = SFevaluator['ElecLooseSF_{year}'.format(year=year)](np.abs(eta),pt)
-  loose_err = SFevaluator['ElecLooseSF_{year}_er'.format(year=year)](np.abs(eta),pt)
-  iso_sf  = SFevaluator['ElecIsoSF_{year}'.format(year=year)](np.abs(eta),pt)
-  iso_err = SFevaluator['ElecIsoSF_{year}_er'.format(year=year)](np.abs(eta),pt)
+    reco_sf  = np.where(
+        pt < 20,
+        SFevaluator['ElecRecoSFBe_{year}'.format(year=year)](eta,pt),
+        SFevaluator['ElecRecoSFAb_{year}'.format(year=year)](eta,pt)
+    )
+    reco_err = np.where(
+        pt < 20,
+        SFevaluator['ElecRecoSFBe_{year}_er'.format(year=year)](eta,pt),
+        SFevaluator['ElecRecoSFAb_{year}_er'.format(year=year)](eta,pt)
+    )
+    new_sf_2l  = SFevaluator['ElecSF_{year}_2lss'.format(year=year)](np.abs(eta),pt)
+    new_err_2l = SFevaluator['ElecSF_{year}_2lss_er'.format(year=year)](np.abs(eta),pt)
+    new_sf_3l  = SFevaluator['ElecSF_{year}_3l'.format(year=year)](np.abs(eta),pt)
+    new_err_3l = SFevaluator['ElecSF_{year}_3l_er'.format(year=year)](np.abs(eta),pt)
+    loose_sf  = SFevaluator['ElecLooseSF_{year}'.format(year=year)](np.abs(eta),pt)
+    loose_err = SFevaluator['ElecLooseSF_{year}_er'.format(year=year)](np.abs(eta),pt)
+    iso_sf  = SFevaluator['ElecIsoSF_{year}'.format(year=year)](np.abs(eta),pt)
+    iso_err = SFevaluator['ElecIsoSF_{year}_er'.format(year=year)](np.abs(eta),pt)
 
-  electrons['sf_nom_2l_elec'] = reco_sf * new_sf_2l * loose_sf * iso_sf
-  electrons['sf_hi_2l_elec']  = (reco_sf + reco_err) * (new_sf_2l + new_err_2l) * (loose_sf + loose_err) * (iso_sf + iso_err)
-  electrons['sf_lo_2l_elec']  = (reco_sf - reco_err) * (new_sf_2l - new_err_2l) * (loose_sf - loose_err) * (iso_sf - iso_err)
-  electrons['sf_nom_3l_elec'] = reco_sf * new_sf_3l * loose_sf
-  electrons['sf_hi_3l_elec']  = (reco_sf + reco_err) * (new_sf_3l + new_err_3l) * (loose_sf + loose_err) * (iso_sf + iso_err)
-  electrons['sf_lo_3l_elec']  = (reco_sf - reco_err) * (new_sf_3l - new_err_3l) * (loose_sf - loose_err) * (iso_sf - iso_err)
-  electrons['sf_nom_2l_muon'] = ak.ones_like(reco_sf)
-  electrons['sf_hi_2l_muon']  = ak.ones_like(reco_sf)
-  electrons['sf_lo_2l_muon']  = ak.ones_like(reco_sf)
-  electrons['sf_nom_3l_muon'] = ak.ones_like(reco_sf)
-  electrons['sf_hi_3l_muon']  = ak.ones_like(reco_sf)
-  electrons['sf_lo_3l_muon']  = ak.ones_like(reco_sf)
-
+    electrons['sf_nom_2l_elec'] = reco_sf * new_sf_2l * loose_sf * iso_sf
+    electrons['sf_hi_2l_elec']  = (reco_sf + reco_err) * (new_sf_2l + new_err_2l) * (loose_sf + loose_err) * (iso_sf + iso_err)
+    electrons['sf_lo_2l_elec']  = (reco_sf - reco_err) * (new_sf_2l - new_err_2l) * (loose_sf - loose_err) * (iso_sf - iso_err)
+    electrons['sf_nom_3l_elec'] = reco_sf * new_sf_3l * loose_sf
+    electrons['sf_hi_3l_elec']  = (reco_sf + reco_err) * (new_sf_3l + new_err_3l) * (loose_sf + loose_err) * (iso_sf + iso_err)
+    electrons['sf_lo_3l_elec']  = (reco_sf - reco_err) * (new_sf_3l - new_err_3l) * (loose_sf - loose_err) * (iso_sf - iso_err)
+    electrons['sf_nom_2l_muon'] = ak.ones_like(reco_sf)
+    electrons['sf_hi_2l_muon']  = ak.ones_like(reco_sf)
+    electrons['sf_lo_2l_muon']  = ak.ones_like(reco_sf)
+    electrons['sf_nom_3l_muon'] = ak.ones_like(reco_sf)
+    electrons['sf_hi_3l_muon']  = ak.ones_like(reco_sf)
+    electrons['sf_lo_3l_muon']  = ak.ones_like(reco_sf)
 
 ###### Btag scale factors
 ################################################################
@@ -271,84 +273,127 @@ def AttachElectronSF(electrons, year):
 
 # MC efficiencies
 def GetMCeffFunc(year, wp='medium', flav='b'):
-  if year not in ['2016','2016APV','2017','2018']: raise Exception(f"Error: Unknown year \"{year}\".")
-
-  pathToBtagMCeff = topcoffea_path('data/btagSF/UL/btagMCeff_%s.pkl.gz'%year)
-  hists = {}
-  with gzip.open(pathToBtagMCeff) as fin:
-    hin = pickle.load(fin)
-    for k in hin.keys():
-      if k in hists: hists[k]+=hin[k]
-      else:          hists[k]=hin[k]
-  h = hists['jetptetaflav']
-  hnum = h.integrate('WP', wp)
-  hden = h.integrate('WP', 'all')
-  getnum = lookup_tools.dense_lookup.dense_lookup(hnum.values(overflow='over')[()], [hnum.axis('pt').edges(), hnum.axis('abseta').edges(), hnum.axis('flav').edges()])
-  getden = lookup_tools.dense_lookup.dense_lookup(hden.values(overflow='over')[()], [hden.axis('pt').edges(), hnum.axis('abseta').edges(), hden.axis('flav').edges()])
-  values = hnum.values(overflow='over')[()]
-  edges = [hnum.axis('pt').edges(), hnum.axis('abseta').edges(), hnum.axis('flav').edges()]
-  fun = lambda pt, abseta, flav : getnum(pt,abseta,flav)/getden(pt,abseta,flav)
-  return fun
+    if year not in ['2016','2016APV','2017','2018']:
+        raise Exception(f"Error: Unknown year \"{year}\".")
+    pathToBtagMCeff = topcoffea_path('data/btagSF/UL/btagMCeff_%s.pkl.gz'%year)
+    hists = {}
+    with gzip.open(pathToBtagMCeff) as fin:
+        hin = pickle.load(fin)
+        for k in hin.keys():
+            if k in hists:
+                hists[k] += hin[k]
+            else:
+                hists[k] = hin[k]
+    h = hists['jetptetaflav']
+    hnum = h.integrate('WP', wp)
+    hden = h.integrate('WP', 'all')
+    getnum = lookup_tools.dense_lookup.dense_lookup(
+        hnum.values(overflow='over')[()],
+        [
+            hnum.axis('pt').edges(),
+            hnum.axis('abseta').edges(),
+            hnum.axis('flav').edges()
+        ]
+    )
+    getden = lookup_tools.dense_lookup.dense_lookup(
+        hden.values(overflow='over')[()],
+        [
+            hden.axis('pt').edges(),
+            hnum.axis('abseta').edges(),
+            hden.axis('flav').edges()
+        ]
+    )
+    values = hnum.values(overflow='over')[()]
+    edges = [hnum.axis('pt').edges(), hnum.axis('abseta').edges(), hnum.axis('flav').edges()]
+    fun = lambda pt, abseta, flav: getnum(pt,abseta,flav)/getden(pt,abseta,flav)
+    return fun
 
 def GetBtagEff(jets, year, wp='medium'):
-  if year not in ['2016','2016APV','2017','2018']: raise Exception(f"Error: Unknown year \"{year}\".")
-  return GetMCeffFunc(year,wp)(jets.pt, np.abs(jets.eta), jets.hadronFlavour)
+    if year not in ['2016','2016APV','2017','2018']:
+        raise Exception(f"Error: Unknown year \"{year}\".")
+    return GetMCeffFunc(year,wp)(jets.pt, np.abs(jets.eta), jets.hadronFlavour)
 
 def GetBTagSF(jets, year, wp='MEDIUM', sys='central'):
-  if   year == '2016': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/DeepJet_106XUL16postVFPSF_v2.csv"),wp) 
-  elif year == '2016APV': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL16preVFP_v2.csv"),wp) 
-  elif year == '2017': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL17_v3.csv"),wp)
-  elif year == '2018': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL18_v2.csv"),wp)
-  else: raise Exception(f"Error: Unknown year \"{year}\".")
+    if   year == '2016': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/DeepJet_106XUL16postVFPSF_v2.csv"),wp) 
+    elif year == '2016APV': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL16preVFP_v2.csv"),wp) 
+    elif year == '2017': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL17_v3.csv"),wp)
+    elif year == '2018': SFevaluatorBtag = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL18_v2.csv"),wp)
+    else: raise Exception(f"Error: Unknown year \"{year}\".")
 
-  pt = jets.pt; abseta = np.abs(jets.eta); flavor = jets.hadronFlavour
-  SF=SFevaluatorBtag.eval('central',jets.hadronFlavour,np.abs(jets.eta),jets.pt)
+    pt = jets.pt; abseta = np.abs(jets.eta)
+    SF = SFevaluatorBtag.eval('central',jets.hadronFlavour,np.abs(jets.eta),jets.pt)
 
-  # Workaround: For UL16, use the SFs from the UL16APV for light flavor jets
-  SFevaluatorBtag_UL16APV = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL16preVFP_v2.csv"),wp)
-  if year == "2016":
-      had_flavor = jets.hadronFlavour
-      SF_UL16APV = SFevaluatorBtag_UL16APV.eval('central',jets.hadronFlavour,np.abs(jets.eta),jets.pt)
-      SF = ak.where(had_flavor==0,SF_UL16APV,SF)
+    # Workaround: For UL16, use the SFs from the UL16APV for light flavor jets
+    SFevaluatorBtag_UL16APV = BTagScaleFactor(topcoffea_path("data/btagSF/UL/wp_deepJet_106XUL16preVFP_v2.csv"),wp)
+    if year == "2016":
+        had_flavor = jets.hadronFlavour
+        SF_UL16APV = SFevaluatorBtag_UL16APV.eval('central',jets.hadronFlavour,np.abs(jets.eta),jets.pt)
+        SF = ak.where(had_flavor == 0,SF_UL16APV,SF)
 
-  # If we are just getting the central, return here
-  if sys=='central':    
-    return (SF)
-
-  # We are calculating up and down
-  else:
-    flavors = {
-        0: ["light_corr", f"light_{year}"],
-        4: ["bc_corr",f"bc_{year}"],
-        5: ["bc_corr",f"bc_{year}"]
-    }
-    
-    jets[f"btag_{sys}_up"] = SF
-    jets[f"btag_{sys}_down"] = SF
-    for f, f_syst in flavors.items():
-      if sys in f_syst:
-
-        # Workaround: For UL16, use the SFs from the UL16APV for light flavor jets
-        if (f == 0) and (year == "2016"):
-          if f"{year}" in sys:
-            jets[f"btag_{sys}_up"]=np.where(abs(jets.hadronFlavour)   == f, SFevaluatorBtag_UL16APV.eval("up_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_up"])
-            jets[f"btag_{sys}_down"]=np.where(abs(jets.hadronFlavour) == f, SFevaluatorBtag_UL16APV.eval("down_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_down"])
-          else:
-            jets[f"btag_{sys}_up"]=np.where(abs(jets.hadronFlavour)   == f, SFevaluatorBtag_UL16APV.eval("up_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_up"])
-            jets[f"btag_{sys}_down"]=np.where(abs(jets.hadronFlavour) == f, SFevaluatorBtag_UL16APV.eval("down_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_down"])
-
-        # Otherwise, proceed as usual
-        else:
-          if f"{year}" in sys:
-            jets[f"btag_{sys}_up"]=np.where(abs(jets.hadronFlavour)   == f, SFevaluatorBtag.eval("up_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_up"])
-            jets[f"btag_{sys}_down"]=np.where(abs(jets.hadronFlavour) == f, SFevaluatorBtag.eval("down_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_down"])
-          else:
-            jets[f"btag_{sys}_up"]=np.where(abs(jets.hadronFlavour)   == f, SFevaluatorBtag.eval("up_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_up"])
-            jets[f"btag_{sys}_down"]=np.where(abs(jets.hadronFlavour) == f, SFevaluatorBtag.eval("down_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),jets[f"btag_{sys}_down"])
-
-    return([jets[f"btag_{sys}_up"],jets[f"btag_{sys}_down"]])
+    if sys == 'central':    
+        # If we are just getting the central, return here
+        return (SF)
+    else:
+        # We are calculating up and down
+        flavors = {
+            0: ["light_corr", f"light_{year}"],
+            4: ["bc_corr",f"bc_{year}"],
+            5: ["bc_corr",f"bc_{year}"]
+        }
+        jets[f"btag_{sys}_up"] = SF
+        jets[f"btag_{sys}_down"] = SF
+        for f, f_syst in flavors.items():
+            if sys in f_syst:
+                # Workaround: For UL16, use the SFs from the UL16APV for light flavor jets
+                if (f == 0) and (year == "2016"):
+                    if f"{year}" in sys:
+                        jets[f"btag_{sys}_up"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag_UL16APV.eval("up_uncorrelated",jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_up"]
+                        )
+                        jets[f"btag_{sys}_down"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag_UL16APV.eval("down_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_down"]
+                        )
+                    else:
+                        jets[f"btag_{sys}_up"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag_UL16APV.eval("up_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_up"]
+                        )
+                        jets[f"btag_{sys}_down"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag_UL16APV.eval("down_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_down"]
+                        )
+                # Otherwise, proceed as usual
+                else:
+                    if f"{year}" in sys:
+                        jets[f"btag_{sys}_up"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag.eval("up_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_up"]
+                        )
+                        jets[f"btag_{sys}_down"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag.eval("down_uncorrelated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_down"]
+                        )
+                    else:
+                        jets[f"btag_{sys}_up"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag.eval("up_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_up"]
+                        )
+                        jets[f"btag_{sys}_down"] = np.where(
+                            abs(jets.hadronFlavour) == f,
+                            SFevaluatorBtag.eval("down_correlated", jets.hadronFlavour,np.abs(jets.eta),pt,jets.btagDeepFlavB,True),
+                            jets[f"btag_{sys}_down"]
+                        )
+    return ([jets[f"btag_{sys}_up"],jets[f"btag_{sys}_down"]])
  
-
 ###### Pileup reweighing
 ##############################################
 ## Get central PU data and MC profiles and calculate reweighting
@@ -364,118 +409,158 @@ def GetBTagSF(jets, year, wp='MEDIUM', sys='central'):
 pudirpath = topcoffea_path('data/pileup/')
 
 def GetDataPUname(year, var=0):
-  ''' Returns the name of the file to read pu observed distribution '''
-  if year == '2016APV': year = '2016-preVFP'
-  if year == '2016'   : year = "2016-postVFP"
-  if   var== 'nominal': ppxsec = get_param("pu_w")
-  elif var== 'up': ppxsec = get_param("pu_w_up")
-  elif var== 'down': ppxsec = get_param("pu_w_down")
-  year = str(year)
-  return 'PileupHistogram-goldenJSON-13tev-%s-%sub-99bins.root'%((year), str(ppxsec))
+    ''' Returns the name of the file to read pu observed distribution '''
+    if year == '2016APV': year = '2016-preVFP'
+    if year == '2016': year = "2016-postVFP"
+    if var == 'nominal':
+        ppxsec = get_param("pu_w")
+    elif var == 'up':
+        ppxsec = get_param("pu_w_up")
+    elif var == 'down':
+        ppxsec = get_param("pu_w_down")
+    year = str(year)
+    return 'PileupHistogram-goldenJSON-13tev-%s-%sub-99bins.root' % ((year), str(ppxsec))
 
 MCPUfile = {'2016APV':'pileup_2016BF.root', '2016':'pileup_2016GH.root', '2017':'pileup_2017_shifts.root', '2018':'pileup_2018_shifts.root'}
 def GetMCPUname(year):
-  ''' Returns the name of the file to read pu MC profile '''
-  return MCPUfile[str(year)]
+    ''' Returns the name of the file to read pu MC profile '''
+    return MCPUfile[str(year)]
 
 PUfunc = {}
 ### Load histograms and get lookup tables (extractors are not working here...)
 for year in ['2016', '2016APV', '2017', '2018']:
-  PUfunc[year] = {}
-  with uproot.open(pudirpath+GetMCPUname(year)) as fMC:
-    hMC = fMC['pileup']
-    PUfunc[year]['MC'] = lookup_tools.dense_lookup.dense_lookup(hMC.values() / np.sum( hMC.values()), hMC.axis(0).edges())
-  with uproot.open(pudirpath+GetDataPUname(year,  'nominal')) as fData:
-    hD   = fData  ['pileup']
-    PUfunc[year]['Data'  ] = lookup_tools.dense_lookup.dense_lookup(hD.values() / np.sum(hD.values()), hD.axis(0).edges())
-  with uproot.open(pudirpath+GetDataPUname(year,  'up')) as fDataUp:
-    hDUp = fDataUp['pileup']
-    PUfunc[year]['DataUp'] = lookup_tools.dense_lookup.dense_lookup(hDUp.values() / np.sum(hDUp.values()), hD.axis(0).edges())
-  with uproot.open(pudirpath+GetDataPUname(year, 'down')) as fDataDo:
-    hDDo = fDataDo['pileup']
-    PUfunc[year]['DataDo'] = lookup_tools.dense_lookup.dense_lookup(hDDo.values() / np.sum(hDDo.values()), hD.axis(0).edges())
-
+    PUfunc[year] = {}
+    with uproot.open(pudirpath+GetMCPUname(year)) as fMC:
+        hMC = fMC['pileup']
+        PUfunc[year]['MC'] = lookup_tools.dense_lookup.dense_lookup(
+            hMC.values() / np.sum(hMC.values()),
+            hMC.axis(0).edges()
+        )
+    with uproot.open(pudirpath + GetDataPUname(year,'nominal')) as fData:
+        hD = fData['pileup']
+        PUfunc[year]['Data'] = lookup_tools.dense_lookup.dense_lookup(
+            hD.values() / np.sum(hD.values()),
+            hD.axis(0).edges()
+        )
+    with uproot.open(pudirpath + GetDataPUname(year,'up')) as fDataUp:
+        hDUp = fDataUp['pileup']
+        PUfunc[year]['DataUp'] = lookup_tools.dense_lookup.dense_lookup(
+            hDUp.values() / np.sum(hDUp.values()),
+            hD.axis(0).edges()
+        )
+    with uproot.open(pudirpath + GetDataPUname(year, 'down')) as fDataDo:
+        hDDo = fDataDo['pileup']
+        PUfunc[year]['DataDo'] = lookup_tools.dense_lookup.dense_lookup(
+            hDDo.values() / np.sum(hDDo.values()),
+            hD.axis(0).edges()
+        )
 
 def GetPUSF(nTrueInt, year, var='nominal'):
-  year = str(year)
-  if year not in ['2016','2016APV','2017','2018']: raise Exception(f"Error: Unknown year \"{year}\".")
-  nMC  =PUfunc[year]['MC'](nTrueInt+1)
-  nData=PUfunc[year]['DataUp' if var == 'up' else ('DataDo' if var == 'down' else 'Data')](nTrueInt)
-  weights = np.divide(nData,nMC)
-  return weights
+    year = str(year)
+    if year not in ['2016','2016APV','2017','2018']:
+      raise Exception(f"Error: Unknown year \"{year}\".")
+    nMC = PUfunc[year]['MC'](nTrueInt+1)
+    data_dir = 'Data'
+    if var == 'up':
+        data_dir = 'DataUp'
+    elif var == 'down':
+        data_dir = 'DataDo'
+    nData = PUfunc[year][data_dir](nTrueInt)
+    weights = np.divide(nData,nMC)
+    return weights
 
 def AttachPSWeights(events):
-  '''
-  Return a list of PS weights
-  PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2
-  '''
-  ISR = 0; FSR = 1; ISRdown = 0; FSRdown = 1; ISRup = 2; FSRup = 3
-  if events.PSWeight is None:
-      raise Exception(f'PSWeight not found in {fname}!')
-  # Add up variation event weights
-  events['ISRUp']   = events.PSWeight[:, ISRup]
-  events['FSRUp']   = events.PSWeight[:, FSRup]
-  # Add down variation event weights
-  events['ISRDown'] = events.PSWeight[:, ISRdown]
-  events['FSRDown'] = events.PSWeight[:, FSRdown]
+    '''
+        Return a list of PS weights
+        PS weights (w_var / w_nominal)
+        [0] is ISR=0.5 FSR = 1
+        [1] is ISR=1 FSR = 0.5
+        [2] is ISR=2 FSR = 1
+        [3] is ISR=1 FSR = 2
+    '''
+    ISR = 0
+    FSR = 1
+    ISRdown = 0
+    FSRdown = 1
+    ISRup = 2
+    FSRup = 3
+    if events.PSWeight is None:
+        raise Exception(f'PSWeight not found in {fname}!')
+    # Add up variation event weights
+    events['ISRUp'] = events.PSWeight[:, ISRup]
+    events['FSRUp'] = events.PSWeight[:, FSRup]
+    # Add down variation event weights
+    events['ISRDown'] = events.PSWeight[:, ISRdown]
+    events['FSRDown'] = events.PSWeight[:, FSRdown]
 
 def AttachScaleWeights(events):
-  '''
-  Return a list of scale weights
-
-  Case 1:
-  LHE scale variation weights (w_var / w_nominal); [0] is renscfact=0.5d0 facscfact=0.5d0 ; [1] is renscfact=0.5d0 facscfact=1d0 ; [2] is renscfact=0.5d0 facscfact=2d0 ; [3] is renscfact=1d0 facscfact=0.5d0 ; [4] is renscfact=1d0 facscfact=1d0 ; [5] is renscfact=1d0 facscfact=2d0 ; [6] is renscfact=2d0 facscfact=0.5d0 ; [7] is renscfact=2d0 facscfact=1d0 ; [8] is renscfact=2d0 facscfact=2d0
-
-  Case 2:
-  [0] is MUF="0.5" MUR="0.5"; [1] is MUF="1.0" MUR="0.5"; [2] is MUF="2.0" MUR="0.5"; [3] is MUF="0.5" MUR="1.0"; [4] is MUF="2.0" MUR="1.0"; [5] is MUF="0.5" MUR="2.0"; [6] is MUF="1.0" MUR="2.0"; [7] is MUF="2.0" MUR="2.0"
-  '''
-
-  # Determine if we are in case 1 or case 2 by checking if we have 8 or 9 weights
-  len_of_wgts = ak.count(events.LHEScaleWeight,axis=-1)
-  all_len_9_or_0_bool = ak.all((len_of_wgts==9) | (len_of_wgts==0))
-  all_len_8_or_0_bool = ak.all((len_of_wgts==8) | (len_of_wgts==0))
-  if all_len_9_or_0_bool:
-      scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 9), 1) # FIXME this is a bandaid until we understand _why_ some are empty 
-      renormDown_factDown = 0
-      renormDown          = 1
-      renormDown_factUp   = 2
-      factDown            = 3
-      nominal             = 4
-      factUp              = 5
-      renormUp_factDown   = 6
-      renormUp            = 7
-      renormUp_factUp     = 8
-  elif all_len_8_or_0_bool:
-      scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 8), 1) # FIXME this is a bandaid until we understand _why_ some are empty 
-      renormDown_factDown = 0
-      renormDown          = 1
-      renormDown_factUp   = 2
-      factDown            = 3
-      factUp              = 4
-      renormUp_factDown   = 5
-      renormUp            = 6
-      renormUp_factUp     = 7
-  else:
-    raise Exception(f"Unknown weight type")
-
-  # Get the weights from the event
-  events['renormfactDown'] = scale_weights[:,renormDown_factDown]
-  events['renormDown']     = scale_weights[:,renormDown]
-  events['factDown']       = scale_weights[:,factDown]
-  events['factUp']         = scale_weights[:,factUp]
-  events['renormUp']       = scale_weights[:,renormUp]
-  events['renormfactUp']   = scale_weights[:,renormUp_factUp]
-
+    '''
+    Return a list of scale weights
+    LHE scale variation weights (w_var / w_nominal)
+    Case 1:
+        [0] is renscfact = 0.5d0 facscfact = 0.5d0
+        [1] is renscfact = 0.5d0 facscfact = 1d0
+        [2] is renscfact = 0.5d0 facscfact = 2d0
+        [3] is renscfact =   1d0 facscfact = 0.5d0
+        [4] is renscfact =   1d0 facscfact = 1d0
+        [5] is renscfact =   1d0 facscfact = 2d0
+        [6] is renscfact =   2d0 facscfact = 0.5d0
+        [7] is renscfact =   2d0 facscfact = 1d0
+        [8] is renscfact =   2d0 facscfact = 2d0
+    Case 2:
+        [0] is MUF = "0.5" MUR = "0.5"
+        [1] is MUF = "1.0" MUR = "0.5"
+        [2] is MUF = "2.0" MUR = "0.5"
+        [3] is MUF = "0.5" MUR = "1.0"
+        [4] is MUF = "2.0" MUR = "1.0"
+        [5] is MUF = "0.5" MUR = "2.0"
+        [6] is MUF = "1.0" MUR = "2.0"
+        [7] is MUF = "2.0" MUR = "2.0"
+    '''
+    # Determine if we are in case 1 or case 2 by checking if we have 8 or 9 weights
+    len_of_wgts = ak.count(events.LHEScaleWeight,axis=-1)
+    all_len_9_or_0_bool = ak.all((len_of_wgts==9) | (len_of_wgts==0))
+    all_len_8_or_0_bool = ak.all((len_of_wgts==8) | (len_of_wgts==0))
+    if all_len_9_or_0_bool:
+        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 9), 1) # FIXME this is a bandaid until we understand _why_ some are empty 
+        renormDown_factDown = 0
+        renormDown          = 1
+        renormDown_factUp   = 2
+        factDown            = 3
+        nominal             = 4
+        factUp              = 5
+        renormUp_factDown   = 6
+        renormUp            = 7
+        renormUp_factUp     = 8
+    elif all_len_8_or_0_bool:
+        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 8), 1) # FIXME this is a bandaid until we understand _why_ some are empty 
+        renormDown_factDown = 0
+        renormDown          = 1
+        renormDown_factUp   = 2
+        factDown            = 3
+        factUp              = 4
+        renormUp_factDown   = 5
+        renormUp            = 6
+        renormUp_factUp     = 7
+    else:
+        raise Exception(f"Unknown weight type")
+    # Get the weights from the event
+    events['renormfactDown'] = scale_weights[:,renormDown_factDown]
+    events['renormDown']     = scale_weights[:,renormDown]
+    events['factDown']       = scale_weights[:,factDown]
+    events['factUp']         = scale_weights[:,factUp]
+    events['renormUp']       = scale_weights[:,renormUp]
+    events['renormfactUp']   = scale_weights[:,renormUp_factUp]
 
 def AttachPdfWeights(events):
-  '''
-  Return a list of PDF weights
-  Should be 100 weights for NNPDF 3.1
-  '''
-  if events.LHEPdfWeight is None:
-      raise Exception(f'LHEPdfWeight not found in {fname}!')
-  pdf_weight = ak.Array(events.LHEPdfWeight)
-  #events['Pdf'] = ak.Array(events.nLHEPdfWeight) # FIXME not working
+    '''
+        Return a list of PDF weights
+        Should be 100 weights for NNPDF 3.1
+    '''
+    if events.LHEPdfWeight is None:
+        raise Exception(f'LHEPdfWeight not found in {fname}!')
+    pdf_weight = ak.Array(events.LHEPdfWeight)
+    #events['Pdf'] = ak.Array(events.nLHEPdfWeight) # FIXME not working
 
 ####### JEC 
 ##############################################
@@ -483,102 +568,148 @@ def AttachPdfWeights(events):
 # JES: https://twiki.cern.ch/twiki/bin/view/CMS/JECDataMC
 
 def ApplyJetCorrections(year, corr_type):
-  if year=='2016': jec_tag='16_V7'; jer_tag='Summer20UL16_JRV3'
-  elif year=='2016APV': jec_tag='16APV_V7'; jer_tag='Summer20UL16APV_JRV3'
-  elif year=='2017': jec_tag='17_V5'; jer_tag='Summer19UL17_JRV2'
-  elif year=='2018': jec_tag='18_V5'; jer_tag='Summer19UL18_JRV2'
-  else: raise Exception(f"Error: Unknown year \"{year}\".")
-  extJEC = lookup_tools.extractor()
-  extJEC.add_weight_sets(["* * "+topcoffea_path('data/JER/%s_MC_SF_AK4PFchs.jersf.txt'%jer_tag),"* * "+topcoffea_path('data/JER/%s_MC_PtResolution_AK4PFchs.jr.txt'%jer_tag),"* * "+topcoffea_path('data/JEC/Summer19UL%s_MC_L1FastJet_AK4PFchs.txt'%jec_tag),"* * "+topcoffea_path('data/JEC/Summer19UL%s_MC_L2Relative_AK4PFchs.txt'%jec_tag),"* * "+topcoffea_path('data/JEC/Quad_Summer19UL%s_MC_UncertaintySources_AK4PFchs.junc.txt'%jec_tag)])
-  jec_types = ['FlavorQCD', 'FlavorPureBottom', 'FlavorPureQuark', 'FlavorPureGluon', 'FlavorPureCharm', 'BBEC1', 'Absolute', 'RelativeBal', 'RelativeSample']
-  jec_regroup = ["Quad_Summer19UL%s_MC_UncertaintySources_AK4PFchs_%s"%(jec_tag,jec_type) for jec_type in jec_types]
-  jec_names = ["%s_MC_SF_AK4PFchs"%jer_tag,"%s_MC_PtResolution_AK4PFchs"%jer_tag,"Summer19UL%s_MC_L1FastJet_AK4PFchs"%jec_tag,"Summer19UL%s_MC_L2Relative_AK4PFchs"%jec_tag]
-  jec_names.extend(jec_regroup)
-  extJEC.finalize()
-  JECevaluator = extJEC.make_evaluator()
-  jec_inputs = {name: JECevaluator[name] for name in jec_names} 
-  jec_stack = JECStack(jec_inputs)
-  name_map = jec_stack.blank_name_map
-  name_map['JetPt'] = 'pt'
-  name_map['JetMass'] = 'mass'
-  name_map['JetEta'] = 'eta'
-  name_map['JetPhi'] = 'phi'
-  name_map['JetA'] = 'area'
-  name_map['ptGenJet'] = 'pt_gen'
-  name_map['ptRaw'] = 'pt_raw'
-  name_map['massRaw'] = 'mass_raw'
-  name_map['Rho'] = 'rho'
-  name_map['METpt'] = 'pt'
-  name_map['METphi'] = 'phi'
-  name_map['UnClusteredEnergyDeltaX'] = 'MetUnclustEnUpDeltaX'
-  name_map['UnClusteredEnergyDeltaY'] = 'MetUnclustEnUpDeltaY'
-  if corr_type=='met': return CorrectedMETFactory(name_map)
-  return CorrectedJetsFactory(name_map, jec_stack)
+    if year == '2016':
+        jec_tag = '16_V7'
+        jer_tag = 'Summer20UL16_JRV3'
+    elif year == '2016APV':
+        jec_tag = '16APV_V7'
+        jer_tag = 'Summer20UL16APV_JRV3'
+    elif year == '2017':
+        jec_tag = '17_V5'
+        jer_tag = 'Summer19UL17_JRV2'
+    elif year == '2018':
+        jec_tag = '18_V5'
+        jer_tag = 'Summer19UL18_JRV2'
+    else:
+        raise Exception(f"Error: Unknown year \"{year}\".")
+    extJEC = lookup_tools.extractor()
+    extJEC.add_weight_sets([
+        "* * " + topcoffea_path('data/JER/%s_MC_SF_AK4PFchs.jersf.txt' % jer_tag),
+        "* * " + topcoffea_path('data/JER/%s_MC_PtResolution_AK4PFchs.jr.txt' % jer_tag),
+        "* * " + topcoffea_path('data/JEC/Summer19UL%s_MC_L1FastJet_AK4PFchs.txt' % jec_tag),
+        "* * " + topcoffea_path('data/JEC/Summer19UL%s_MC_L2Relative_AK4PFchs.txt' % jec_tag),
+        "* * " + topcoffea_path('data/JEC/Quad_Summer19UL%s_MC_UncertaintySources_AK4PFchs.junc.txt' % jec_tag)
+    ])
+    jec_types = [
+        'FlavorQCD', 'FlavorPureBottom', 'FlavorPureQuark', 'FlavorPureGluon', 'FlavorPureCharm',
+        'BBEC1', 'Absolute', 'RelativeBal', 'RelativeSample'
+    ]
+    jec_regroup = ["Quad_Summer19UL%s_MC_UncertaintySources_AK4PFchs_%s" % (jec_tag,jec_type) for jec_type in jec_types]
+    jec_names = [
+        "%s_MC_SF_AK4PFchs" % jer_tag,
+        "%s_MC_PtResolution_AK4PFchs" % jer_tag,
+        "Summer19UL%s_MC_L1FastJet_AK4PFchs" % jec_tag,
+        "Summer19UL%s_MC_L2Relative_AK4PFchs" % jec_tag
+    ]
+    jec_names.extend(jec_regroup)
+    extJEC.finalize()
+    JECevaluator = extJEC.make_evaluator()
+    jec_inputs = {name: JECevaluator[name] for name in jec_names} 
+    jec_stack = JECStack(jec_inputs)
+    name_map = jec_stack.blank_name_map
+    name_map['JetPt'] = 'pt'
+    name_map['JetMass'] = 'mass'
+    name_map['JetEta'] = 'eta'
+    name_map['JetPhi'] = 'phi'
+    name_map['JetA'] = 'area'
+    name_map['ptGenJet'] = 'pt_gen'
+    name_map['ptRaw'] = 'pt_raw'
+    name_map['massRaw'] = 'mass_raw'
+    name_map['Rho'] = 'rho'
+    name_map['METpt'] = 'pt'
+    name_map['METphi'] = 'phi'
+    name_map['UnClusteredEnergyDeltaX'] = 'MetUnclustEnUpDeltaX'
+    name_map['UnClusteredEnergyDeltaY'] = 'MetUnclustEnUpDeltaY'
+    if corr_type == 'met':
+        return CorrectedMETFactory(name_map)
+    return CorrectedJetsFactory(name_map, jec_stack)
 
 def ApplyJetSystematics(year,cleanedJets,syst_var):
-  if(syst_var == f'JER_{year}Up'): return cleanedJets.JER.up
-  elif(syst_var == f'JER_{year}Down'): return cleanedJets.JER.down
-  elif(syst_var == 'JESUp'): return cleanedJets.JES_jes.up
-  elif(syst_var == 'JESDown'): return cleanedJets.JES_jes.down
-  elif(syst_var == 'nominal'): return cleanedJets
-  elif(syst_var in ['nominal','MuonESUp','MuonESDown']): return cleanedJets
-  # Overwrite FlavorQCD with the proper jet flavor uncertainty
-  elif('JES_FlavorQCD' in syst_var in syst_var):# and (('Up' in syst_var and syst_var.replace('Up', '') in cleanedJets.fields) or ('Down' in syst_var and syst_var.replace('Down', '') in cleanedJets.fields))):
-      bmask = np.array(ak.flatten(abs(cleanedJets.partonFlavour)==5))
-      cmask = abs(cleanedJets.partonFlavour)==4
-      cmask = np.array(ak.flatten(cmask))
-      qmask = abs(cleanedJets.partonFlavour)<=3
-      qmask = np.array(ak.flatten(qmask))
-      gmask = abs(cleanedJets.partonFlavour)==21
-      gmask = np.array(ak.flatten(gmask))
-      corrections = np.array(np.zeros_like(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt)))
-      if 'Up' in syst_var:
-          corrections[bmask] = corrections[bmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[bmask]
-          corrections[cmask] = corrections[cmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[cmask]
-          corrections[qmask] = corrections[qmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[qmask]
-          corrections[gmask] = corrections[gmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[gmask]
-          corrections = ak.unflatten(corrections, ak.num(cleanedJets.JES_FlavorQCD.up.pt))
-          cleanedJets['JES_FlavorQCD']['up']['pt'] = corrections
-          return cleanedJets.JES_FlavorQCD.up
-      if 'Down' in syst_var:
-          corrections[bmask] = corrections[bmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[bmask]
-          corrections[cmask] = corrections[cmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[cmask]
-          corrections[qmask] = corrections[qmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[qmask]
-          corrections[gmask] = corrections[gmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[gmask]
-          corrections = ak.unflatten(corrections, ak.num(cleanedJets.JES_FlavorQCD.down.pt))
-          cleanedJets['JES_FlavorQCD']['down']['pt'] = corrections
-          return cleanedJets.JES_FlavorQCD.down
-  # Save `2016APV` as `2016APV` but look up `2016` corrections (no separate APV corrections available)
-  elif('Up' in syst_var and syst_var.replace('Up', '').replace('APV', '') in cleanedJets.fields): return cleanedJets[syst_var.replace('Up', '').replace('APV', '')].up
-  elif('Down' in syst_var and syst_var.replace('Down', '').replace('APV', '') in cleanedJets.fields): return cleanedJets[syst_var.replace('Down', '').replace('APV', '')].down
-  else: raise Exception(f"Error: Unknown variation \"{syst_var}\".")
+    if (syst_var == f'JER_{year}Up'):
+        return cleanedJets.JER.up
+    elif (syst_var == f'JER_{year}Down'):
+        return cleanedJets.JER.down
+    elif (syst_var == 'JESUp'):
+        return cleanedJets.JES_jes.up
+    elif (syst_var == 'JESDown'):
+        return cleanedJets.JES_jes.down
+    elif (syst_var == 'nominal'):
+        return cleanedJets
+    elif (syst_var in ['nominal','MuonESUp','MuonESDown']):
+        return cleanedJets
+    elif ('JES_FlavorQCD' in syst_var in syst_var):# and (('Up' in syst_var and syst_var.replace('Up', '') in cleanedJets.fields) or ('Down' in syst_var and syst_var.replace('Down', '') in cleanedJets.fields))):
+        # Overwrite FlavorQCD with the proper jet flavor uncertainty
+        bmask = np.array(ak.flatten(abs(cleanedJets.partonFlavour)==5))
+        cmask = abs(cleanedJets.partonFlavour)==4
+        cmask = np.array(ak.flatten(cmask))
+        qmask = abs(cleanedJets.partonFlavour)<=3
+        qmask = np.array(ak.flatten(qmask))
+        gmask = abs(cleanedJets.partonFlavour)==21
+        gmask = np.array(ak.flatten(gmask))
+        corrections = np.array(np.zeros_like(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt)))
+        if 'Up' in syst_var:
+            corrections[bmask] = corrections[bmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[bmask]
+            corrections[cmask] = corrections[cmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[cmask]
+            corrections[qmask] = corrections[qmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[qmask]
+            corrections[gmask] = corrections[gmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.up.pt))[gmask]
+            corrections = ak.unflatten(corrections, ak.num(cleanedJets.JES_FlavorQCD.up.pt))
+            cleanedJets['JES_FlavorQCD']['up']['pt'] = corrections
+            return cleanedJets.JES_FlavorQCD.up
+        if 'Down' in syst_var:
+            corrections[bmask] = corrections[bmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[bmask]
+            corrections[cmask] = corrections[cmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[cmask]
+            corrections[qmask] = corrections[qmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[qmask]
+            corrections[gmask] = corrections[gmask] + np.array(ak.flatten(cleanedJets.JES_FlavorQCD.down.pt))[gmask]
+            corrections = ak.unflatten(corrections, ak.num(cleanedJets.JES_FlavorQCD.down.pt))
+            cleanedJets['JES_FlavorQCD']['down']['pt'] = corrections
+            return cleanedJets.JES_FlavorQCD.down
+    # Save `2016APV` as `2016APV` but look up `2016` corrections (no separate APV corrections available)
+    elif ('Up' in syst_var and syst_var.replace('Up', '').replace('APV', '') in cleanedJets.fields):
+        return cleanedJets[syst_var.replace('Up', '').replace('APV', '')].up
+    elif ('Down' in syst_var and syst_var.replace('Down', '').replace('APV', '') in cleanedJets.fields):
+        return cleanedJets[syst_var.replace('Down', '').replace('APV', '')].down
+    else:
+        raise Exception(f"Error: Unknown variation \"{syst_var}\".")
 
 ###### Muon Rochester corrections
 ################################################################
 # https://gitlab.cern.ch/akhukhun/roccor
 # https://github.com/CoffeaTeam/coffea/blob/master/coffea/lookup_tools/rochester_lookup.py
-
 def ApplyRochesterCorrections(year, mu, is_data):
-    if year=='2016': rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2016bUL.txt"), loaduncs=True)
-    elif year=='2016APV': rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2016aUL.txt"), loaduncs=True)
-    elif year=='2017': rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2017UL.txt"), loaduncs=True)
-    elif year=='2018': rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2018UL.txt"), loaduncs=True)
+    if year == '2016':
+        rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2016bUL.txt"), loaduncs=True)
+    elif year == '2016APV':
+        rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2016aUL.txt"), loaduncs=True)
+    elif year == '2017':
+        rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2017UL.txt"), loaduncs=True)
+    elif year == '2018':
+        rochester_data = txt_converters.convert_rochester_file(topcoffea_path("data/MuonScale/RoccoR2018UL.txt"), loaduncs=True)
     rochester = rochester_lookup.rochester_lookup(rochester_data)
     if not is_data:
         hasgen = ~np.isnan(ak.fill_none(mu.matched_gen.pt, np.nan))
         mc_rand = np.random.rand(*ak.to_numpy(ak.flatten(mu.pt)).shape)
         mc_rand = ak.unflatten(mc_rand, ak.num(mu.pt, axis=1))
         corrections = np.array(ak.flatten(ak.ones_like(mu.pt)))
-        
-        mc_kspread = rochester.kSpreadMC(mu.charge[hasgen],mu.pt[hasgen],mu.eta[hasgen],mu.phi[hasgen],mu.matched_gen.pt[hasgen])
-        mc_ksmear = rochester.kSmearMC(mu.charge[~hasgen],mu.pt[~hasgen],mu.eta[~hasgen],mu.phi[~hasgen],mu.nTrackerLayers[~hasgen],mc_rand[~hasgen])
+        mc_kspread = rochester.kSpreadMC(
+            mu.charge[hasgen],mu.pt[hasgen],
+            mu.eta[hasgen],
+            mu.phi[hasgen],
+            mu.matched_gen.pt[hasgen]
+        )
+        mc_ksmear = rochester.kSmearMC(
+            mu.charge[~hasgen],
+            mu.pt[~hasgen],
+            mu.eta[~hasgen],
+            mu.phi[~hasgen],
+            mu.nTrackerLayers[~hasgen],
+            mc_rand[~hasgen]
+        )
         hasgen_flat = np.array(ak.flatten(hasgen))
         corrections[hasgen_flat] = np.array(ak.flatten(mc_kspread))
         corrections[~hasgen_flat] = np.array(ak.flatten(mc_ksmear))
         corrections = ak.unflatten(corrections, ak.num(mu.pt, axis=1))
     else:
         corrections = rochester.kScaleDT(mu.charge, mu.pt, mu.eta, mu.phi)
-
     return (mu.pt * corrections)
 
 ###### Trigger SFs
@@ -588,79 +719,85 @@ def ApplyRochesterCorrections(year, mu, is_data):
 StackOverUnderflow = lambda v : [sum(v[0:2])] + v[2:-2] + [sum(v[-2:])]
 
 def GetClopperPearsonInterval(hnum, hden):
-  ''' Compute Clopper-Pearson interval from numerator and denominator histograms '''
-  num = list(hnum.values(overflow='all')[()])
-  den = list(hden.values(overflow='all')[()])
-  if isinstance(num, list) and isinstance(num[0], np.ndarray):
-    for i in range(len(num)):
-      num[i] = np.array(StackOverUnderflow(list(num[i])), dtype=float)
-      den[i] = np.array(StackOverUnderflow(list(den[i])), dtype=float)
-    den = StackOverUnderflow(den)
-    num = StackOverUnderflow(num)
-  else: 
-    num = np.array(StackOverUnderflow(num), dtype=float); den = np.array(StackOverUnderflow(den), dtype=float)
-  num = np.array(num); den = np.array(den)
-  num[num>den]=den[num>den]
-  down, up = hist.clopper_pearson_interval(num, den)
-  ratio = np.array(num, dtype=float)/den
-  return [ratio, down, up]
+    ''' Compute Clopper-Pearson interval from numerator and denominator histograms '''
+    num = list(hnum.values(overflow='all')[()])
+    den = list(hden.values(overflow='all')[()])
+    if isinstance(num, list) and isinstance(num[0], np.ndarray):
+        for i in range(len(num)):
+            num[i] = np.array(StackOverUnderflow(list(num[i])), dtype=float)
+            den[i] = np.array(StackOverUnderflow(list(den[i])), dtype=float)
+        den = StackOverUnderflow(den)
+        num = StackOverUnderflow(num)
+    else: 
+        num = np.array(StackOverUnderflow(num), dtype=float)
+        den = np.array(StackOverUnderflow(den), dtype=float)
+    num = np.array(num); den = np.array(den)
+    num[num>den] = den[num>den]
+    down, up = hist.clopper_pearson_interval(num, den)
+    ratio = np.array(num, dtype=float) / den
+    return [ratio, down, up]
   
 def GetEff(num, den):
-  ''' Compute efficiency values from numerator and denominator histograms '''
-  ratio, down, up =  GetClopperPearsonInterval(num, den)
-  axis = num.axes()[0].name
-  bins = num.axis(axis).edges()
-  x    = num.axis(axis).centers()
-  xlo  = bins[:-1]
-  xhi  = bins[1:]
-  return [[x, xlo-x, xhi-x],[ratio, down-ratio, up-ratio]]
+    ''' Compute efficiency values from numerator and denominator histograms '''
+    ratio, down, up = GetClopperPearsonInterval(num, den)
+    axis = num.axes()[0].name
+    bins = num.axis(axis).edges()
+    x    = num.axis(axis).centers()
+    xlo  = bins[:-1]
+    xhi  = bins[1:]
+    return [[x, xlo-x, xhi-x],[ratio, down-ratio, up-ratio]]
 
 def GetSFfromCountsHisto(hnumMC, hdenMC, hnumData, hdenData):
-  ''' Compute scale factors from efficiency histograms for data and MC '''
-  Xmc, Ymc = GetEff(hnumMC, hdenMC)
-  Xda, Yda = GetEff(hnumData, hdenData)
-  ratio, do, up = GetRatioAssymetricUncertainties(Yda[0], Yda[1], Yda[2], Ymc[0], Ymc[1], Ymc[2])
-  return ratio, do, up
+    ''' Compute scale factors from efficiency histograms for data and MC '''
+    Xmc, Ymc = GetEff(hnumMC, hdenMC)
+    Xda, Yda = GetEff(hnumData, hdenData)
+    ratio, do, up = GetRatioAssymetricUncertainties(Yda[0], Yda[1], Yda[2], Ymc[0], Ymc[1], Ymc[2])
+    return ratio, do, up
     
 def GetRatioAssymetricUncertainties(num, numDo, numUp, den, denDo, denUp):
-  ''' Compute efficiencies from numerator and denominator counts histograms and uncertainties '''
-  ratio = num/den
-  uncUp = ratio*np.sqrt(numUp*numUp + denUp*denUp) 
-  uncDo = ratio*np.sqrt(numDo*numDo + denDo*denDo) 
-  return ratio, -uncDo, uncUp
+    ''' Compute efficiencies from numerator and denominator counts histograms and uncertainties '''
+    ratio = num / den
+    uncUp = ratio * np.sqrt(numUp * numUp + denUp * denUp) 
+    uncDo = ratio * np.sqrt(numDo * numDo + denDo * denDo) 
+    return ratio, -uncDo, uncUp
 
 ######  Scale Factors
 
 def LoadTriggerSF(year, ch='2l', flav='em'):
-  pathToTriggerSF = topcoffea_path('data/triggerSF/triggerSF_%s.pkl.gz'%year)
-  with gzip.open(pathToTriggerSF) as fin: hin = pickle.load(fin)
-  if ch=='2l': axisY='l1pt'
-  else: axisY='l0eta'
-  h = hin[ch][flav]
-  ratio, do, up = GetSFfromCountsHisto(h['hmn'], h['hmd'], h['hdn'], h['hdd'])
-  ratio[np.isnan(ratio)]=1.0; do[np.isnan(do)]=0.0;up[np.isnan(up)]=0.0
-  GetTrig   = lookup_tools.dense_lookup.dense_lookup(ratio, [h['hmn'].axis('l0pt').edges(), h['hmn'].axis(axisY).edges()])
-  GetTrigUp = lookup_tools.dense_lookup.dense_lookup(up   , [h['hmn'].axis('l0pt').edges(), h['hmn'].axis(axisY).edges()])
-  GetTrigDo = lookup_tools.dense_lookup.dense_lookup(do   , [h['hmn'].axis('l0pt').edges(), h['hmn'].axis(axisY).edges()])
-  return [GetTrig, GetTrigDo, GetTrigUp]
+    pathToTriggerSF = topcoffea_path('data/triggerSF/triggerSF_%s.pkl.gz' % year)
+    with gzip.open(pathToTriggerSF) as fin:
+        hin = pickle.load(fin)
+    if ch == '2l':
+        axisY = 'l1pt'
+    else:
+        axisY = 'l0eta'
+    h = hin[ch][flav]
+    ratio, do, up = GetSFfromCountsHisto(h['hmn'], h['hmd'], h['hdn'], h['hdd'])
+    ratio[np.isnan(ratio)] = 1.0
+    do[np.isnan(do)] = 0.0
+    up[np.isnan(up)] = 0.0
+    GetTrig   = lookup_tools.dense_lookup.dense_lookup(ratio, [h['hmn'].axis('l0pt').edges(), h['hmn'].axis(axisY).edges()])
+    GetTrigUp = lookup_tools.dense_lookup.dense_lookup(up   , [h['hmn'].axis('l0pt').edges(), h['hmn'].axis(axisY).edges()])
+    GetTrigDo = lookup_tools.dense_lookup.dense_lookup(do   , [h['hmn'].axis('l0pt').edges(), h['hmn'].axis(axisY).edges()])
+    return [GetTrig, GetTrigDo, GetTrigUp]
 
 def GetTriggerSF(year, events, lep0, lep1):
-  ls=[]
-  for syst in [0,1]:
-    #2l
-    SF_ee=np.where((events.is2l & events.is_ee),LoadTriggerSF(year,ch='2l',flav='ee')[syst](lep0.pt,lep1.pt),1.0)
-    SF_em=np.where((events.is2l & events.is_em),LoadTriggerSF(year,ch='2l',flav='em')[syst](lep0.pt,lep1.pt),1.0)
-    SF_mm=np.where((events.is2l & events.is_mm),LoadTriggerSF(year,ch='2l',flav='mm')[syst](lep0.pt,lep1.pt),1.0)
-    #3l
-    '''
-    SF_eee=np.where((events.is3l & events.is_eee),LoadTriggerSF(year,ch='3l',flav='eee')[syst](lep0.pt,lep0.eta),1.0)
-    SF_eem=np.where((events.is3l & events.is_eem),LoadTriggerSF(year,ch='3l',flav='eem')[syst](lep0.pt,lep0.eta),1.0)
-    SF_emm=np.where((events.is3l & events.is_emm),LoadTriggerSF(year,ch='3l',flav='emm')[syst](lep0.pt,lep0.eta),1.0)
-    SF_mmm=np.where((events.is3l & events.is_mmm),LoadTriggerSF(year,ch='3l',flav='mmm')[syst](lep0.pt,lep0.eta),1.0)
-    ls.append(SF_ee*SF_em*SF_mm*SF_eee*SF_eem*SF_emm*SF_mmm)
-    '''
-    ls.append(SF_ee*SF_em*SF_mm)
-  ls[1]=np.where(ls[1]==1.0,0.0,ls[1]) # stat unc. down
-  events['trigger_sf']=ls[0] #nominal
-  events['trigger_sfDown']=ls[0]-np.sqrt(ls[1]*ls[1]+ls[0]*0.02*ls[0]*0.02)
-  events['trigger_sfUp']=ls[0]+np.sqrt(ls[1]*ls[1]+ls[0]*0.02*ls[0]*0.02) 
+    ls = []
+    for syst in [0,1]:
+        #2l
+        SF_ee = np.where((events.is2l & events.is_ee), LoadTriggerSF(year,ch='2l',flav='ee')[syst](lep0.pt,lep1.pt), 1.0)
+        SF_em = np.where((events.is2l & events.is_em), LoadTriggerSF(year,ch='2l',flav='em')[syst](lep0.pt,lep1.pt), 1.0)
+        SF_mm = np.where((events.is2l & events.is_mm), LoadTriggerSF(year,ch='2l',flav='mm')[syst](lep0.pt,lep1.pt), 1.0)
+        #3l
+        '''
+        SF_eee=np.where((events.is3l & events.is_eee),LoadTriggerSF(year,ch='3l',flav='eee')[syst](lep0.pt,lep0.eta),1.0)
+        SF_eem=np.where((events.is3l & events.is_eem),LoadTriggerSF(year,ch='3l',flav='eem')[syst](lep0.pt,lep0.eta),1.0)
+        SF_emm=np.where((events.is3l & events.is_emm),LoadTriggerSF(year,ch='3l',flav='emm')[syst](lep0.pt,lep0.eta),1.0)
+        SF_mmm=np.where((events.is3l & events.is_mmm),LoadTriggerSF(year,ch='3l',flav='mmm')[syst](lep0.pt,lep0.eta),1.0)
+        ls.append(SF_ee*SF_em*SF_mm*SF_eee*SF_eem*SF_emm*SF_mmm)
+        '''
+        ls.append(SF_ee * SF_em * SF_mm)
+    ls[1] = np.where(ls[1] == 1.0, 0.0, ls[1]) # stat unc. down
+    events['trigger_sf'] = ls[0] #nominal
+    events['trigger_sfDown'] = ls[0] - np.sqrt(ls[1] * ls[1] + ls[0]*0.02*ls[0]*0.02)
+    events['trigger_sfUp'] = ls[0] + np.sqrt(ls[1] * ls[1] + ls[0]*0.02*ls[0]*0.02) 

--- a/topcoffea/modules/dataDrivenEstimation.py
+++ b/topcoffea/modules/dataDrivenEstimation.py
@@ -1,13 +1,14 @@
 import argparse
-from coffea import hist, processor
+from coffea import hist
 from topcoffea.modules.YieldTools import YieldTools
 from topcoffea.modules.GetValuesFromJsons import get_lumi, get_param
 import topcoffea.modules.utils as utils
 import cloudpickle
-from collections import defaultdict 
-import re, gzip
+from collections import defaultdict
+import re
+import gzip
 
-class DataDrivenProducer: 
+class DataDrivenProducer:
     def __init__(self, inputHist, outputName):
         yt=YieldTools()
         if type(inputHist) == str and inputHist.endswith('.pkl.gz'): # we are plugging a pickle file
@@ -43,7 +44,7 @@ class DataDrivenProducer:
                 match = pattern.search(sample.name)
                 sampleName=match.group('sample')
                 year=match.group('year')
-                if not match: 
+                if not match:
                     raise RuntimeError(f"Sample {sample} does not match the naming convention.")
                 if year not in ['16APV','16','17','18']:
                     raise RuntimeError(f"Sample {sample} does not match the naming convention, year \"{year}\" is unknown.")
@@ -62,7 +63,7 @@ class DataDrivenProducer:
                 hAR=histo.integrate('appl', ident)
 
                 if 'isAR' not in ident.name:
-                    # if we are in the signal region, we just take the 
+                    # if we are in the signal region, we just take the
                     # whole histogram integrating out the application region axis
                     if newhist==None:
                         newhist=hAR
@@ -88,13 +89,13 @@ class DataDrivenProducer:
                             if (syst_var_idet.name != "nominal"):
                                 syst_var_idet_rm_lst.append(syst_var_idet)
                         hFlips = hFlips.remove(syst_var_idet_rm_lst,"systematic")
-                        
-                        # now adding them to the list of processes: 
+
+                        # now adding them to the list of processes:
                         if newhist==None:
                             newhist=hFlips
                         else:
-                            newhist.add( hFlips ) 
-                            
+                            newhist.add( hFlips )
+
 
                     else:
                         # if we are in the nonprompt application region, we also integrate the application region axis
@@ -109,17 +110,17 @@ class DataDrivenProducer:
                             nonPromptName='nonpromptUL%s'%year
                             if self.dataName==sampleName:
                                 newNameDictData[nonPromptName].append(sample.name)
-                            elif sampleName in self.promptSubtractionSamples: 
+                            elif sampleName in self.promptSubtractionSamples:
                                 newNameDictNoData[nonPromptName].append(sample.name)
                             else:
                                 print(f"We won't consider {sampleName} for the prompt subtraction in the appl. region")
-                        
+
                         hFakes=hAR.group('sample',  hist.Cat('sample','sample'), newNameDictData)
                         # now we take all the stuff that is not data in the AR to make the prompt subtraction and assign them to nonprompt.
                         hPromptSub=hAR.group('sample', hist.Cat('sample','sample'), newNameDictNoData )
 
                         # remove the up/down variations (if any) from the prompt subtraction histo
-                        # but keep FFUp and FFDown, as these are the nonprompt up and down variations 
+                        # but keep FFUp and FFDown, as these are the nonprompt up and down variations
                         syst_var_idet_rm_lst = []
                         syst_var_idet_lst = hPromptSub.identifiers("systematic")
                         for syst_var_idet in syst_var_idet_lst:
@@ -131,7 +132,7 @@ class DataDrivenProducer:
                         # now we actually make the subtraction
                         hPromptSub.scale(-1)
                         hFakes.add(hPromptSub)
-                        # now adding them to the list of processes: 
+                        # now adding them to the list of processes:
                         if newhist==None:
                             newhist=hFakes
                         else:

--- a/topcoffea/modules/dataDrivenEstimation.py
+++ b/topcoffea/modules/dataDrivenEstimation.py
@@ -100,7 +100,7 @@ class DataDrivenProducer:
                     else:
                         # if we are in the nonprompt application region, we also integrate the application region axis
                         # and construct the new sample 'nonprompt'
-                        
+
                         # we look at data only, and rename it to fakes
                         newNameDictData=defaultdict(list); newNameDictNoData=defaultdict(list)
                         for sample in hAR.identifiers('sample'):

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -1,6 +1,5 @@
 import pickle
 import gzip
-import topcoffea.modules.HistEFT
 import numpy as np
 import boost_histogram as bh
 import uproot
@@ -14,7 +13,6 @@ from coffea.hist import StringBin, Cat, Bin
 
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.utils import regex_match
-import topcoffea.modules.eft_helper as efth
 
 PRECISION = 6   # Decimal point precision in the text datacard output
 
@@ -37,7 +35,7 @@ def to_hist(arr,name,zero_wgts=False):
         if arr[i] is not None:
             clipped.append( np.array(arr[i][1:-1]))     # Strip off the under/overflow bins
             clipped[i][-1] += arr[i][-1]  # Add the overflow bin to the right most bin content
-        else: 
+        else:
             clipped[i]=None
 
 
@@ -87,7 +85,7 @@ class JetScale(RateSystematic):
 
         self.symmeterize = True     # whether or not we attempt to make the up/down shifts equal in absolute terms
         self.min_lo = 0.01          # For large kappa values, do not let the symmeterization go negative
-    
+
     # Override the base implementation to handle the different dict structure
     # Note: The return value should be as a string
     def get_process(self,p,j):
@@ -172,7 +170,7 @@ class DatacardMaker():
         "njets": {
             "2l": [4,5,6,7],
             "3l": [2,3,4,5],
-            "4l": [2,3,4],    
+            "4l": [2,3,4],
         },
 
         "ptbl":    [0,100,200,400],
@@ -256,7 +254,7 @@ class DatacardMaker():
     def get_jet_mults(cls,s):
         """
             Returns the njet and bjet multiplicities based on the string passed to it in (j,b) order.
-            For the regular expression, group 1 matches 'njet_bjet', group 2 matches 'bjet_njet' 
+            For the regular expression, group 1 matches 'njet_bjet', group 2 matches 'bjet_njet'
             group 3 matches '_njet'.
         """
         rgx = re.compile(r"(_[2-7]j_[1-2]b)|(_[1-2]b_[2-7]j)|(_[2-7]j$)")
@@ -873,7 +871,7 @@ class DatacardMaker():
                             negative_bin_mask = np.where( arr[0] < 0) # see where bins are negative
                             arr[0][negative_bin_mask] = np.zeros_like( arr[0][negative_bin_mask] )  # set those to zero
                             if arr[1] is not None:
-                                arr[1][negative_bin_mask] = np.zeros_like( arr[1][negative_bin_mask] )  # if there's a sumw2 defined, that one's set to zero as well. Otherwise we will get 0 +/- something, which is compatible with negative 
+                                arr[1][negative_bin_mask] = np.zeros_like( arr[1][negative_bin_mask] )  # if there's a sumw2 defined, that one's set to zero as well. Otherwise we will get 0 +/- something, which is compatible with negative
 
                         syst = sp_key[0]
 
@@ -906,7 +904,7 @@ class DatacardMaker():
                                     # No matches found, so keep the original systematic name
                                     split_syst = syst_base
                                 elif len(matched) == 1:
-                                    # Found a match, so decorrelate the process from non-matched processes 
+                                    # Found a match, so decorrelate the process from non-matched processes
                                     group = matched[0]
                                     split_syst = f"{syst_base}_{group}"
                                     if group == "":
@@ -1115,8 +1113,8 @@ class DatacardMaker():
                 tup = tuple(x.name for x in sparse_key)
                 r[quad_name][tup]=[]
                 for i in range(2):
-                    r[quad_name][tup].append( 0.5*(tmp_lin_2[tup][i] - 2*tmp_lin_1[tup][i] + sm[tup][i]) ) 
-                    
+                    r[quad_name][tup].append( 0.5*(tmp_lin_2[tup][i] - 2*tmp_lin_1[tup][i] + sm[tup][i]) )
+
             for n2,wc2 in enumerate(wcs):
                 if n1 >= n2: continue
                 mixed_name = f"quad_mixed_{wc1}_{wc2}"

--- a/topcoffea/modules/eft_helper.py
+++ b/topcoffea/modules/eft_helper.py
@@ -9,9 +9,9 @@ import math
 @numba.njit
 def calc_eft_weights(q_coeffs,wc_values):
     """Calculate the weights for a specific set of WC values.
-        
+
     Args:
-        q_coeffs: Array specifying a set of quadric coefficients parameterizing the weights.  
+        q_coeffs: Array specifying a set of quadric coefficients parameterizing the weights.
                   The last dimension should specify the coefficients, while any earlier dimensions
                   might be for different histogram bins, events, etc.
         wc_values: A 1D array specifying the Wilson coefficients corrersponding to the desired weight.
@@ -19,7 +19,7 @@ def calc_eft_weights(q_coeffs,wc_values):
     Returns:
         An array of the weight values calculated from the quadratic parameterization.
     """
-    
+
     # Prepend "1" to the start of the WC array to account for constant and linear terms
     wcs = np.hstack((np.ones(1),wc_values))
 
@@ -132,7 +132,7 @@ def n_quartic_terms(n_wc):
 def calc_w2_coeffs(q_coeffs, dtype=np.float64):
     """Calculate the quartic coefficients for calculating the w**2 value (needed for histogram errors.
 
-    Args: 
+    Args:
         q_coeffs: Array specifying a set of quadric coefficients
                     parameterizing the weights.  The last dimension should
                     specify the coefficients, while any earlier dimensions
@@ -151,7 +151,7 @@ def calc_w2_coeffs(q_coeffs, dtype=np.float64):
 
     # Storage for the factors to multiply these coefficients
     factors = np.zeros(4)
-    
+
     # Loop over the quadratic terms and multiply them together
     for i in range(n_quad):
         for j in range(i+1):
@@ -177,10 +177,10 @@ def calc_w2_coeffs(q_coeffs, dtype=np.float64):
 @numba.njit
 def calc_eft_w2(quartic_coeffs_unique, wc_values):
     """Calculate the w**2 values for a specific set of WC values.
-        
+
     Args:
         quartic_coeffs_unique: Array specifying a set of quartic coefficients parameterizing the
-                    w**2 values.  Coefficients multiplying redundant terms have been summed.  
+                    w**2 values.  Coefficients multiplying redundant terms have been summed.
                     The last dimension should specify the coefficients, while any earlier dimensions
                     might be for different histogram bins, events, etc.
         wc_values: A 1D array specifying the Wilson coefficients corrersponding to the desired weight.
@@ -207,7 +207,7 @@ def calc_eft_w2(quartic_coeffs_unique, wc_values):
 
 def remap_coeffs(current_list, target_list, coeffs):
     """Remaps the quadratic fit coefficients to the appropriate order desired for filling a HistEFT.
-    
+
     Args:
         current_list: The list of WC names for this sample
         target_list: The list of WC names needed to fill the HistEFT
@@ -233,7 +233,7 @@ def remap_coeffs(current_list, target_list, coeffs):
 
     # The actual logic is inside this compiled code
     return _remap_coeffs(cl, tl, coeffs)
-    
+
 
 @numba.njit
 def _remap_coeffs(current_list, target_list, coeffs):
@@ -242,7 +242,7 @@ def _remap_coeffs(current_list, target_list, coeffs):
     for i, wc in enumerate(target_list):
         try:
             target_indices[i] = current_list.index(wc)
-        except:
+        except BaseException: # Edited this line Mar 25, 2023: flake8 says not to use bare except, so replacing with "except BaseException" which is supposed to be equivalent, but would probably be better to catch specific exceptions)
             target_indices[i] = -1
 
     # Next, loop over the WC pairs from the target_list and figure out

--- a/topcoffea/modules/parsejec.py
+++ b/topcoffea/modules/parsejec.py
@@ -7,7 +7,7 @@ It loads flat JEC files and parses them into a dictionary as:
     }
 }.
 The script then uses `jes_to_combine` to find all corrections which it should add in quadrature.
-Finanlly, it creates a new set of files (with `Quad` in the name instead of `RegroupedV2`) 
+Finanlly, it creates a new set of files (with `Quad` in the name instead of `RegroupedV2`)
 and writes out the new corrections.
 '''
 

--- a/topcoffea/modules/remote_environment.py
+++ b/topcoffea/modules/remote_environment.py
@@ -60,9 +60,9 @@ def _check_current_env():
         spec_file = open(f.name,  'r')
         current_spec = json.load(spec_file)
         if 'dependencies' in current_spec:
-        # get current conda packages
+            # get current conda packages
             conda_deps = {re.sub("[!~=<>].*$", "", x):x  for x in current_spec['dependencies'] if not isinstance(x, dict)}
-        # get current pip packages
+            # get current pip packages
             pip_deps = {re.sub("[!~=<>].*$", "", y):y for y in  [x for x in current_spec['dependencies'] if isinstance(x, dict) and 'pip' in x for x in x['pip']]}
 
 

--- a/topcoffea/modules/remote_environment.py
+++ b/topcoffea/modules/remote_environment.py
@@ -1,11 +1,9 @@
 #! /usr/bin/env python
 import json
 import hashlib
-import shutil
 import subprocess
 import sys
 import tempfile
-import time
 import logging
 import glob
 import os
@@ -21,8 +19,8 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s:%(levelname)s:%(mess
 env_dir_cache = Path.cwd().joinpath(Path('topeft-envs'))
 
 py_version = "{}.{}.{}".format(
-        sys.version_info[0], sys.version_info[1], sys.version_info[2]
-        )  # 3.8 or 3.9, or etc.
+    sys.version_info[0], sys.version_info[1], sys.version_info[2]
+)  # 3.8 or 3.9, or etc.
 
 coffea_version = coffea.__version__
 
@@ -62,9 +60,9 @@ def _check_current_env():
         spec_file = open(f.name,  'r')
         current_spec = json.load(spec_file)
         if 'dependencies' in current_spec:
-	    # get current conda packages
+        # get current conda packages
             conda_deps = {re.sub("[!~=<>].*$", "", x):x  for x in current_spec['dependencies'] if not isinstance(x, dict)}
-	    # get current pip packages
+        # get current pip packages
             pip_deps = {re.sub("[!~=<>].*$", "", y):y for y in  [x for x in current_spec['dependencies'] if isinstance(x, dict) and 'pip' in x for x in x['pip']]}
 
 

--- a/topcoffea/modules/selection.py
+++ b/topcoffea/modules/selection.py
@@ -1,7 +1,7 @@
 '''
  selection.py
 
- This script contains several functions that implement the some event selection. 
+ This script contains several functions that implement the some event selection.
  The functinos defined here can be used to define a selection, signal/control region, etc.
  The functions are called with (jagged)arrays as imputs plus some custom paramenters and return a boolean mask.
 
@@ -168,7 +168,7 @@ def passesTrgInLst(events,trg_name_lst):
 #   - Elements are false if they do not pass any of the triggers defined in dataset_dict
 #   - In the case of data, events are also false if they overlap with another dataset
 def trgPassNoOverlap(events,is_data,dataset,year):
-    
+
     # The trigger for 2016 and 2016APV are the same
     if year == "2016APV":
         year = "2016"
@@ -220,7 +220,7 @@ def add2lMaskAndSFs(events, year, isData, sampleType):
     dilep = (ak.num(FOs)) >= 2
     pt2515 = (ak.any(FOs[:,0:1].conept > 25.0, axis=1) & ak.any(FOs[:,1:2].conept > 15.0, axis=1))
     mask = (filters & cleanup & dilep & pt2515 & exclusive & eleID1 & eleID2 & muTightCharge)
-    
+
     # MC matching requirement (already passed for data)
     if sampleType == "data":
         pass
@@ -390,15 +390,15 @@ def addLepCatMasks(events):
     n_m_4l = ak.sum(is_m_mask,axis=-1)        # Look at all the leps
 
     # 2l masks
-    events['is_ee'] = ((n_e_2l==2) & (n_m_2l==0)) 
-    events['is_em'] = ((n_e_2l==1) & (n_m_2l==1)) 
-    events['is_mm'] = ((n_e_2l==0) & (n_m_2l==2)) 
+    events['is_ee'] = ((n_e_2l==2) & (n_m_2l==0))
+    events['is_em'] = ((n_e_2l==1) & (n_m_2l==1))
+    events['is_mm'] = ((n_e_2l==0) & (n_m_2l==2))
 
     # 3l masks
-    events['is_eee'] = ((n_e_3l==3) & (n_m_3l==0)) 
-    events['is_eem'] = ((n_e_3l==2) & (n_m_3l==1)) 
-    events['is_emm'] = ((n_e_3l==1) & (n_m_3l==2)) 
-    events['is_mmm'] = ((n_e_3l==0) & (n_m_3l==3)) 
+    events['is_eee'] = ((n_e_3l==3) & (n_m_3l==0))
+    events['is_eem'] = ((n_e_3l==2) & (n_m_3l==1))
+    events['is_emm'] = ((n_e_3l==1) & (n_m_3l==2))
+    events['is_mmm'] = ((n_e_3l==0) & (n_m_3l==3))
 
     # 4l masks
     events['is_eeee'] = ((n_e_4l==4) & (n_m_4l==0))

--- a/topcoffea/scripts/make_html.py
+++ b/topcoffea/scripts/make_html.py
@@ -106,7 +106,7 @@ def make_html(tar_dir, width=355, height=355):
         image_tag.addAttributes(width=width,height=height,border=0,src="./%s" % (fname))
 
         link_tag.addAttributes(target='_blank')
-        
+
         text_div.addAttributes(style=f'width:{width}px',id='imgName')
         text_div.setContent(image_name)
 


### PR DESCRIPTION
This PR adds [flake8](https://flake8.pycqa.org/en/latest/) to the CI. The PR also applies fixes to many of the topcoffea files in order to fix issues caught by the flake8 test. 

In the flake8 job in the CI yaml file, I added several flake8 error codes to ignore (for formatting things that I don't think we want to bother enforcing). I also entirely excluded a few files from the check (these files are quite old and are close to being deprecated, but are unfortunately still used in a few places, so we probably don't want to remove them yet. But if/when we come to the point where we want to build on these files, we might consider rewriting them instead of building the old ones). Eventually it may be useful to specify the error codes and files to ignore via a flake8 config file (instead of writing them all out in the CI yaml file). 

Addresses Issue #334 