### PR TITLE
Use mamba

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env
-        init-shell: >-
-          bash
+          init-shell: >-
+            bash
 
       - name: Conda list
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,42 @@ jobs:
           exclude: "./topcoffea/modules/WCFit.py,./topcoffea/modules/WCPoint.py"
           ignore: "E116,E201,E202,E203,E211,E221,E222,E226,E225,E227,E228,E231,E241,E251,E261,E262,E265,E266,E271,E272,E301,E302,E303,E305,E402,F403,F405,E501,W504,E701,E702,E711,E713,E714,E722,E731,E741,F841,W391,W605"
 
+  Check-topcoffea-mamba:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
+          environment-name: topcoffea-env
+
+      - name: Conda list
+        run: |
+          conda list -n topcoffea-env
+
+      - name: Install pip packages
+        run: |
+          conda run -n topcoffea-env pip install -e .
+
+      - name: Pytest setup
+        run: |
+          conda install -y -n topcoffea-env -c conda-forge pytest
+
+      - name: Test update json
+        run: |
+          conda run -n topcoffea-env pytest tests/test_update_json.py
+
+      - name: Test HistEFT unit test
+        run: |
+          conda run -n topcoffea-env pytest tests/test_unit.py
+
+      - name: Test histEFT
+        run: |
+          conda run -n topcoffea-env pytest tests/test_HistEFT_add.py
+
+
   Check-topcoffea:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,12 @@ jobs:
           environment-file: environment.yml
           environment-name: topcoffea-env
 
-      - name: Conda list
+      - uses: mamba-org/setup-micromamba@v1
         with:
           init-shell: >-
             bash
+
+      - name: Conda list
         run: |
           micromamba list -n topcoffea-env
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,17 +32,11 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env
-      - run: |
-          micromamba info | grep -q "environment : env-name"
-        shell: micromamba-shell {0}
-
-      - name: Conda list
-        run: |
-          micromamba list -n topcoffea-env
 
       - name: Install pip packages
         run: |
-          micromamba run -n topcoffea-env pip install -e .
+          pip install -e .
+        shell: micromamba-shell {0}
 
       - name: Pytest setup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,34 +28,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: micromamba-org/setup-micromicromamba@v1
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env
 
       - name: Conda list
         run: |
-          mamba list -n topcoffea-env
+          micromamba list -n topcoffea-env
 
       - name: Install pip packages
         run: |
-          mamba run -n topcoffea-env pip install -e .
+          micromamba run -n topcoffea-env pip install -e .
 
       - name: Pytest setup
         run: |
-          mamba install -y -n topcoffea-env -c mamba-forge pytest
+          micromamba install -y -n topcoffea-env -c micromamba-forge pytest
 
       - name: Test update json
         run: |
-          mamba run -n topcoffea-env pytest tests/test_update_json.py
+          micromamba run -n topcoffea-env pytest tests/test_update_json.py
 
       - name: Test HistEFT unit test
         run: |
-          mamba run -n topcoffea-env pytest tests/test_unit.py
+          micromamba run -n topcoffea-env pytest tests/test_unit.py
 
       - name: Test histEFT
         run: |
-          mamba run -n topcoffea-env pytest tests/test_HistEFT_add.py
+          micromamba run -n topcoffea-env pytest tests/test_HistEFT_add.py
 
 
   Check-topcoffea:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,6 @@ jobs:
           environment-name: topcoffea-env
 
       - name: Conda list
-        uses: mamba-org/setup-micromamba@v1
         with:
           init-shell: >-
             bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,13 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env
+          init-shell: >-
+                bash
 
       - name: Install pip packages
         run: |
           pip install -e .
         shell: micromamba-shell {0}
-
-      - uses: mamba-org/setup-micromamba@v1
 
       - name: Pytest setup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,11 @@ jobs:
           pip install -e .
         shell: micromamba-shell {0}
 
+      - uses: mamba-org/setup-micromamba@v1
+
       - name: Pytest setup
         run: |
-          install -y -n topcoffea-env -c conda-forge pytest
-        shell: micromamba-shell {0}
+          micromba install -y -n topcoffea-env -c conda-forge pytest
 
       - name: Test update json
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           environment-name: topcoffea-env
       - run: |
           micromamba info | grep -q "environment : env-name"
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
 
       - name: Conda list
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,27 +35,27 @@ jobs:
 
       - name: Conda list
         run: |
