### PR TITLE
Move scale weights from topeft to topcoffea

### DIFF
--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -8,6 +8,8 @@ from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.get_param_from_jsons import GetParam
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
 
+### Btag corrections ###
+
 # Evaluate btag method 1a weight for a single WP (https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods)
 #   - Takes as input a given array of eff and sf and a mask for whether or not the events pass a tag
 #   - Returns P(DATA)/P(MC)
@@ -126,4 +128,91 @@ def GetPUSF(nTrueInt, year, var='nominal'):
     weights = np.divide(nData,nMC)
     return weights
 
+
+
 ###############################################################
+###### Scale, PS weights (as implimented for TOP-22-006) ######
+###############################################################
+
+def AttachPSWeights(events):
+    '''
+        Return a list of PS weights
+        PS weights (w_var / w_nominal)
+        [0] is ISR=0.5 FSR = 1
+        [1] is ISR=1 FSR = 0.5
+        [2] is ISR=2 FSR = 1
+        [3] is ISR=1 FSR = 2
+    '''
+    ISR = 0
+    FSR = 1
+    ISRdown = 0
+    FSRdown = 1
+    ISRup = 2
+    FSRup = 3
+    if events.PSWeight is None:
+        raise Exception('PSWeight not found!')
+    # Add up variation event weights
+    events['ISRUp'] = events.PSWeight[:, ISRup]
+    events['FSRUp'] = events.PSWeight[:, FSRup]
+    # Add down variation event weights
+    events['ISRDown'] = events.PSWeight[:, ISRdown]
+    events['FSRDown'] = events.PSWeight[:, FSRdown]
+
+def AttachScaleWeights(events):
+    '''
+    Return a list of scale weights
+    LHE scale variation weights (w_var / w_nominal)
+    Case 1:
+        [0] is renscfact = 0.5d0 facscfact = 0.5d0
+        [1] is renscfact = 0.5d0 facscfact = 1d0
+        [2] is renscfact = 0.5d0 facscfact = 2d0
+        [3] is renscfact =   1d0 facscfact = 0.5d0
+        [4] is renscfact =   1d0 facscfact = 1d0
+        [5] is renscfact =   1d0 facscfact = 2d0
+        [6] is renscfact =   2d0 facscfact = 0.5d0
+        [7] is renscfact =   2d0 facscfact = 1d0
+        [8] is renscfact =   2d0 facscfact = 2d0
+    Case 2:
+        [0] is MUF = "0.5" MUR = "0.5"
+        [1] is MUF = "1.0" MUR = "0.5"
+        [2] is MUF = "2.0" MUR = "0.5"
+        [3] is MUF = "0.5" MUR = "1.0"
+        [4] is MUF = "2.0" MUR = "1.0"
+        [5] is MUF = "0.5" MUR = "2.0"
+        [6] is MUF = "1.0" MUR = "2.0"
+        [7] is MUF = "2.0" MUR = "2.0"
+    '''
+    # Determine if we are in case 1 or case 2 by checking if we have 8 or 9 weights
+    len_of_wgts = ak.count(events.LHEScaleWeight,axis=-1)
+    all_len_9_or_0_bool = ak.all((len_of_wgts==9) | (len_of_wgts==0))
+    all_len_8_or_0_bool = ak.all((len_of_wgts==8) | (len_of_wgts==0))
+    if all_len_9_or_0_bool:
+        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 9), 1) # FIXME this is a bandaid until we understand _why_ some are empty
+        renormDown_factDown = 0
+        renormDown          = 1
+        renormDown_factUp   = 2
+        factDown            = 3
+        nominal             = 4
+        factUp              = 5
+        renormUp_factDown   = 6
+        renormUp            = 7
+        renormUp_factUp     = 8
+    elif all_len_8_or_0_bool:
+        scale_weights = ak.fill_none(ak.pad_none(events.LHEScaleWeight, 8), 1) # FIXME this is a bandaid until we understand _why_ some are empty
+        renormDown_factDown = 0
+        renormDown          = 1
+        renormDown_factUp   = 2
+        factDown            = 3
+        factUp              = 4
+        renormUp_factDown   = 5
+        renormUp            = 6
+        renormUp_factUp     = 7
+    else:
+        raise Exception("Unknown weight type")
+    # Get the weights from the event
+    events['renormfactDown'] = scale_weights[:,renormDown_factDown]
+    events['renormDown']     = scale_weights[:,renormDown]
+    events['factDown']       = scale_weights[:,factDown]
+    events['factUp']         = scale_weights[:,factUp]
+    events['renormUp']       = scale_weights[:,renormUp]
+    events['renormfactUp']   = scale_weights[:,renormUp_factUp]

--- a/topcoffea/modules/createJSON.py
+++ b/topcoffea/modules/createJSON.py
@@ -130,8 +130,6 @@ def main():
                     n_sum_of_lhe_weights[i] += i_sum_of_lhe_weights[i]
 
         # Raise error if there is a mix of data and mc files
