### PR TITLE
Get latest coffea backport from pip (not available from conda)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - conda-forge::python=3.9
   - numpy=1.23.5
-  - ndcctools>=7.15.4
+  - ndcctools>=7.15.10
   - conda-pack
   - dill
   - xrootd

--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,12 @@ channels:
 dependencies:
   - conda-forge::python=3.9
   - numpy=1.23.5
-  - coffea=0.7.21
-  - ndcctools
+  - ndcctools>=7.15.4
   - conda-pack
   - dill
   - xrootd
   - git
   - pyyaml
+  - pip:
+    - coffea>=0.7.26
+


### PR DESCRIPTION
This change is needed for coffea-casa.