-          conda list -n topcoffea-env
+          mamba list -n topcoffea-env
 
       - name: Install pip packages
         run: |
-          conda run -n topcoffea-env pip install -e .
+          mamba run -n topcoffea-env pip install -e .
 
       - name: Pytest setup
         run: |
-          conda install -y -n topcoffea-env -c conda-forge pytest
+          mamba install -y -n topcoffea-env -c mamba-forge pytest
 
       - name: Test update json
         run: |
-          conda run -n topcoffea-env pytest tests/test_update_json.py
+          mamba run -n topcoffea-env pytest tests/test_update_json.py
 
       - name: Test HistEFT unit test
         run: |
-          conda run -n topcoffea-env pytest tests/test_unit.py
+          mamba run -n topcoffea-env pytest tests/test_unit.py
 
       - name: Test histEFT
         run: |
-          conda run -n topcoffea-env pytest tests/test_HistEFT_add.py
+          mamba run -n topcoffea-env pytest tests/test_HistEFT_add.py
 
 
   Check-topcoffea:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Pytest setup
         run: |
-          micromba install -y -n topcoffea-env -c conda-forge pytest
+          micromamba install -y -n topcoffea-env -c conda-forge pytest
         shell: micromamba-shell {0}
 
       - name: Test update json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: mamba-org/setup-micromamba@v1
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Add conda to system path
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,12 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env
-          init-shell: >-
-            bash
 
       - name: Conda list
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          init-shell: >-
+            bash
         run: |
           micromamba list -n topcoffea-env
 
@@ -45,7 +47,7 @@ jobs:
 
       - name: Pytest setup
         run: |
-          micromamba install -y -n topcoffea-env -c micromamba-forge pytest
+          micromamba install -y -n topcoffea-env -c conda-forge pytest
 
       - name: Test update json
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Install pip packages
         run: |
           pip install -e .
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
 
       - name: Pytest setup
         run: |
           micromamba install -y -n topcoffea-env -c conda-forge pytest
-        shell: micromamba-shell {0}
+        shell: bash -el {0}
 
       - name: Test update json
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,9 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env
-
-      - uses: mamba-org/setup-micromamba@v1
-        with:
-          init-shell: >-
-            bash
+      - run: |
+          micromamba info | grep -q "environment : env-name"
+        shell: bash -el {0}
 
       - name: Conda list
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,19 +40,23 @@ jobs:
 
       - name: Pytest setup
         run: |
-          micromamba install -y -n topcoffea-env -c conda-forge pytest
+          install -y -n topcoffea-env -c conda-forge pytest
+        shell: micromamba-shell {0}
 
       - name: Test update json
         run: |
-          micromamba run -n topcoffea-env pytest tests/test_update_json.py
+          pytest tests/test_update_json.py
+        shell: micromamba-shell {0}
 
       - name: Test HistEFT unit test
         run: |
-          micromamba run -n topcoffea-env pytest tests/test_unit.py
+          pytest tests/test_unit.py
+        shell: micromamba-shell {0}
 
       - name: Test histEFT
         run: |
-          micromamba run -n topcoffea-env pytest tests/test_HistEFT_add.py
+          pytest tests/test_HistEFT_add.py
+        shell: micromamba-shell {0}
 
 
   Check-topcoffea:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,12 @@ jobs:
       - name: Install pip packages
         run: |
           pip install -e .
-        shell: micromamba-shell {0}
+        shell: bash -el {0}
 
       - name: Pytest setup
         run: |
           micromba install -y -n topcoffea-env -c conda-forge pytest
+        shell: micromamba-shell {0}
 
       - name: Test update json
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env
+        init-shell: >-
+          bash
 
       - name: Conda list
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: micromamba-org/setup-micromicromamba@v1
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
           environment-name: topcoffea-env


### PR DESCRIPTION
After a _lot_ of debugging, I got the CI working with mamba. It ran in under 2 minutes. For now I kept the original conda version in. We could discuss removing it, since the point of trying mamba was to speed up the CI time.