### PR TITLE
3l-offZ event categories division update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # topcoffea
+
+Tools that sit on top of coffea to facilitate CMS analyses. The repository is set up as a pip installable package. To install this package into a conda environment: 
+```
+git clone https://github.com/TopEFT/topcoffea.git
+cd topcoffea
+pip install -e .
+```
+
+
+
+Examples of analysis repositories making use of `topcoffea`:
+* [`topeft`](https://github.com/TopEFT/topeft): EFT analyses in the top sector. 
+* [`ewkcoffea`](): Multi boson analyses. 

--- a/topcoffea/modules/event_selection.py
+++ b/topcoffea/modules/event_selection.py
@@ -69,3 +69,19 @@ def get_Z_peak_mask(lep_collection,pt_window,flavor="os",zmass=91.2):
         raise Exception(f"Error: flavor requirement \"{flavor}\" is unknown.")
     sfosz_mask = ak.flatten(ak.any((zpeak_mask & sf_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
     return sfosz_mask
+
+# Returns a mask for all events with any os lepton pair within low region of off-Z
+# Mask will be True if any combination of 2 leptons from within the given collection satisfies the requirement
+def get_off_Z_mask_low(lep_collection,pt_window,flavor="os"):
+    ll_pairs = ak.combinations(lep_collection, 2, fields=["l0","l1"])
+    zpeak_mask = ((91.2-(ll_pairs.l0+ll_pairs.l1).mass)>pt_window)
+    if flavor == "os":
+        sf_mask = (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId)
+    elif flavor == "ss":
+        sf_mask = (ll_pairs.l0.pdgId == ll_pairs.l1.pdgId)
+    elif flavor == "as": # Same flav any sign
+        sf_mask = ((ll_pairs.l0.pdgId == ll_pairs.l1.pdgId) | (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId))
+    else:
+        raise Exception(f"Error: flavor requirement \"{flavor}\" is unknown.")
+    sfosz_mask = ak.flatten(ak.any((zpeak_mask & sf_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
+    return sfosz_mask

--- a/topcoffea/modules/event_selection.py
+++ b/topcoffea/modules/event_selection.py
@@ -72,16 +72,23 @@ def get_Z_peak_mask(lep_collection,pt_window,flavor="os",zmass=91.2):
 
 # Returns a mask for all events with any os lepton pair within low region of off-Z
 # Mask will be True if any combination of 2 leptons from within the given collection satisfies the requirement
-def get_off_Z_mask_low(lep_collection,pt_window,flavor="os"):
-    ll_pairs = ak.combinations(lep_collection, 2, fields=["l0","l1"])
+#def get_off_Z_mask_low(lep_collection,pt_window,flavor="os"):
+#    ll_pairs = ak.combinations(lep_collection, 2, fields=["l0","l1"])
+#    zpeak_mask = ((91.2-(ll_pairs.l0+ll_pairs.l1).mass)>pt_window)
+#    if flavor == "os":
+#        sf_mask = (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId)
+#    elif flavor == "ss":
+#        sf_mask = (ll_pairs.l0.pdgId == ll_pairs.l1.pdgId)
+#    elif flavor == "as": # Same flav any sign
+#        sf_mask = ((ll_pairs.l0.pdgId == ll_pairs.l1.pdgId) | (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId))
+#    else:
+#        raise Exception(f"Error: flavor requirement \"{flavor}\" is unknown.")
+#    sfosz_mask = ak.flatten(ak.any((zpeak_mask & sf_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
+#    return sfosz_mask
+
+# Returns a mask for all events with mll of leading pt lepton within low region of off-Z
+def get_off_Z_mask_low(lep_collection,pt_window):
+    ll_pairs = ak.combinations(lep_collection[:,0:2], 2, fields=["l0","l1"])   
     zpeak_mask = ((91.2-(ll_pairs.l0+ll_pairs.l1).mass)>pt_window)
-    if flavor == "os":
-        sf_mask = (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId)
-    elif flavor == "ss":
-        sf_mask = (ll_pairs.l0.pdgId == ll_pairs.l1.pdgId)
-    elif flavor == "as": # Same flav any sign
-        sf_mask = ((ll_pairs.l0.pdgId == ll_pairs.l1.pdgId) | (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId))
-    else:
-        raise Exception(f"Error: flavor requirement \"{flavor}\" is unknown.")
-    sfosz_mask = ak.flatten(ak.any((zpeak_mask & sf_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
+    sfosz_mask = ak.flatten(ak.any((zpeak_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
     return sfosz_mask

--- a/topcoffea/modules/event_selection.py
+++ b/topcoffea/modules/event_selection.py
@@ -72,23 +72,16 @@ def get_Z_peak_mask(lep_collection,pt_window,flavor="os",zmass=91.2):
 
 # Returns a mask for all events with any os lepton pair within low region of off-Z
 # Mask will be True if any combination of 2 leptons from within the given collection satisfies the requirement
-#def get_off_Z_mask_low(lep_collection,pt_window,flavor="os"):
-#    ll_pairs = ak.combinations(lep_collection, 2, fields=["l0","l1"])
-#    zpeak_mask = ((91.2-(ll_pairs.l0+ll_pairs.l1).mass)>pt_window)
-#    if flavor == "os":
-#        sf_mask = (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId)
-#    elif flavor == "ss":
-#        sf_mask = (ll_pairs.l0.pdgId == ll_pairs.l1.pdgId)
-#    elif flavor == "as": # Same flav any sign
-#        sf_mask = ((ll_pairs.l0.pdgId == ll_pairs.l1.pdgId) | (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId))
-#    else:
-#        raise Exception(f"Error: flavor requirement \"{flavor}\" is unknown.")
-#    sfosz_mask = ak.flatten(ak.any((zpeak_mask & sf_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
-#    return sfosz_mask
-
-# Returns a mask for all events with mll of leading pt lepton within low region of off-Z
-def get_off_Z_mask_low(lep_collection,pt_window):
-    ll_pairs = ak.combinations(lep_collection[:,0:2], 2, fields=["l0","l1"])   
+def get_off_Z_mask_low(lep_collection,pt_window,flavor="os"):
+    ll_pairs = ak.combinations(lep_collection, 2, fields=["l0","l1"])
     zpeak_mask = ((91.2-(ll_pairs.l0+ll_pairs.l1).mass)>pt_window)
-    sfosz_mask = ak.flatten(ak.any((zpeak_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
+    if flavor == "os":
+        sf_mask = (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId)
+    elif flavor == "ss":
+        sf_mask = (ll_pairs.l0.pdgId == ll_pairs.l1.pdgId)
+    elif flavor == "as": # Same flav any sign
+        sf_mask = ((ll_pairs.l0.pdgId == ll_pairs.l1.pdgId) | (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId))
+    else:
+        raise Exception(f"Error: flavor requirement \"{flavor}\" is unknown.")
+    sfosz_mask = ak.flatten(ak.any((zpeak_mask & sf_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
     return sfosz_mask

--- a/topcoffea/modules/event_selection.py
+++ b/topcoffea/modules/event_selection.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import awkward as ak
+import operator as op
 
 # This is a helper function called by trg_pass_no_overlap
 #   - Takes events objects, and a lits of triggers
@@ -84,4 +85,11 @@ def get_off_Z_mask_low(lep_collection,pt_window,flavor="os"):
     else:
         raise Exception(f"Error: flavor requirement \"{flavor}\" is unknown.")
     sfosz_mask = ak.flatten(ak.any((zpeak_mask & sf_mask),axis=1,keepdims=True)) # Use flatten here because it is too nested (i.e. it looks like this [[T],[F],[T],...], and want this [T,F,T,...]))
+    return sfosz_mask
+
+# Returns a mask for all events with any os lepton pair
+def get_any_sfos_pair(lep_collection):
+    ll_pairs = ak.combinations(lep_collection, 2, fields=["l0","l1"])
+    sf_mask = (ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId)
+    sfosz_mask = ak.flatten(ak.any(sf_mask,axis=1, keepdims=True))
     return sfosz_mask


### PR DESCRIPTION
This PR is crucial for the update of analysis including the division of 3l event categories.

The changes are made in `event_selection.py` to add an extra masking for low mass region of 3l-offZ channels (to use in the analysis processor in topeft).