### PR TITLE
Cross section with qqZZ k factor applied

### DIFF
--- a/topcoffea/params/xsec.yml
+++ b/topcoffea/params/xsec.yml
@@ -90,6 +90,10 @@ ZZTo2L2Q                : 3.28
 ZZTo2Q2Nu               : 4.04
 ZZTo4L                  : 1.256
 
+# qq-ZZ sample scaled by the 1.1 K factor as per SMP-19-001
+# See further: https://indico.cern.ch/event/494560/contributions/2014919/attachments/1223781/1798362/ZZ_crosssection_13TeV_preapproval.pdf
+ZZTo4LK                 : 1.3816
+
 ggToZHToHToWWTo2L2Nu    : 0.00275
 qqToZHToZTo2L           : 0.0018639
 


### PR DESCRIPTION
Adding a qqZZ cross section number that has the nnlo k factor of 1.1 applied (e.g. see SMP-19-001, as documented in the cross section yaml file). 