-        print("is_data_lst",is_data_lst)
-        print("is_data_set",set(is_data_lst))
         if len(set(is_data_lst)) != 1:
             raise Exception("ERROR: There are a mix of files that are data and mc")
         # Otherwise all are same, so we can take is_data for the full list to be just whatever it is for the first element

--- a/topcoffea/modules/createJSON.py
+++ b/topcoffea/modules/createJSON.py
@@ -26,6 +26,9 @@ def main():
     parser.add_argument('--options'         , default=''           , help = 'Sample-dependent options to pass to your analysis')
     parser.add_argument('--verbose','-v'    , action='store_true'  , help = 'Activate the verbosing')
 
+    parser.add_argument('--includeLheWgts'  , action='store_true' , help = 'Include the set of LHE weights')
+
+
     args, unknown = parser.parse_known_args()
     #cfgfile     = args.cfgfile
     path         = args.path
@@ -110,12 +113,21 @@ def main():
         n_gen_events = 0
         n_sum_of_weights = 0
         is_data_lst = []
+        n_sum_of_lhe_weights = None
         for f in files_with_prefix:
-            i_events, i_gen_events, i_sum_of_weights, is_data = get_info(f, treeName)
+            i_events, i_gen_events, i_sum_of_weights, i_sum_of_lhe_weights, is_data = get_info(f, treeName)
             n_events += i_events
             n_gen_events += i_gen_events
             n_sum_of_weights += i_sum_of_weights
             is_data_lst.append(is_data)
+            # Get the sum of the up and down LHE weights
+            if n_sum_of_lhe_weights is None:
+                n_sum_of_lhe_weights = list(i_sum_of_lhe_weights)
+            else:
+                if len(n_sum_of_lhe_weights) != len(i_sum_of_lhe_weights):
+                    raise Exception("Different length of LHE weight array in different files.")
+                for i in range(len(n_sum_of_lhe_weights)):
+                    n_sum_of_lhe_weights[i] += i_sum_of_lhe_weights[i]
 
         # Raise error if there is a mix of data and mc files
         print("is_data_lst",is_data_lst)
@@ -138,6 +150,8 @@ def main():
     sampdic['nSumOfWeights'] = n_sum_of_weights
     sampdic['isData']        = is_data
     sampdic['path']          = path
+    if args.includeLheWgts:
+        sampdic['nSumOfLheWeights'] = n_sum_of_lhe_weights
 
     outname = sample
     if not outname.endswith('.json'): outname += '.json'

--- a/topcoffea/modules/sample_lst_jsons_tools.py
+++ b/topcoffea/modules/sample_lst_jsons_tools.py
@@ -47,11 +47,13 @@ def replace_xsec_for_dict_of_samples(samples_dict,out_dir):
         replace_val_in_json(path_to_json,"xsec",new_xsec)
 
 # Wrapper for createJSON.py
-def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,on_das=False):
+def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,on_das=False,include_lhe_wgts_arr=False):
 
     # If the sample is on DAS, inclue the DAS flag in the createJSON.py arguments
     das_flag = ""
+    include_lhe_wgts_arr_flag = ""
     if on_das: das_flag = "--DAS"
+    if include_lhe_wgts_arr: include_lhe_wgts_arr_flag = "--includeLheWgts"
 
     path_to_createJSON = topcoffea_path("modules/createJSON.py")
     path_to_xsecs = topcoffea_path("params/xsec.yml")
@@ -61,6 +63,7 @@ def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,o
         path_to_createJSON,
         sample_dir,
         das_flag,
+        include_lhe_wgts_arr_flag,
         "--sampleName"   , sample_name,
         "--prefix"       , prefix,
         "--xsec"         , path_to_xsecs,

--- a/topcoffea/modules/utils.py
+++ b/topcoffea/modules/utils.py
@@ -144,7 +144,13 @@ def get_info(fname, tree_name = "Events"):
                 sow_key = "genEventSumw"  if "genEventSumw"  in runs else "genEventSumw_"
                 gen_events = sum(runs[gen_key].array())
                 sow_events = sum(runs[sow_key].array())
-    return [raw_events, gen_events, sow_events, is_data]
+
+                # Get the LHE weights array (note it's stored as a ratio, so multiply by sow before summing)
+                sow_arr = runs[sow_key].array()
+                LHEScaleSumw_arr = runs["LHEScaleSumw"].array()
+                sow_lhe_wgts = sum(sow_arr*LHEScaleSumw_arr)
+
+    return [raw_events, gen_events, sow_events, sow_lhe_wgts, is_data]
 
 
 # Get the list of WC names from an EFT sample naod root file


### PR DESCRIPTION
Move the code for getting reform/fact and ISR/FSR weights to topcoffea from topeft.

Also add an option to createJSON to return the array of the summed LHE up and down weights (i.e. renormalization and factorization up and down weights). 