### PR TITLE
Add Type-1 MET correction factory

### DIFF
--- a/tests/test_corrected_met_factory.py
+++ b/tests/test_corrected_met_factory.py
@@ -1,9 +1,12 @@
+import inspect
 import math
 
 import awkward as ak
+import numpy as np
 import pytest
 
 from topcoffea.modules.CorrectedMETFactory import CorrectedMETFactory
+from topcoffea.modules.Type1CorrectedMETFactory import Type1CorrectedMETFactory
 
 
 NAME_MAP = {
@@ -23,6 +26,223 @@ def _jets():
 
 def _value(array):
     return float(ak.to_numpy(ak.materialized(array))[0])
+
+
+class _CorrectionInput:
+    def __init__(self, name):
+        self.name = name
+
+
+class _ConstantCorrection:
+    def __init__(self, scale):
+        self.scale = np.float32(scale)
+        self.inputs = [
+            _CorrectionInput("JetPt"),
+            _CorrectionInput("JetEta"),
+            _CorrectionInput("JetA"),
+            _CorrectionInput("Rho"),
+        ]
+
+    def evaluate(self, *inputs):
+        return np.ones(len(np.asarray(inputs[0])), dtype=np.float32) * self.scale
+
+
+class _PtScaledCorrection:
+    def __init__(self, reference_pt):
+        self.reference_pt = np.float32(reference_pt)
+        self.inputs = [
+            _CorrectionInput("JetPt"),
+            _CorrectionInput("JetEta"),
+            _CorrectionInput("JetA"),
+            _CorrectionInput("Rho"),
+        ]
+
+    def evaluate(self, *inputs):
+        return np.asarray(inputs[0], dtype=np.float32) / self.reference_pt
+
+
+class _FakeJECStack:
+    def __init__(self, l1_scale=1.0, l2_scale=2.0, l2_correction=None):
+        self.use_clib = True
+        self.jec_names_clib = [
+            "Test_L1FastJet_AK4PFPuppi",
+            "Test_L2Relative_AK4PFPuppi",
+        ]
+        self.corrections = {
+            self.jec_names_clib[0]: _ConstantCorrection(l1_scale),
+            self.jec_names_clib[1]: l2_correction or _ConstantCorrection(l2_scale),
+        }
+
+    def get_l1_jec_names(self):
+        return [self.jec_names_clib[0]]
+
+    def get_full_jec_names(self):
+        return list(self.jec_names_clib)
+
+
+def _make_fake_corrected_jets_factory(
+    nominal_pt=50.0,
+    jer_up_pt=75.0,
+    jer_down_pt=25.0,
+    jes_up_pt=60.0,
+    jes_down_pt=45.0,
+):
+    class _FakeCorrectedJetsFactory:
+        instances = []
+
+        def __init__(
+            self,
+            name_map,
+            jec_stack,
+            run,
+            suppress_forward_eta_stochastic_jer=False,
+        ):
+            self.name_map = name_map
+            self.jec_stack = jec_stack
+            self.run = run
+            self.suppress_forward_eta_stochastic_jer = suppress_forward_eta_stochastic_jer
+            self.build_calls = 0
+            type(self).instances.append(self)
+
+        def build(self, jets, lazy_cache):
+            self.build_calls += 1
+            self.lazy_cache = lazy_cache
+            pt_field = self.name_map["JetPt"]
+            nominal = ak.ones_like(jets[pt_field]) * nominal_pt
+            out = ak.with_field(jets, nominal, pt_field)
+
+            jer_up = ak.with_field(out, ak.ones_like(jets[pt_field]) * jer_up_pt, pt_field)
+            jer_down = ak.with_field(out, ak.ones_like(jets[pt_field]) * jer_down_pt, pt_field)
+            jes_up = ak.with_field(out, ak.ones_like(jets[pt_field]) * jes_up_pt, pt_field)
+            jes_down = ak.with_field(out, ak.ones_like(jets[pt_field]) * jes_down_pt, pt_field)
+
+            out = ak.with_field(out, ak.zip({"up": jer_up, "down": jer_down}), "JER")
+            return ak.with_field(
+                out,
+                ak.zip({"up": jes_up, "down": jes_down}),
+                "JES_Total",
+            )
+
+    return _FakeCorrectedJetsFactory
+
+
+TYPE1_NAME_MAP = {
+    "METpt": "pt",
+    "METphi": "phi",
+    "RawMETpt": "pt",
+    "RawMETphi": "phi",
+    "JetPt": "pt",
+    "JetPhi": "phi",
+    "JetEta": "eta",
+    "JetA": "area",
+    "JetRawFactor": "rawFactor",
+    "JetMuonSubtrFactor": "muonSubtrFactor",
+    "JetMuonSubtrDeltaPhi": "muonSubtrDeltaPhi",
+    "JetChEmEF": "chEmEF",
+    "JetNeEmEF": "neEmEF",
+    "CorrT1JetPt": "rawPt",
+    "CorrT1JetPhi": "phi",
+    "CorrT1JetEta": "eta",
+    "CorrT1JetArea": "area",
+    "CorrT1JetMuonSubtrFactor": "muonSubtrFactor",
+    "CorrT1JetMuonSubtrDeltaPhi": "muonSubtrDeltaPhi",
+    "CorrT1JetEmEF": "EmEF",
+    "Rho": "rho",
+    "UnClusteredEnergyDeltaX": "MetUnclustEnUpDeltaX",
+    "UnClusteredEnergyDeltaY": "MetUnclustEnUpDeltaY",
+}
+
+
+def _stored_puppimet():
+    return ak.Array(
+        [
+            {
+                "pt": 120.0,
+                "phi": 0.0,
+                "ptUnclusteredUp": 130.0,
+                "ptUnclusteredDown": 110.0,
+                "phiUnclusteredUp": 0.0,
+                "phiUnclusteredDown": 0.0,
+            }
+        ]
+    )
+
+
+def _raw_puppimet():
+    return ak.Array([{"pt": 100.0, "phi": 0.0}])
+
+
+def _type1_jets(include_delta_phi=False, em_fail=False, low_pt=False):
+    jet = {
+        "pt": 50.0 if not low_pt else 10.0,
+        "phi": 0.0,
+        "eta": 0.2,
+        "area": 0.5,
+        "rawFactor": 0.2,
+        "muonSubtrFactor": 0.1,
+        "chEmEF": 0.2 if not em_fail else 0.6,
+        "neEmEF": 0.1 if not em_fail else 0.35,
+        "rho": 20.0,
+    }
+    if include_delta_phi:
+        jet["muonSubtrDeltaPhi"] = math.pi / 2.0
+    return ak.Array([[jet]])
+
+
+def _corr_t1_jets(include_delta_phi=False, include_emef=False, em_fail=False):
+    corr = {
+        "rawPt": 20.0,
+        "phi": 0.0,
+        "eta": 0.3,
+        "area": 0.4,
+        "muonSubtrFactor": 0.5,
+        "rho": 20.0,
+    }
+    if include_delta_phi:
+        corr["muonSubtrDeltaPhi"] = math.pi / 2.0
+    if include_emef:
+        corr["EmEF"] = 0.95 if em_fail else 0.1
+    return ak.Array([[corr]])
+
+
+def _type1_factory(
+    corrected_jets_factory_cls=None,
+    suppress_forward_eta_stochastic_jer=False,
+    jec_stack=None,
+):
+    if corrected_jets_factory_cls is None:
+        corrected_jets_factory_cls = _make_fake_corrected_jets_factory()
+    test_factory_cls = corrected_jets_factory_cls
+
+    class _TestType1CorrectedMETFactory(Type1CorrectedMETFactory):
+        pass
+
+    _TestType1CorrectedMETFactory._corrected_jets_factory_cls = test_factory_cls
+    return _TestType1CorrectedMETFactory(
+        TYPE1_NAME_MAP,
+        _FakeJECStack() if jec_stack is None else jec_stack,
+        suppress_forward_eta_stochastic_jer=suppress_forward_eta_stochastic_jer,
+    )
+
+
+def _build_type1(
+    jets=None,
+    corr_t1=None,
+    corrected_jets_factory_cls=None,
+    suppress_forward_eta_stochastic_jer=False,
+    jec_stack=None,
+):
+    return _type1_factory(
+        corrected_jets_factory_cls=corrected_jets_factory_cls,
+        suppress_forward_eta_stochastic_jer=suppress_forward_eta_stochastic_jer,
+        jec_stack=jec_stack,
+    ).build(
+        _stored_puppimet(),
+        _raw_puppimet(),
+        _type1_jets() if jets is None else jets,
+        _corr_t1_jets() if corr_t1 is None else corr_t1,
+        lazy_cache={},
+    )
 
 
 def test_met_unclustered_energy_legacy_delta_xy_mode():
@@ -74,3 +294,148 @@ def test_met_unclustered_energy_missing_fields_fails_clearly():
 
     with pytest.raises(ValueError, match="could not build MET_UnclusteredEnergy"):
         CorrectedMETFactory(NAME_MAP).build(met, _jets(), lazy_cache={})
+
+
+def test_type1_met_nominal_formula_and_v12_fallbacks():
+    corrected = _build_type1()
+
+    # Jet: 50 * (1 - 0.2) * (1 - 0.1) = 36, full-L1 delta = 36.
+    # CorrT1METJet: 20 * (1 - 0.5) = 10, full-L1 delta = 10.
+    # RawPuppiMET x is 100, so Type-1 x is 100 - 46.
+    assert _value(corrected.pt) == pytest.approx(54.0)
+    assert _value(corrected.phi) == pytest.approx(0.0)
+
+
+def test_type1_met_nominal_uses_original_raw_jet_pt_not_corrected_pt():
+    corrected_jets_factory = _make_fake_corrected_jets_factory(
+        nominal_pt=500.0,
+        jer_up_pt=750.0,
+        jer_down_pt=250.0,
+        jes_up_pt=600.0,
+        jes_down_pt=450.0,
+    )
+
+    corrected = _build_type1(corrected_jets_factory_cls=corrected_jets_factory)
+
+    assert _value(corrected.pt) == pytest.approx(54.0)
+    assert corrected_jets_factory.instances[-1].build_calls == 1
+
+
+def test_type1_met_jet_jec_uses_raw_pt_input_and_applies_to_no_mu_raw_pt():
+    jec_stack = _FakeJECStack(
+        l1_scale=1.0,
+        l2_correction=_PtScaledCorrection(reference_pt=20.0),
+    )
+
+    corrected = _build_type1(
+        corr_t1=_corr_t1_jets(include_emef=True, em_fail=True),
+        jec_stack=jec_stack,
+    )
+
+    # The L2 factor is JetPt / 20. With the intended raw JEC input,
+    # JetPt is 50 * (1 - 0.2) = 40, so L2 = 2. That factor is then applied
+    # to no-muon raw pT, 40 * (1 - 0.1) = 36, so the delta is 36.
+    # If the JEC input were no-muon raw pT, L2 would instead see 36.
+    assert _value(corrected.pt) == pytest.approx(64.0)
+
+
+def test_type1_met_corr_t1_jec_uses_raw_pt_input_and_applies_to_no_mu_raw_pt():
+    jec_stack = _FakeJECStack(
+        l1_scale=1.0,
+        l2_correction=_PtScaledCorrection(reference_pt=10.0),
+    )
+
+    corrected = _build_type1(
+        jets=_type1_jets(em_fail=True),
+        jec_stack=jec_stack,
+    )
+
+    # The CorrT1 L2 factor is JetPt / 10. With the intended raw JEC input,
+    # JetPt is rawPt = 20, so L2 = 2. That factor is then applied to
+    # no-muon raw pT, 20 * (1 - 0.5) = 10, so the delta is 10.
+    # If the JEC input were no-muon raw pT, L2 would instead see 10.
+    assert _value(corrected.pt) == pytest.approx(90.0)
+
+
+def test_type1_met_corrected_jets_factory_hook_is_private():
+    assert "corrected_jets_factory_cls" not in inspect.signature(Type1CorrectedMETFactory).parameters
+
+    corrected_jets_factory = _make_fake_corrected_jets_factory()
+    factory = _type1_factory(corrected_jets_factory_cls=corrected_jets_factory)
+    factory.build(
+        _stored_puppimet(),
+        _raw_puppimet(),
+        _type1_jets(),
+        _corr_t1_jets(),
+        lazy_cache={},
+    )
+
+    assert corrected_jets_factory.instances[-1].build_calls == 1
+
+
+def test_type1_met_threads_forward_jer_suppression_to_internal_factory():
+    corrected_jets_factory = _make_fake_corrected_jets_factory()
+
+    _build_type1(
+        corrected_jets_factory_cls=corrected_jets_factory,
+        suppress_forward_eta_stochastic_jer=True,
+    )
+
+    assert corrected_jets_factory.instances[-1].suppress_forward_eta_stochastic_jer
+
+
+def test_type1_met_missing_delta_phi_fallback_uses_collection_phi():
+    nominal = _build_type1()
+    shifted = _build_type1(
+        jets=_type1_jets(include_delta_phi=True),
+        corr_t1=_corr_t1_jets(include_delta_phi=True),
+    )
+
+    assert _value(nominal.pt) == pytest.approx(54.0)
+    assert _value(shifted.pt) == pytest.approx(math.hypot(100.0, 46.0))
+    assert _value(shifted.phi) == pytest.approx(math.atan2(-46.0, 100.0))
+
+
+def test_type1_met_missing_corr_t1_emef_skips_only_corr_t1_cut():
+    missing_emef = _build_type1(corr_t1=_corr_t1_jets(include_emef=False))
+    failing_emef = _build_type1(corr_t1=_corr_t1_jets(include_emef=True, em_fail=True))
+
+    assert _value(missing_emef.pt) == pytest.approx(54.0)
+    assert _value(failing_emef.pt) == pytest.approx(64.0)
+
+
+def test_type1_met_jet_em_and_pt_cuts():
+    jet_em_fail = _build_type1(jets=_type1_jets(em_fail=True))
+    jet_low_pt = _build_type1(jets=_type1_jets(low_pt=True))
+
+    assert _value(jet_em_fail.pt) == pytest.approx(90.0)
+    assert _value(jet_low_pt.pt) == pytest.approx(90.0)
+
+
+def test_type1_met_direct_unclustered_recentering():
+    corrected = _build_type1()
+
+    assert _value(corrected.MET_UnclusteredEnergy.up.pt) == pytest.approx(64.0)
+    assert _value(corrected.MET_UnclusteredEnergy.down.pt) == pytest.approx(44.0)
+    assert _value(corrected.MET_UnclusteredEnergy.up.phi) == pytest.approx(0.0)
+    assert _value(corrected.MET_UnclusteredEnergy.down.phi) == pytest.approx(0.0)
+
+
+def test_type1_met_jes_jer_variations_vary_jet_full_leg_only():
+    corrected = _build_type1()
+
+    assert "MET_UnclusteredEnergy" in ak.fields(corrected)
+    assert "JER" in ak.fields(corrected)
+    assert "JES_Total" in ak.fields(corrected)
+    assert {"up", "down"} == set(ak.fields(corrected.JER))
+    assert {"up", "down"} == set(ak.fields(corrected.JES_Total))
+
+    # JER up scales the Jet full leg by 75/50, while the Jet L1 leg and
+    # CorrT1METJet contribution stay nominal: raw 100 - (72 + 10) = 18.
+    assert _value(corrected.JER.up.pt) == pytest.approx(18.0)
+    # JER down scales the Jet full leg by 25/50, below the L1 leg:
+    # raw 100 - ((36 - 36) + 10) = 90.
+    assert _value(corrected.JER.down.pt) == pytest.approx(90.0)
+    # JES_Total up/down use the same public field shape.
+    assert _value(corrected.JES_Total.up.pt) == pytest.approx(39.6)
+    assert _value(corrected.JES_Total.down.pt) == pytest.approx(61.2)

--- a/tests/test_corrected_met_factory.py
+++ b/tests/test_corrected_met_factory.py
@@ -50,6 +50,7 @@ class _ConstantCorrection:
 class _PtScaledCorrection:
     def __init__(self, reference_pt):
         self.reference_pt = np.float32(reference_pt)
+        self.seen_pt = []
         self.inputs = [
             _CorrectionInput("JetPt"),
             _CorrectionInput("JetEta"),
@@ -58,7 +59,9 @@ class _PtScaledCorrection:
         ]
 
     def evaluate(self, *inputs):
-        return np.asarray(inputs[0], dtype=np.float32) / self.reference_pt
+        jet_pt = np.asarray(inputs[0], dtype=np.float32)
+        self.seen_pt.append(jet_pt.copy())
+        return jet_pt / self.reference_pt
 
 
 class _FakeJECStack:
@@ -107,6 +110,7 @@ def _make_fake_corrected_jets_factory(
         def build(self, jets, lazy_cache):
             self.build_calls += 1
             self.lazy_cache = lazy_cache
+            self.jets = jets
             pt_field = self.name_map["JetPt"]
             nominal = ak.ones_like(jets[pt_field]) * nominal_pt
             out = ak.with_field(jets, nominal, pt_field)
@@ -132,9 +136,12 @@ TYPE1_NAME_MAP = {
     "RawMETpt": "pt",
     "RawMETphi": "phi",
     "JetPt": "pt",
+    "JetMass": "mass",
     "JetPhi": "phi",
     "JetEta": "eta",
     "JetA": "area",
+    "ptRaw": "pt_raw",
+    "massRaw": "mass_raw",
     "JetRawFactor": "rawFactor",
     "JetMuonSubtrFactor": "muonSubtrFactor",
     "JetMuonSubtrDeltaPhi": "muonSubtrDeltaPhi",
@@ -172,18 +179,39 @@ def _raw_puppimet():
     return ak.Array([{"pt": 100.0, "phi": 0.0}])
 
 
-def _type1_jets(include_delta_phi=False, em_fail=False, low_pt=False):
+def _type1_jets(
+    include_delta_phi=False,
+    em_fail=False,
+    low_pt=False,
+    pt=50.0,
+    raw_factor=0.2,
+    pt_raw=None,
+    mass=10.0,
+    mass_raw=None,
+    include_pt_raw=True,
+    include_mass_raw=True,
+):
+    jet_pt = pt if not low_pt else 10.0
+    if pt_raw is None:
+        pt_raw = jet_pt * (1.0 - raw_factor)
+    if mass_raw is None:
+        mass_raw = mass * (1.0 - raw_factor)
     jet = {
-        "pt": 50.0 if not low_pt else 10.0,
+        "pt": jet_pt,
+        "mass": mass,
         "phi": 0.0,
         "eta": 0.2,
         "area": 0.5,
-        "rawFactor": 0.2,
+        "rawFactor": raw_factor,
         "muonSubtrFactor": 0.1,
         "chEmEF": 0.2 if not em_fail else 0.6,
         "neEmEF": 0.1 if not em_fail else 0.35,
         "rho": 20.0,
     }
+    if include_pt_raw:
+        jet["pt_raw"] = pt_raw
+    if include_mass_raw:
+        jet["mass_raw"] = mass_raw
     if include_delta_phi:
         jet["muonSubtrDeltaPhi"] = math.pi / 2.0
     return ak.Array([[jet]])
@@ -299,7 +327,7 @@ def test_met_unclustered_energy_missing_fields_fails_clearly():
 def test_type1_met_nominal_formula_and_v12_fallbacks():
     corrected = _build_type1()
 
-    # Jet: 50 * (1 - 0.2) * (1 - 0.1) = 36, full-L1 delta = 36.
+    # Jet: caller-provided pt_raw 40 * (1 - 0.1) = 36, full-L1 delta = 36.
     # CorrT1METJet: 20 * (1 - 0.5) = 10, full-L1 delta = 10.
     # RawPuppiMET x is 100, so Type-1 x is 100 - 46.
     assert _value(corrected.pt) == pytest.approx(54.0)
@@ -322,21 +350,69 @@ def test_type1_met_nominal_uses_original_raw_jet_pt_not_corrected_pt():
 
 
 def test_type1_met_jet_jec_uses_raw_pt_input_and_applies_to_no_mu_raw_pt():
+    l2_correction = _PtScaledCorrection(reference_pt=15.0)
     jec_stack = _FakeJECStack(
         l1_scale=1.0,
-        l2_correction=_PtScaledCorrection(reference_pt=20.0),
+        l2_correction=l2_correction,
     )
 
     corrected = _build_type1(
+        jets=_type1_jets(pt=50.0, raw_factor=0.2, pt_raw=30.0, mass_raw=7.0),
         corr_t1=_corr_t1_jets(include_emef=True, em_fail=True),
         jec_stack=jec_stack,
     )
 
-    # The L2 factor is JetPt / 20. With the intended raw JEC input,
-    # JetPt is 50 * (1 - 0.2) = 40, so L2 = 2. That factor is then applied
-    # to no-muon raw pT, 40 * (1 - 0.1) = 36, so the delta is 36.
-    # If the JEC input were no-muon raw pT, L2 would instead see 36.
-    assert _value(corrected.pt) == pytest.approx(64.0)
+    # The L2 factor is JetPt / 15. The caller-provided pt_raw is 30, while
+    # pt * (1 - rawFactor) would be 40. The JEC input must see 30, then the
+    # factor is applied to no-muon raw pT, 30 * (1 - 0.1) = 27.
+    np.testing.assert_allclose(l2_correction.seen_pt[0], np.array([30.0], dtype=np.float32))
+    assert _value(corrected.pt) == pytest.approx(73.0)
+
+
+def test_type1_met_requires_regular_jet_pt_raw():
+    with pytest.raises(
+        ValueError,
+        match="Type1CorrectedMETFactory.*regular Jet pt_raw.*caller-prepared raw pT",
+    ):
+        _build_type1(jets=_type1_jets(include_pt_raw=False))
+
+
+def test_type1_met_requires_regular_jet_mass_raw():
+    with pytest.raises(
+        ValueError,
+        match="Type1CorrectedMETFactory.*regular Jet mass_raw.*caller-prepared raw mass",
+    ):
+        _build_type1(jets=_type1_jets(include_mass_raw=False))
+
+
+def test_type1_met_requires_pt_raw_name_map_key():
+    name_map = dict(TYPE1_NAME_MAP)
+    del name_map["ptRaw"]
+
+    with pytest.raises(ValueError, match="ptRaw.*Type1CorrectedMETFactory"):
+        Type1CorrectedMETFactory(name_map, _FakeJECStack())
+
+
+def test_type1_met_requires_mass_raw_name_map_key():
+    name_map = dict(TYPE1_NAME_MAP)
+    del name_map["massRaw"]
+
+    with pytest.raises(ValueError, match="massRaw.*Type1CorrectedMETFactory"):
+        Type1CorrectedMETFactory(name_map, _FakeJECStack())
+
+
+def test_type1_met_uses_caller_provided_raw_mass_for_jec_inputs():
+    corrected_jets_factory = _make_fake_corrected_jets_factory()
+
+    _build_type1(
+        jets=_type1_jets(mass=10.0, raw_factor=0.2, mass_raw=7.0),
+        corrected_jets_factory_cls=corrected_jets_factory,
+    )
+
+    np.testing.assert_allclose(
+        ak.to_numpy(ak.flatten(corrected_jets_factory.instances[-1].jets.mass_raw)),
+        np.array([7.0], dtype=np.float32),
+    )
 
 
 def test_type1_met_corr_t1_jec_uses_raw_pt_input_and_applies_to_no_mu_raw_pt():
@@ -415,6 +491,33 @@ def test_type1_met_jet_em_and_pt_cuts():
 def test_type1_met_direct_unclustered_recentering():
     corrected = _build_type1()
 
+    assert _value(corrected.MET_UnclusteredEnergy.up.pt) == pytest.approx(64.0)
+    assert _value(corrected.MET_UnclusteredEnergy.down.pt) == pytest.approx(44.0)
+    assert _value(corrected.MET_UnclusteredEnergy.up.phi) == pytest.approx(0.0)
+    assert _value(corrected.MET_UnclusteredEnergy.down.phi) == pytest.approx(0.0)
+
+
+def test_type1_met_legacy_delta_xy_unclustered_recentering():
+    stored_met = ak.Array(
+        [
+            {
+                "pt": 120.0,
+                "phi": 0.0,
+                "MetUnclustEnUpDeltaX": 10.0,
+                "MetUnclustEnUpDeltaY": 0.0,
+            }
+        ]
+    )
+
+    corrected = _type1_factory().build(
+        stored_met,
+        _raw_puppimet(),
+        _type1_jets(),
+        _corr_t1_jets(),
+        lazy_cache={},
+    )
+
+    assert _value(corrected.pt) == pytest.approx(54.0)
     assert _value(corrected.MET_UnclusteredEnergy.up.pt) == pytest.approx(64.0)
     assert _value(corrected.MET_UnclusteredEnergy.down.pt) == pytest.approx(44.0)
     assert _value(corrected.MET_UnclusteredEnergy.up.phi) == pytest.approx(0.0)

--- a/topcoffea/modules/JECStack.py
+++ b/topcoffea/modules/JECStack.py
@@ -93,6 +93,22 @@ class JECStack:
         """Convert to list for clib case."""
         return self.jec_names_clib + self.jer_names_clib + self.jec_uncsources_clib + [self.json_path, self.savecorr]
 
+    def get_l1_jec_names(self):
+        """Return the configured L1-only correctionlib JEC name."""
+        if not self.use_clib:
+            raise NotImplementedError("L1/full JEC name helpers are only implemented for correctionlib stacks.")
+
+        l1_names = [name for name in self.jec_names_clib if "_L1FastJet_" in name]
+        if len(l1_names) != 1:
+            raise ValueError(f"Expected exactly one L1FastJet correction, found {l1_names}.")
+        return l1_names
+
+    def get_full_jec_names(self):
+        """Return configured correctionlib JEC names in multiplication order."""
+        if not self.use_clib:
+            raise NotImplementedError("L1/full JEC name helpers are only implemented for correctionlib stacks.")
+        return list(self.jec_names_clib)
+
     def assemble_corrections(self):
         """Assemble corrections for both scenarios."""
         assembled = {"jec": {}, "junc": {}, "jer": {}, "jersf": {}}

--- a/topcoffea/modules/Type1CorrectedMETFactory.py
+++ b/topcoffea/modules/Type1CorrectedMETFactory.py
@@ -1,0 +1,466 @@
+from copy import copy
+from functools import reduce
+
+import awkward
+import numpy
+
+from topcoffea.modules.CorrectedJetsFactory import CorrectedJetsFactory
+from topcoffea.modules.JECStack import JECStack
+
+
+_TYPE1_REQUIRED_KEYS = [
+    "METpt",
+    "METphi",
+    "RawMETpt",
+    "RawMETphi",
+    "JetPt",
+    "JetPhi",
+    "JetEta",
+    "JetA",
+    "JetRawFactor",
+    "JetMuonSubtrFactor",
+    "JetChEmEF",
+    "JetNeEmEF",
+    "CorrT1JetPt",
+    "CorrT1JetPhi",
+    "CorrT1JetEta",
+    "CorrT1JetArea",
+    "CorrT1JetMuonSubtrFactor",
+    "Rho",
+]
+
+
+def _has_field(obj, field):
+    return field is not None and field in awkward.fields(obj)
+
+
+def _field_or_zeros(obj, field, like):
+    if _has_field(obj, field):
+        return obj[field]
+    return awkward.zeros_like(like)
+
+
+def _object_counts(obj):
+    return awkward.num(obj)
+
+
+def _rawvar_jec(jecval, rawvar):
+    return jecval * rawvar
+
+
+def _input_values(objs, corr_obj, name_map, run, current_correction=None):
+    input_values = []
+    run_flat = None
+    if any(inp.name == "run" for inp in corr_obj.inputs):
+        if run is None:
+            raise ValueError("A JEC correction requires a run input, but run=None was provided.")
+        run_flat = awkward.flatten(
+            awkward.ones_like(objs[name_map["JetPt"]], dtype=numpy.int32) * run
+        )
+
+    for inp in corr_obj.inputs:
+        if inp.name == "systematic":
+            continue
+        if inp.name == "run":
+            input_value = run_flat
+        elif inp.name == "JetPt" and current_correction is not None:
+            input_value = _rawvar_jec(
+                current_correction,
+                awkward.flatten(objs[name_map["JetPt"]]),
+            )
+        else:
+            input_value = awkward.flatten(objs[name_map[inp.name]])
+        input_values.append(input_value)
+
+    return input_values
+
+
+def _evaluate_jec_sequence(objs, name_map, jec_stack, correction_names, run):
+    corrections_list = []
+    total_correction = None
+
+    for correction_name in correction_names:
+        current_correction = None
+        if corrections_list:
+            ones = numpy.ones_like(corrections_list[-1], dtype=numpy.float32)
+            current_correction = reduce(
+                lambda x, y: y * x,
+                corrections_list,
+                ones,
+            ).astype(dtype=numpy.float32)
+
+        correction = jec_stack.corrections.get(correction_name)
+        if correction is None:
+            raise ValueError(f"Correction {correction_name} not found in the JEC stack.")
+
+        inputs = _input_values(
+            objs,
+            correction,
+            name_map,
+            run,
+            current_correction=current_correction,
+        )
+        evaluated = correction.evaluate(*inputs).astype(dtype=numpy.float32)
+        corrections_list.append(evaluated)
+        if total_correction is None:
+            total_correction = numpy.ones_like(evaluated, dtype=numpy.float32)
+        total_correction *= evaluated
+
+    if total_correction is None:
+        raise ValueError("No JEC corrections were configured for Type-1 MET.")
+
+    return awkward.unflatten(total_correction, _object_counts(objs))
+
+
+def _met_from_xy(px, py):
+    return awkward.zip(
+        {"pt": numpy.hypot(px, py), "phi": numpy.arctan2(py, px)},
+        depth_limit=1,
+    )
+
+
+def _type1_met(raw_met, name_map, delta_px, delta_py):
+    raw_px = raw_met[name_map["RawMETpt"]] * numpy.cos(raw_met[name_map["RawMETphi"]])
+    raw_py = raw_met[name_map["RawMETpt"]] * numpy.sin(raw_met[name_map["RawMETphi"]])
+    return _met_from_xy(raw_px - delta_px, raw_py - delta_py)
+
+
+def _copy_with_met(stored_met, name_map, met_vector):
+    out = copy(stored_met)
+    out[name_map["METpt"]] = met_vector.pt
+    out[name_map["METphi"]] = met_vector.phi
+    return out
+
+
+class Type1CorrectedMETFactory(object):
+    _corrected_jets_factory_cls = CorrectedJetsFactory
+    _direct_unc_fields = {
+        "pt_up": "ptUnclusteredUp",
+        "pt_down": "ptUnclusteredDown",
+        "phi_up": "phiUnclusteredUp",
+        "phi_down": "phiUnclusteredDown",
+    }
+    _delta_unc_fields = ("UnClusteredEnergyDeltaX", "UnClusteredEnergyDeltaY")
+
+    def __init__(
+        self,
+        name_map,
+        jec_stack,
+        run=None,
+        suppress_forward_eta_stochastic_jer=False,
+        unclustered_mode="auto",
+    ):
+        if not isinstance(jec_stack, JECStack):
+            if not (
+                hasattr(jec_stack, "corrections")
+                and hasattr(jec_stack, "get_l1_jec_names")
+                and hasattr(jec_stack, "get_full_jec_names")
+            ):
+                raise TypeError("jec_stack must be a JECStack or expose the JECStack Type-1 helper API.")
+
+        for name in _TYPE1_REQUIRED_KEYS:
+            if name not in name_map or name_map[name] is None:
+                raise ValueError(
+                    f"There is no name mapping for {name}, which is needed for Type1CorrectedMETFactory."
+                )
+
+        if unclustered_mode not in ("auto", "direct_pt_phi", "delta_xy"):
+            raise ValueError(f"Unknown unclustered_mode '{unclustered_mode}'.")
+
+        self.name_map = name_map
+        self.jec_stack = jec_stack
+        self.run = run
+        self.suppress_forward_eta_stochastic_jer = suppress_forward_eta_stochastic_jer
+        self.unclustered_mode = unclustered_mode
+
+    def _get_unclustered_mode(self, stored_met):
+        if self.unclustered_mode != "auto":
+            return self.unclustered_mode
+
+        if all(_has_field(stored_met, field) for field in self._direct_unc_fields.values()):
+            return "direct_pt_phi"
+
+        delta_fields = [self.name_map.get(name) for name in self._delta_unc_fields]
+        if all(_has_field(stored_met, field) for field in delta_fields):
+            return "delta_xy"
+
+        raise ValueError(
+            "Type1CorrectedMETFactory could not build MET_UnclusteredEnergy. "
+            "Expected either direct pt/phi unclustered fields "
+            f"{list(self._direct_unc_fields.values())} or legacy delta fields {delta_fields}."
+        )
+
+    def _evaluate_l1_and_full(self, objs, name_map):
+        l1_factor = _evaluate_jec_sequence(
+            objs,
+            name_map,
+            self.jec_stack,
+            self.jec_stack.get_l1_jec_names(),
+            self.run,
+        )
+        full_factor = _evaluate_jec_sequence(
+            objs,
+            name_map,
+            self.jec_stack,
+            self.jec_stack.get_full_jec_names(),
+            self.run,
+        )
+        return l1_factor, full_factor
+
+    def _jet_jec_name_map(self):
+        name_map = dict(self.name_map)
+        name_map["JetPt"] = "pt_type1Raw"
+        name_map["JetMass"] = "mass_type1Raw"
+        return name_map
+
+    def _corr_t1_jec_name_map(self):
+        name_map = dict(self.name_map)
+        name_map["JetPt"] = "pt_type1Raw"
+        name_map["JetEta"] = self.name_map["CorrT1JetEta"]
+        name_map["JetA"] = self.name_map["CorrT1JetArea"]
+        return name_map
+
+    def _jet_raw_pt(self, raw_jets):
+        return raw_jets[self.name_map["JetPt"]] * (1.0 - raw_jets[self.name_map["JetRawFactor"]])
+
+    def _jet_no_mu_raw_pt(self, raw_jets):
+        return self._jet_raw_pt(raw_jets) * (
+            1.0 - raw_jets[self.name_map["JetMuonSubtrFactor"]]
+        )
+
+    def _corr_t1_raw_pt(self, corr_t1_met_jets):
+        return corr_t1_met_jets[self.name_map["CorrT1JetPt"]]
+
+    def _corr_t1_no_mu_raw_pt(self, corr_t1_met_jets):
+        return self._corr_t1_raw_pt(corr_t1_met_jets) * (
+            1.0 - corr_t1_met_jets[self.name_map["CorrT1JetMuonSubtrFactor"]]
+        )
+
+    def _prepare_jets_for_jec(self, raw_jets):
+        prepared = awkward.with_field(raw_jets, self._jet_raw_pt(raw_jets), "pt_type1Raw")
+        mass_raw_field = self.name_map.get("massRaw", "mass_raw")
+        if _has_field(raw_jets, mass_raw_field):
+            mass_type1_raw = raw_jets[mass_raw_field]
+        elif _has_field(raw_jets, self.name_map.get("JetMass")):
+            mass_type1_raw = raw_jets[self.name_map["JetMass"]] * (
+                1.0 - raw_jets[self.name_map["JetRawFactor"]]
+            )
+        else:
+            mass_type1_raw = awkward.zeros_like(prepared["pt_type1Raw"])
+        return awkward.with_field(prepared, mass_type1_raw, "mass_type1Raw")
+
+    def _prepare_corr_t1_for_jec(self, corr_t1_met_jets):
+        return awkward.with_field(
+            corr_t1_met_jets,
+            self._corr_t1_raw_pt(corr_t1_met_jets),
+            "pt_type1Raw",
+        )
+
+    def _prepare_jets_for_corrected_factory(self, raw_jets):
+        prepared = raw_jets
+        pt_raw_field = self.name_map.get("ptRaw")
+        if pt_raw_field is not None and not _has_field(prepared, pt_raw_field):
+            prepared = awkward.with_field(prepared, self._jet_raw_pt(raw_jets), pt_raw_field)
+
+        mass_raw_field = self.name_map.get("massRaw")
+        jet_mass_field = self.name_map.get("JetMass")
+        if mass_raw_field is not None and not _has_field(prepared, mass_raw_field):
+            if _has_field(raw_jets, jet_mass_field):
+                mass_raw = raw_jets[jet_mass_field] * (1.0 - raw_jets[self.name_map["JetRawFactor"]])
+            else:
+                mass_raw = awkward.zeros_like(self._jet_raw_pt(raw_jets))
+            prepared = awkward.with_field(prepared, mass_raw, mass_raw_field)
+
+        return prepared
+
+    def _make_corrected_jets_factory(self):
+        return self._corrected_jets_factory_cls(
+            dict(self.name_map),
+            self.jec_stack,
+            self.run,
+            suppress_forward_eta_stochastic_jer=self.suppress_forward_eta_stochastic_jer,
+        )
+
+    def _build_corrected_jets_for_variations(self, raw_jets, lazy_cache):
+        factory = self._make_corrected_jets_factory()
+        return factory.build(
+            self._prepare_jets_for_corrected_factory(raw_jets),
+            lazy_cache={} if lazy_cache is None else lazy_cache,
+        )
+
+    def _jet_type1_deltas(self, jets, factor_l1, factor_full, pt_scale_factor=None):
+        pt_no_mu_raw = self._jet_no_mu_raw_pt(jets)
+        delta_phi = _field_or_zeros(
+            jets,
+            self.name_map.get("JetMuonSubtrDeltaPhi"),
+            jets[self.name_map["JetPhi"]],
+        )
+        phi_no_mu_raw = jets[self.name_map["JetPhi"]] + delta_phi
+
+        pt_no_mu_l1 = pt_no_mu_raw * factor_l1
+        pt_no_mu_full = pt_no_mu_raw * factor_full
+        if pt_scale_factor is not None:
+            pt_no_mu_full = pt_no_mu_full * pt_scale_factor
+
+        mask = (
+            (pt_no_mu_full > 15.0)
+            & ((jets[self.name_map["JetChEmEF"]] + jets[self.name_map["JetNeEmEF"]]) < 0.9)
+        )
+        diff_pt = awkward.where(mask, pt_no_mu_full - pt_no_mu_l1, 0.0)
+        return awkward.zip(
+            {
+                "delta_px": awkward.sum(diff_pt * numpy.cos(phi_no_mu_raw), axis=1),
+                "delta_py": awkward.sum(diff_pt * numpy.sin(phi_no_mu_raw), axis=1),
+            },
+            depth_limit=1,
+        )
+
+    def _corr_t1_type1_deltas(self, corr_t1_met_jets, factor_l1, factor_full):
+        pt_no_mu_raw = self._corr_t1_no_mu_raw_pt(corr_t1_met_jets)
+        delta_phi = _field_or_zeros(
+            corr_t1_met_jets,
+            self.name_map.get("CorrT1JetMuonSubtrDeltaPhi"),
+            corr_t1_met_jets[self.name_map["CorrT1JetPhi"]],
+        )
+        phi_no_mu_raw = corr_t1_met_jets[self.name_map["CorrT1JetPhi"]] + delta_phi
+
+        pt_no_mu_l1 = pt_no_mu_raw * factor_l1
+        pt_no_mu_full = pt_no_mu_raw * factor_full
+
+        mask = pt_no_mu_full > 15.0
+        em_ef_field = self.name_map.get("CorrT1JetEmEF")
+        if _has_field(corr_t1_met_jets, em_ef_field):
+            mask = mask & (corr_t1_met_jets[em_ef_field] < 0.9)
+
+        diff_pt = awkward.where(mask, pt_no_mu_full - pt_no_mu_l1, 0.0)
+        return awkward.zip(
+            {
+                "delta_px": awkward.sum(diff_pt * numpy.cos(phi_no_mu_raw), axis=1),
+                "delta_py": awkward.sum(diff_pt * numpy.sin(phi_no_mu_raw), axis=1),
+            },
+            depth_limit=1,
+        )
+
+    def _make_unclustered(self, stored_met, nominal_met):
+        mode = self._get_unclustered_mode(stored_met)
+        nominal_px = nominal_met[self.name_map["METpt"]] * numpy.cos(nominal_met[self.name_map["METphi"]])
+        nominal_py = nominal_met[self.name_map["METpt"]] * numpy.sin(nominal_met[self.name_map["METphi"]])
+
+        if mode == "direct_pt_phi":
+            stored_px = stored_met[self.name_map["METpt"]] * numpy.cos(stored_met[self.name_map["METphi"]])
+            stored_py = stored_met[self.name_map["METpt"]] * numpy.sin(stored_met[self.name_map["METphi"]])
+            up_px = stored_met[self._direct_unc_fields["pt_up"]] * numpy.cos(
+                stored_met[self._direct_unc_fields["phi_up"]]
+            )
+            up_py = stored_met[self._direct_unc_fields["pt_up"]] * numpy.sin(
+                stored_met[self._direct_unc_fields["phi_up"]]
+            )
+            down_px = stored_met[self._direct_unc_fields["pt_down"]] * numpy.cos(
+                stored_met[self._direct_unc_fields["phi_down"]]
+            )
+            down_py = stored_met[self._direct_unc_fields["pt_down"]] * numpy.sin(
+                stored_met[self._direct_unc_fields["phi_down"]]
+            )
+            up_vector = _met_from_xy(nominal_px + (up_px - stored_px), nominal_py + (up_py - stored_py))
+            down_vector = _met_from_xy(
+                nominal_px + (down_px - stored_px),
+                nominal_py + (down_py - stored_py),
+            )
+        else:
+            dx = stored_met[self.name_map["UnClusteredEnergyDeltaX"]]
+            dy = stored_met[self.name_map["UnClusteredEnergyDeltaY"]]
+            up_vector = _met_from_xy(nominal_px + dx, nominal_py + dy)
+            down_vector = _met_from_xy(nominal_px - dx, nominal_py - dy)
+
+        return awkward.zip(
+            {
+                "up": _copy_with_met(stored_met, self.name_map, up_vector),
+                "down": _copy_with_met(stored_met, self.name_map, down_vector),
+            },
+            depth_limit=1,
+            with_name="METSystematic",
+        )
+
+    def build(self, stored_met, raw_met, raw_jets, corr_t1_met_jets, lazy_cache=None):
+        if not isinstance(stored_met, awkward.highlevel.Array):
+            raise TypeError("'stored_met' must be an awkward array.")
+        if not isinstance(raw_met, awkward.highlevel.Array):
+            raise TypeError("'raw_met' must be an awkward array.")
+        if not isinstance(raw_jets, awkward.highlevel.Array):
+            raise TypeError("'raw_jets' must be an awkward array.")
+        if not isinstance(corr_t1_met_jets, awkward.highlevel.Array):
+            raise TypeError("'corr_t1_met_jets' must be an awkward array.")
+
+        jec_jets = self._prepare_jets_for_jec(raw_jets)
+        jet_l1, jet_full = self._evaluate_l1_and_full(jec_jets, self._jet_jec_name_map())
+        jet_deltas = self._jet_type1_deltas(raw_jets, jet_l1, jet_full)
+
+        corr_jec_jets = self._prepare_corr_t1_for_jec(corr_t1_met_jets)
+        corr_l1, corr_full = self._evaluate_l1_and_full(corr_jec_jets, self._corr_t1_jec_name_map())
+        corr_deltas = self._corr_t1_type1_deltas(corr_t1_met_jets, corr_l1, corr_full)
+
+        total_delta_px = jet_deltas.delta_px + corr_deltas.delta_px
+        total_delta_py = jet_deltas.delta_py + corr_deltas.delta_py
+
+        nominal_vector = _type1_met(raw_met, self.name_map, total_delta_px, total_delta_py)
+        out = _copy_with_met(stored_met, self.name_map, nominal_vector)
+        out[self.name_map["METpt"] + "_orig"] = raw_met[self.name_map["RawMETpt"]]
+        out[self.name_map["METphi"] + "_orig"] = raw_met[self.name_map["RawMETphi"]]
+
+        out_dict = {field: out[field] for field in awkward.fields(out)}
+        out_dict["MET_UnclusteredEnergy"] = self._make_unclustered(stored_met, out)
+
+        variation_jets = self._build_corrected_jets_for_variations(raw_jets, lazy_cache)
+
+        # CorrT1METJet is included in the nominal Type-1 correction but kept nominal
+        # under JES/JER variations, following the coffea PR reference implementation.
+        for unc in filter(lambda x: x.startswith(("JER", "JES")), awkward.fields(variation_jets)):
+            nominal_pt = variation_jets[self.name_map["JetPt"]]
+            safe_nominal = awkward.where(nominal_pt > 0, nominal_pt, 1.0)
+            scale_up = variation_jets[unc].up[self.name_map["JetPt"]] / safe_nominal
+            scale_down = variation_jets[unc].down[self.name_map["JetPt"]] / safe_nominal
+
+            up_jet_deltas = self._jet_type1_deltas(
+                raw_jets,
+                jet_l1,
+                jet_full,
+                pt_scale_factor=scale_up,
+            )
+            down_jet_deltas = self._jet_type1_deltas(
+                raw_jets,
+                jet_l1,
+                jet_full,
+                pt_scale_factor=scale_down,
+            )
+
+            up_vector = _type1_met(
+                raw_met,
+                self.name_map,
+                up_jet_deltas.delta_px + corr_deltas.delta_px,
+                up_jet_deltas.delta_py + corr_deltas.delta_py,
+            )
+            down_vector = _type1_met(
+                raw_met,
+                self.name_map,
+                down_jet_deltas.delta_px + corr_deltas.delta_px,
+                down_jet_deltas.delta_py + corr_deltas.delta_py,
+            )
+
+            out_dict[unc] = awkward.zip(
+                {
+                    "up": _copy_with_met(stored_met, self.name_map, up_vector),
+                    "down": _copy_with_met(stored_met, self.name_map, down_vector),
+                },
+                depth_limit=1,
+                with_name="METSystematic",
+            )
+
+        return awkward.zip(
+            out_dict,
+            depth_limit=1,
+            parameters=out.layout.parameters,
+            behavior=out.behavior,
+        )
+
+    def uncertainties(self):
+        return ["MET_UnclusteredEnergy"]

--- a/topcoffea/modules/Type1CorrectedMETFactory.py
+++ b/topcoffea/modules/Type1CorrectedMETFactory.py
@@ -17,7 +17,9 @@ _TYPE1_REQUIRED_KEYS = [
     "JetPhi",
     "JetEta",
     "JetA",
-    "JetRawFactor",
+    # Regular-Jet Type-1 raw inputs are caller-prepared by contract.
+    "ptRaw",
+    "massRaw",
     "JetMuonSubtrFactor",
     "JetChEmEF",
     "JetNeEmEF",
@@ -38,6 +40,12 @@ def _field_or_zeros(obj, field, like):
     if _has_field(obj, field):
         return obj[field]
     return awkward.zeros_like(like)
+
+
+def _require_field(obj, field, message):
+    if not _has_field(obj, field):
+        raise ValueError(message)
+    return obj[field]
 
 
 def _object_counts(obj):
@@ -220,13 +228,27 @@ class Type1CorrectedMETFactory(object):
         name_map["JetA"] = self.name_map["CorrT1JetArea"]
         return name_map
 
+    def _regular_jet_raw_field(self, raw_jets, map_key, field_label, description):
+        field = self.name_map.get(map_key)
+        return _require_field(
+            raw_jets,
+            field,
+            f"Type1CorrectedMETFactory requires regular Jet {field_label} "
+            f"as a caller-prepared {description}; no fallback reconstruction is provided.",
+        )
+
     def _jet_raw_pt(self, raw_jets):
-        return raw_jets[self.name_map["JetPt"]] * (1.0 - raw_jets[self.name_map["JetRawFactor"]])
+        return self._regular_jet_raw_field(raw_jets, "ptRaw", "pt_raw", "raw pT")
 
     def _jet_no_mu_raw_pt(self, raw_jets):
+        # Type-1 JEC inputs use caller-prepared raw pT. The no-muon vector leg
+        # is derived from that same field; there is intentionally no rawFactor fallback.
         return self._jet_raw_pt(raw_jets) * (
             1.0 - raw_jets[self.name_map["JetMuonSubtrFactor"]]
         )
+
+    def _jet_raw_mass(self, raw_jets):
+        return self._regular_jet_raw_field(raw_jets, "massRaw", "mass_raw", "raw mass")
 
     def _corr_t1_raw_pt(self, corr_t1_met_jets):
         return corr_t1_met_jets[self.name_map["CorrT1JetPt"]]
@@ -238,16 +260,7 @@ class Type1CorrectedMETFactory(object):
 
     def _prepare_jets_for_jec(self, raw_jets):
         prepared = awkward.with_field(raw_jets, self._jet_raw_pt(raw_jets), "pt_type1Raw")
-        mass_raw_field = self.name_map.get("massRaw", "mass_raw")
-        if _has_field(raw_jets, mass_raw_field):
-            mass_type1_raw = raw_jets[mass_raw_field]
-        elif _has_field(raw_jets, self.name_map.get("JetMass")):
-            mass_type1_raw = raw_jets[self.name_map["JetMass"]] * (
-                1.0 - raw_jets[self.name_map["JetRawFactor"]]
-            )
-        else:
-            mass_type1_raw = awkward.zeros_like(prepared["pt_type1Raw"])
-        return awkward.with_field(prepared, mass_type1_raw, "mass_type1Raw")
+        return awkward.with_field(prepared, self._jet_raw_mass(raw_jets), "mass_type1Raw")
 
     def _prepare_corr_t1_for_jec(self, corr_t1_met_jets):
         return awkward.with_field(
@@ -257,21 +270,9 @@ class Type1CorrectedMETFactory(object):
         )
 
     def _prepare_jets_for_corrected_factory(self, raw_jets):
-        prepared = raw_jets
-        pt_raw_field = self.name_map.get("ptRaw")
-        if pt_raw_field is not None and not _has_field(prepared, pt_raw_field):
-            prepared = awkward.with_field(prepared, self._jet_raw_pt(raw_jets), pt_raw_field)
-
-        mass_raw_field = self.name_map.get("massRaw")
-        jet_mass_field = self.name_map.get("JetMass")
-        if mass_raw_field is not None and not _has_field(prepared, mass_raw_field):
-            if _has_field(raw_jets, jet_mass_field):
-                mass_raw = raw_jets[jet_mass_field] * (1.0 - raw_jets[self.name_map["JetRawFactor"]])
-            else:
-                mass_raw = awkward.zeros_like(self._jet_raw_pt(raw_jets))
-            prepared = awkward.with_field(prepared, mass_raw, mass_raw_field)
-
-        return prepared
+        self._jet_raw_pt(raw_jets)
+        self._jet_raw_mass(raw_jets)
+        return raw_jets
 
     def _make_corrected_jets_factory(self):
         return self._corrected_jets_factory_cls(


### PR DESCRIPTION
### Summary

* Add a dedicated `Type1CorrectedMETFactory` for NanoAOD Type-1 MET reconstruction.
* Add correctionlib `JECStack` helpers to expose L1-only and full JEC correction sequences.
* Support regular `Jet` and `CorrT1METJet` Type-1 contributions, including no-muon raw-pT handling.
* Propagate JES/JER variations to Type-1 MET through the corrected-jet machinery.
* Add focused tests for nominal Type-1 MET, unclustered-energy variations, JES/JER variations, raw-input contracts, and Run 2/Run 3 NanoAOD field conventions.

### Motivation

The existing MET correction support covers stored MET systematic handling, but it does not provide a dedicated Type-1 MET factory that can rebuild Type-1 MET from raw MET, regular jets, and `CorrT1METJet`.

Run 2 and Run 3 NanoAOD workflows need an explicit and testable Type-1 MET construction path with the following behavior:

```text
regular Jet leg:
  use caller-prepared raw pT and raw mass
  apply JEC factors to no-muon raw pT

CorrT1METJet leg:
  use CorrT1METJet.rawPt
  apply JEC factors to no-muon raw pT

nominal MET:
  start from raw MET
  subtract the Type-1 jet deltas

JES/JER variations:
  vary the regular-jet full-correction leg
  keep CorrT1METJet nominal

unclustered variations:
  support both direct pt/phi fields and legacy delta-X/Y fields
```

This PR adds that machinery in `topcoffea`, with explicit contracts and tests so downstream analysis code can use the factory without duplicating or ambiguously reconstructing Type-1 MET logic.

### Implementation details

#### A. New Type-1 MET factory

This PR adds:

```text
topcoffea/modules/Type1CorrectedMETFactory.py
```

The new `Type1CorrectedMETFactory` builds Type-1 MET from:

```text
stored_met
raw_met
raw_jets
corr_t1_met_jets
```

The nominal correction computes the Type-1 delta from two components:

```text
regular Jet contribution
CorrT1METJet contribution
```

The output preserves the stored MET object layout while replacing the nominal `pt` and `phi` with the Type-1-corrected values.

The factory also stores the raw MET seed as:

```text
pt_orig
phi_orig
```

using the configured name map.

#### B. JECStack helper API

`JECStack` now provides correctionlib-only helpers:

```python
get_l1_jec_names()
get_full_jec_names()
```

`get_l1_jec_names()` returns the configured L1FastJet correction and fails clearly unless exactly one L1FastJet correction is configured.

`get_full_jec_names()` returns the full configured correctionlib JEC sequence in multiplication order.

These helpers allow `Type1CorrectedMETFactory` to evaluate:

```text
L1-only JEC factors
full JEC factors
```

and then build the Type-1 delta from their difference.

#### C. Regular-jet raw-input contract

The Type-1 factory requires caller-prepared regular-jet raw inputs through the name map:

```text
ptRaw
massRaw
```

The factory intentionally does not reconstruct these from:

```text
Jet.pt * (1 - Jet.rawFactor)
Jet.mass * (1 - Jet.rawFactor)
```

This makes the raw-input provenance explicit and avoids hidden fallback arithmetic.

The regular-jet no-muon raw pT is built as:

```text
pt_raw * (1 - JetMuonSubtrFactor)
```

This preserves the Type-1 MET convention:

```text
JEC-factor retrieval:
  raw pT before muon subtraction

Type-1 vector / delta:
  no-muon raw pT
```

#### D. CorrT1METJet handling

The `CorrT1METJet` leg uses the NanoAOD-provided raw pT:

```text
CorrT1METJet.rawPt
```

and derives no-muon raw pT as:

```text
CorrT1METJet.rawPt * (1 - CorrT1JetMuonSubtrFactor)
```

No `CorrT1METJet.pt_raw` or `CorrT1METJet.mass_raw` contract is introduced.

The optional `CorrT1METJet` electromagnetic-energy-fraction field is handled as a field-dependent cut when present. If the field is missing, only the corresponding `CorrT1METJet` EM-fraction cut is skipped.

#### E. Muon-subtraction delta-phi fallbacks

For both regular jets and `CorrT1METJet`, the factory supports optional muon-subtraction delta-phi fields:

```text
JetMuonSubtrDeltaPhi
CorrT1JetMuonSubtrDeltaPhi
```

If these fields are missing, the factory falls back to the object phi direction, matching NanoAOD versions where the delta-phi branches are unavailable.

#### F. Unclustered-energy variations

The factory supports two unclustered-energy modes:

```text
direct_pt_phi
delta_xy
```

In `auto` mode, it selects the direct stored-MET pt/phi variation fields when present, otherwise it uses the legacy delta-X/Y convention.

This covers both newer NanoAOD-style direct unclustered fields and older Run 2-style delta-X/Y fields.

#### G. JES/JER variation propagation

The factory builds corrected jets internally through `CorrectedJetsFactory` and then propagates regular-jet JES/JER variations to Type-1 MET.

The variation behavior is:

```text
regular Jet full leg:
  varied using the corrected-jet scale response

regular Jet L1 leg:
  kept as the nominal L1 reference

CorrT1METJet leg:
  kept nominal under JES/JER variations
```

The forward-eta stochastic JER suppression option is threaded to the internal corrected-jet factory.

#### H. Test coverage

`tests/test_corrected_met_factory.py` is extended with a synthetic Type-1 MET test setup covering:

```text
fake correctionlib JEC corrections
fake JECStack behavior
fake CorrectedJetsFactory behavior
regular Jet and CorrT1METJet inputs
direct and legacy unclustered variation modes
JES/JER variation outputs
```

The fixture allows caller-provided `pt_raw` and `mass_raw` to differ from values reconstructed from `rawFactor`, making the tests sensitive to accidental fallback raw-input reconstruction.

### Testing

Focused tests were added/updated in:

```text
tests/test_corrected_met_factory.py
```

The tests cover:

```text
- nominal Type-1 MET formula;
- use of regular-jet raw pT as the JEC input;
- application of JEC factors to no-muon raw pT;
- required regular-jet pt_raw and mass_raw fields;
- required ptRaw and massRaw name-map keys;
- propagation of caller-provided mass_raw into the corrected-jet preparation path;
- CorrT1METJet raw-pT and no-muon raw-pT behavior;
- private corrected-jet factory hook used by tests;
- forwarding of the stochastic JER suppression option;
- missing delta-phi fallbacks;
- missing CorrT1METJet EmEF fallback behavior;
- jet EM-fraction and low-pT cuts;
- direct unclustered-energy recentering;
- legacy delta-X/Y unclustered-energy recentering;
- JES/JER variation shape and values.
```

Validation command:

```bash
python -m pytest -q tests/test_corrected_met_factory.py
```

Expected result from the final validation round:

```text
20 passed
```

### Review notes

* This PR introduces a new public factory, `Type1CorrectedMETFactory`.
* The factory requires correctionlib-style `JECStack` helpers; non-correctionlib stacks are not supported for Type-1 MET in this implementation.
* The regular-jet raw-input contract is strict: callers must provide `pt_raw` and `mass_raw`.
* This is intentionally different from reconstructing raw inputs inside the factory from `rawFactor`.
* `CorrT1METJet` keeps the NanoAOD `rawPt` contract and does not require `pt_raw` or `mass_raw`.
* JES/JER variations are propagated through the regular-jet leg only; `CorrT1METJet` is kept nominal under those variations.
* The factory supports both direct unclustered pt/phi fields and legacy delta-X/Y fields.
* Downstream analysis code should prepare full, uncleaned Type-1 jet inputs separately from analysis-cleaned jets.
