### PR TITLE
Do not hard code a file to skip

### DIFF
--- a/topcoffea/modules/createJSON.py
+++ b/topcoffea/modules/createJSON.py
@@ -29,6 +29,7 @@ def main():
 
     parser.add_argument('--includeLheWgts'  , action='store_true' , help = 'Include the set of LHE weights')
 
+    parser.add_argument('--skipFileName', default=None            , help = 'Skip this root file')
 
     args, unknown = parser.parse_known_args()
     #cfgfile     = args.cfgfile
@@ -46,6 +47,7 @@ def main():
     isDAS        = args.DAS
     nFiles       = int(args.nFiles) if not args.nFiles is None else None
     verbose      = args.verbose
+    skip_file_name = args.skipFileName
 
     with open(topcoffea_path("params/xsec.yml")) as f:
         xsecdic = yaml.load(f,Loader=yaml.CLoader)
@@ -85,9 +87,11 @@ def main():
         dicFiles = GetDatasetFromDAS(dataset, nFiles, options='file', withRedirector=prefix)
         files = [f[len(prefix):] for f in dicFiles['files']]
         files_with_prefix = dicFiles['files']
-        if 'root://cms-xrd-global.cern.ch//store/mc/Run3Summer22NanoAODv12/ZZZ_TuneCP5_13p6TeV_amcatnlo-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_v5-v2/50000/7c4f3eb2-3c7e-4c21-98ed-c1892bb3a057.root' in files_with_prefix:
-            print("ZZZ sample")
-            files_with_prefix.remove('root://cms-xrd-global.cern.ch//store/mc/Run3Summer22NanoAODv12/ZZZ_TuneCP5_13p6TeV_amcatnlo-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_v5-v2/50000/7c4f3eb2-3c7e-4c21-98ed-c1892bb3a057.root')
+        # Skip a root file if it's specified
+        if skip_file_name is not None:
+            if skip_file_name in files_with_prefix:
+                print(f"\nNote: Skipping file {skip_file_name}.\n")
+                files_with_prefix.remove(skip_file_name)
         # This DAS command for some reason returns the output doubled and will look something like this:
         #   output = " \ndata  \ndata  \n "
         # So we strip off the whitespace and spurious newlines and then only take the first of the duplicates

--- a/topcoffea/modules/createJSON.py
+++ b/topcoffea/modules/createJSON.py
@@ -92,6 +92,7 @@ def main():
             if skip_file_name in files_with_prefix:
                 print(f"\nNote: Skipping file {skip_file_name}.\n")
                 files_with_prefix.remove(skip_file_name)
+                files.remove(skip_file_name[len(prefix):])
         # This DAS command for some reason returns the output doubled and will look something like this:
         #   output = " \ndata  \ndata  \n "
         # So we strip off the whitespace and spurious newlines and then only take the first of the duplicates

--- a/topcoffea/modules/createJSON.py
+++ b/topcoffea/modules/createJSON.py
@@ -29,7 +29,7 @@ def main():
 
     parser.add_argument('--includeLheWgts'  , action='store_true' , help = 'Include the set of LHE weights')
 
-    parser.add_argument('--skipFileName', default=None            , help = 'Skip this root file')
+    parser.add_argument('--skipFileName', nargs='+', default=[], help = 'Skip this root file')
 
     args, unknown = parser.parse_known_args()
     #cfgfile     = args.cfgfile
@@ -88,11 +88,11 @@ def main():
         files = [f[len(prefix):] for f in dicFiles['files']]
         files_with_prefix = dicFiles['files']
         # Skip a root file if it's specified
-        if skip_file_name is not None:
-            if skip_file_name in files_with_prefix:
-                print(f"\nNote: Skipping file {skip_file_name}.\n")
-                files_with_prefix.remove(skip_file_name)
-                files.remove(skip_file_name[len(prefix):])
+        for skip_file in skip_file_name:
+            if skip_file in files_with_prefix:
+                print(f"\nNote: Skipping file {skip_file}.\n")
+                files_with_prefix.remove(skip_file)
+                files.remove(skip_file[len(prefix):])
         # This DAS command for some reason returns the output doubled and will look something like this:
         #   output = " \ndata  \ndata  \n "
         # So we strip off the whitespace and spurious newlines and then only take the first of the duplicates

--- a/topcoffea/modules/sample_lst_jsons_tools.py
+++ b/topcoffea/modules/sample_lst_jsons_tools.py
@@ -47,7 +47,7 @@ def replace_xsec_for_dict_of_samples(samples_dict,out_dir):
         replace_val_in_json(path_to_json,"xsec",new_xsec)
 
 # Wrapper for createJSON.py
-def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,era=None,on_das=False,include_lhe_wgts_arr=False,skip_file_name=None):
+def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,era=None,on_das=False,include_lhe_wgts_arr=False,skip_file_name=[]):
 
     # If the sample is on DAS, inclue the DAS flag in the createJSON.py arguments
     das_flag = ""
@@ -77,8 +77,11 @@ def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,e
     if xsec_name:
         args.extend(['--xsecName',xsec_name])
 
-    if skip_file_name is not None:
-        args.extend(['--skipFileName', skip_file_name])
+    if skip_file_name:
+        if isinstance(skip_file_name,list):
+            args.extend(['--skipFileName', *skip_file_name])
+        elif isinstance(skip_file_name,str):
+            args.extend(['--skipFileName', skip_file_name])
 
     # Run createJSON.py
     subprocess.run(args)

--- a/topcoffea/modules/sample_lst_jsons_tools.py
+++ b/topcoffea/modules/sample_lst_jsons_tools.py
@@ -47,7 +47,7 @@ def replace_xsec_for_dict_of_samples(samples_dict,out_dir):
         replace_val_in_json(path_to_json,"xsec",new_xsec)
 
 # Wrapper for createJSON.py
-def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,era=None,on_das=False,include_lhe_wgts_arr=False):
+def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,era=None,on_das=False,include_lhe_wgts_arr=False,skip_file_name=None):
 
     # If the sample is on DAS, inclue the DAS flag in the createJSON.py arguments
     das_flag = ""
@@ -76,6 +76,9 @@ def make_json(sample_dir,sample_name,prefix,sample_yr,xsec_name,hist_axis_name,e
 
     if xsec_name:
         args.extend(['--xsecName',xsec_name])
+
+    if skip_file_name is not None:
+        args.extend(['--skipFileName', skip_file_name])
 
     # Run createJSON.py
     subprocess.run(args)


### PR DESCRIPTION
This PR removes the hard coded skipping of a particular ROOT file, as discussed here https://github.com/TopEFT/topcoffea/issues/55.

To achieve the same behavior as the current master branch, one would just need to pass the previously hard coded string to `sample_lst_jsons_tools.py.make_json()`

However, please note that the current master version only implements this skipping in the case when the files are being obtained via DAS (so this fix to remove the hard coding follows the same). 