### PR TITLE
current versions from conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - conda-forge::python=3.9
   - numpy=1.23.5
   - coffea=0.7.21
-  - ndcctools
+  - ndcctools>=7.14.6
   - conda-pack
   - dill
   - xrootd

--- a/topcoffea/modules/remote_environment.py
+++ b/topcoffea/modules/remote_environment.py
@@ -28,15 +28,14 @@ default_modules = {
         "packages": [
             f"python={py_version}",
             "pip",
-            "coffea",
-            "conda",
+            "conda<2025.1.0",
             "conda-pack",
-            "dill",
+            "ndcctools>=7.14.7",
             "xrootd",
             "setuptools==70.3.0",
         ],
     },
-    "pip": ["topcoffea"],
+    "pip": ["topcoffea", "coffea==0.7.26"],
 }
 
 pip_local_to_watch = {"topcoffea": ["topcoffea", "setup.py"]}


### PR DESCRIPTION

This pr add supports for automatic pinning to the package versions of the current conda environment. For any package not explicitly pinned, if the package comes from conda it will correspond to the version of the conda environment currently in use. This should ensure compatibility of python, numpy, etc.

Supersedes #63 