### PR TITLE
scaling ttgamma xsec by NLO k-factor

### DIFF
--- a/topcoffea/params/xsec.yml
+++ b/topcoffea/params/xsec.yml
@@ -34,9 +34,12 @@ TTG                     : 3.697
 TTGJets                 : 3.697
 
 # For the dileptonic and semileptonic ttgamma xsecs, use the LO xsec from the gridpacks
-# As done in TOP-21-004, the LO xsec is scaled by an NLO k-factor of 1.4852
-TTGamma_Dilept     : 2.2471   # 1.513 * 1.4852
-TTGamma_SingleLept : 7.6057   # 5.121 * 1.4852
+TTGamma_Dilept     : 1.513
+TTGamma_SingleLept : 5.121
+
+# As done in TOP-21-004, the LO TTGamma xsec is scaled by an NLO k-factor of 1.4852
+TTGamma_DileptK     : 2.2471   # 1.513 * 1.4852
+TTGamma_SingleLeptK : 7.6057   # 5.121 * 1.4852
 
 # The most up to date ttW xsec is from JHEP 11 (2021) 29: (1-0.6741)*0.722
 TTWJetsToLNu            : 0.23529979999999998

--- a/topcoffea/params/xsec.yml
+++ b/topcoffea/params/xsec.yml
@@ -34,8 +34,9 @@ TTG                     : 3.697
 TTGJets                 : 3.697
 
 # For the dileptonic and semileptonic ttgamma xsecs, use the LO xsec from the gridpacks
-TTGamma_Dilept     : 1.513
-TTGamma_SingleLept : 5.121
+# As done in TOP-21-004, the LO xsec is scaled by an NLO k-factor of 1.4852
+TTGamma_Dilept     : 2.2471   # 1.513 * 1.4852
+TTGamma_SingleLept : 7.6057   # 5.121 * 1.4852
 
 # The most up to date ttW xsec is from JHEP 11 (2021) 29: (1-0.6741)*0.722
 TTWJetsToLNu            : 0.23529979999999998


### PR DESCRIPTION
This is a simple PR to scale the current LO ttgamma xsec by an NLO k-factor as done in TOP-21-004 analysis (see CMS AN-20-186 v14 for more details). 