### PR TITLE
edited condor datacard making command to remove do-nuisance flag

### DIFF
--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -199,13 +199,6 @@ def main():
     if isinstance(wcs,str):
         wcs = wcs.split(",")
 
-    #if use_condor:
-        # Note:
-        #   The dc in the parent submission is only used to generate the selectedWCs file and figure
-        #   out what channels/samples are available, so we can just drop the systematics to speed
-        #   things up
-        #do_nuis = False
-
     kwargs = {
         "wcs": wcs,
         "lumi_json_path": lumi_json,

--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -56,7 +56,7 @@ source ${USR_DIR}/miniconda3/etc/profile.d/conda.sh
 unset PYTHONPATH
 conda activate ${CONDA_DEFAULT_ENV}
 
-python make_cards.py ${INF} -d ${OUT_DIR} --var-lst ${VAR_LST} --ch-lst ${CH_LST} --use-selected "selectedWCs.txt" --do-nuisance ${OTHER}
+python make_cards.py ${INF} -d ${OUT_DIR} --var-lst ${VAR_LST} --ch-lst ${CH_LST} --use-selected "selectedWCs.txt" ${OTHER}
 """
 
 def run_local(dc,km_dists,channels,selected_wcs, crop_negative_bins):
@@ -111,6 +111,8 @@ def run_condor(dc,pkl_fpath,out_dir,var_lst,ch_lst,chunk_size):
         other_opts.append("--verbose")
     if dc.use_real_data:
         other_opts.append("--unblind")
+    if dc.do_nuisance:
+        other_opts.append("--do-nuisance")
     if dc.year_lst:
         other_opts.extend(["--year"," ".join(dc.year_lst)])
     if dc.drop_syst:
@@ -197,12 +199,12 @@ def main():
     if isinstance(wcs,str):
         wcs = wcs.split(",")
 
-    if use_condor:
+    #if use_condor:
         # Note:
         #   The dc in the parent submission is only used to generate the selectedWCs file and figure
         #   out what channels/samples are available, so we can just drop the systematics to speed
         #   things up
-        do_nuis = False
+        #do_nuis = False
 
     kwargs = {
         "wcs": wcs,


### PR DESCRIPTION
This PR fixes the issue with the `--do-nuisance` flag not working properly when running datacard maker (make_cards.py) using condor. The issue was that even when the flag was not explicitly called, the resulting datacards would still have the systematics included. It turned out that the datacard making command passed to condor had `--do-nuisance` flag always included. Getting rid of that and adding a new option to use the flag in `run_condor` method resolved the issue. 