### PR TITLE
Change electron name from e to ele in topeft

### DIFF
--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -180,7 +180,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # Initialize objects
         met  = events.MET
-        e    = events.Electron
+        ele  = events.Electron
         mu   = events.Muon
         tau  = events.Tau
         jets = events.Jet
@@ -189,13 +189,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Probably there's a better way to do this, but we use this method elsewhere so I guess why not..
         events.nom = ak.ones_like(events.MET.pt)
 
-        e["idEmu"] = ttH_idEmu_cuts_E3(e.hoe, e.eta, e.deltaEtaSC, e.eInvMinusPInv, e.sieie)
-        e["conept"] = coneptElec(e.pt, e.mvaTTHUL, e.jetRelIso)
+        ele["idEmu"] = ttH_idEmu_cuts_E3(ele.hoe, ele.eta, ele.deltaEtaSC, ele.eInvMinusPInv, ele.sieie)
+        ele["conept"] = coneptElec(ele.pt, ele.mvaTTHUL, ele.jetRelIso)
         mu["conept"] = coneptMuon(mu.pt, mu.mvaTTHUL, mu.jetRelIso, mu.mediumId)
-        e["btagDeepFlavB"] = ak.fill_none(e.matched_jet.btagDeepFlavB, -99)
+        ele["btagDeepFlavB"] = ak.fill_none(ele.matched_jet.btagDeepFlavB, -99)
         mu["btagDeepFlavB"] = ak.fill_none(mu.matched_jet.btagDeepFlavB, -99)
         if not isData:
-            e["gen_pdgId"] = ak.fill_none(e.matched_gen.pdgId, 0)
+            ele["gen_pdgId"] = ak.fill_none(ele.matched_gen.pdgId, 0)
             mu["gen_pdgId"] = ak.fill_none(mu.matched_gen.pdgId, 0)
 
         # Get the lumi mask for data
@@ -224,10 +224,10 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         ################### Electron selection ####################
 
-        e["isPres"] = isPresElec(e.pt, e.eta, e.dxy, e.dz, e.miniPFRelIso_all, e.sip3d, getattr(e,"mvaFall17V2noIso_WPL"))
-        e["isLooseE"] = isLooseElec(e.miniPFRelIso_all,e.sip3d,e.lostHits)
-        e["isFO"] = isFOElec(e.pt, e.conept, e.btagDeepFlavB, e.idEmu, e.convVeto, e.lostHits, e.mvaTTHUL, e.jetRelIso, e.mvaFall17V2noIso_WP90, year)
-        e["isTightLep"] = tightSelElec(e.isFO, e.mvaTTHUL)      
+        ele["isPres"] = isPresElec(ele.pt, ele.eta, ele.dxy, ele.dz, ele.miniPFRelIso_all, ele.sip3d, getattr(ele,"mvaFall17V2noIso_WPL"))
+        ele["isLooseE"] = isLooseElec(ele.miniPFRelIso_all,ele.sip3d,ele.lostHits)
+        ele["isFO"] = isFOElec(ele.pt, ele.conept, ele.btagDeepFlavB, ele.idEmu, ele.convVeto, ele.lostHits, ele.mvaTTHUL, ele.jetRelIso, ele.mvaFall17V2noIso_WP90, year)
+        ele["isTightLep"] = tightSelElec(ele.isFO, ele.mvaTTHUL)      
 
         ################### Muon selection ####################
 
@@ -240,7 +240,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         ################### Loose selection ####################
 
         m_loose = mu[mu.isPres & mu.isLooseM]
-        e_loose = e[e.isPres & e.isLooseE]
+        e_loose = ele[ele.isPres & ele.isLooseE]
         l_loose = ak.with_name(ak.concatenate([e_loose, m_loose], axis=1), 'PtEtaPhiMCandidate')
 
         ################### Tau selection ####################
@@ -257,7 +257,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # Build FO collection
         m_fo = mu[mu.isPres & mu.isLooseM & mu.isFO]
-        e_fo = e[e.isPres & e.isLooseE & e.isFO]
+        e_fo = ele[ele.isPres & ele.isLooseE & ele.isFO]
 
         # Attach the lepton SFs to the electron and muons collections
         AttachElectronSF(e_fo,year=year)

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -222,7 +222,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         ele["isPres"] = isPresElec(ele.pt, ele.eta, ele.dxy, ele.dz, ele.miniPFRelIso_all, ele.sip3d, getattr(ele,"mvaFall17V2noIso_WPL"))
         ele["isLooseE"] = isLooseElec(ele.miniPFRelIso_all,ele.sip3d,ele.lostHits)
         ele["isFO"] = isFOElec(ele.pt, ele.conept, ele.btagDeepFlavB, ele.idEmu, ele.convVeto, ele.lostHits, ele.mvaTTHUL, ele.jetRelIso, ele.mvaFall17V2noIso_WP90, year)
-        ele["isTightLep"] = tightSelElec(ele.isFO, ele.mvaTTHUL)      
+        ele["isTightLep"] = tightSelElec(ele.isFO, ele.mvaTTHUL)
 
         ################### Muon selection ####################
 


### PR DESCRIPTION
In this simple PR, topeft script has been modified to change all instances of `e` to `ele`. 
To verify that all such instances were changed and there were no issues as a result of this, I ran topeft on some signal samples, and there was no issue producing the pkl file. 