### PR TITLE
Fix `renormfact` terms

### DIFF
--- a/topcoffea/modules/corrections.py
+++ b/topcoffea/modules/corrections.py
@@ -363,4 +363,10 @@ def AttachScaleWeights(events):
 
     # Assign the weights from the event to the respective fields dynamically using a loop
     for key in scale_indices:
-        events[key] = scale_weights[:, scale_indices[key]]
+        # Hack to change renorm<Up/Down>_fact<Up/Down> to renormfact_<Up/Down>
+        tkey = key
+        if tkey == 'renormUp_factUp':
+            tkey = 'renormfactUp'
+        elif tkey == 'renormDown_factDown':
+            tkey = 'renormfactDown'
+        events[tkey] = scale_weights[:, scale_indices[key]]


### PR DESCRIPTION
The new docstring based LHE scale method in `corrections.py` gives slightly different names from what TopEFT expects. Instead of `renormfact<Up/Down>` it produces `renorm<Up/Down>_fact<Up/Down>`. This was the simplest change, but it is a hack, so we can revisit it if others would prefer a better solution.